### PR TITLE
feat(new-chat): split-button "in worktree" send variant

### DIFF
--- a/apps/server/src/modules/worktree/ISOLATION-DESIGN.md
+++ b/apps/server/src/modules/worktree/ISOLATION-DESIGN.md
@@ -133,7 +133,7 @@ stateDiagram-v2
 
 | Phase | Cradle API / UI | Cursor analogue |
 |-------|-----------------|-----------------|
-| **Start (new chat)** | Create session + `POST …/isolation/start` in one user action | `/worktree` at chat start |
+| **Start (new chat)** | Send ▾ → “in worktree” → create session + `POST …/isolation/start` + first message | `/worktree` at chat start |
 | **Start (running chat)** | Header “隔离” → `isolation/start`; if streaming → `pending` | `/worktree` mid-chat |
 | **Boundary** | Main dirty + pending → dialog: migrate / leave-main / cancel | (Cursor: manual apply) |
 | **Work** | Agent, PTY, git scoped to execution root | Agent in worktree |
@@ -189,15 +189,18 @@ UI: banner when `worktreeHealth !== 'ok'` — **“隔离环境不可用”** wi
 
 ## UI flows (minimal)
 
-### New chat — “新建隔离环境”
+### New chat — split-button send
 
-One-shot:
+Isolation is chosen **at send time** — not a navigation target, not a persistent toggle.
 
-1. User selects project workspace.
-2. Click → create session + start isolation + navigate to chat.
-3. Toast: “已在隔离环境 {branch} 中运行”.
+1. User selects project workspace → the send button becomes a split button `[Send][▾]` (a `ButtonGroup`).
+2. Compose first prompt → click `Send` for a normal session, or click `▾` and pick “in worktree”.
+3. “in worktree” → `postSessions` + `isolation/start` + first message, then navigate to chat.
+4. Toast: “已在隔离环境 {branch} 中运行”.
 
-No silent ref-only arming.
+No empty-session navigation. No silent ref-only arming. The choice is one-shot per send — no armed state lingers across sessions.
+
+When the launcher is opened for an issue that already has isolation groups, a normal send still triggers `IssueIsolationStartDialog` (choose main / continue existing / new isolated); “in worktree” is an explicit new-isolated shortcut.
 
 ### Chat header — “隔离”
 
@@ -243,7 +246,7 @@ Run once after `git worktree add`, cwd = new checkout. Failures → warning in i
 | Phase | Scope |
 |-------|--------|
 | **A — Storage & health** | App Support paths; `reconcileWorktree`; extended `isolationView`; execution root strict mode; repair/leave APIs |
-| **B — UX & git client** | One-click new isolated chat; header labels/toasts; git `sessionId` scoping + api-gen; missing-worktree banner |
+| **B — UX & git client** | Split-button “in worktree” send variant; header labels/toasts; git `sessionId` scoping + api-gen; missing-worktree banner |
 | **C — Legacy & setup** | Relocate/abandon repo-path worktrees; optional `worktrees.json` hooks |
 
 Phase A unblocks correct behavior; B fixes reported confusion; C is polish.

--- a/apps/web/src/features/chat/composer/composer-actions.tsx
+++ b/apps/web/src/features/chat/composer/composer-actions.tsx
@@ -1,4 +1,5 @@
 import {
+  DownSmallLine as ChevronDownIcon,
   RouteLine as RouteIcon,
   SendPlaneLine as SendHorizonalIcon,
   SquareLine as SquareIcon,
@@ -8,6 +9,13 @@ import type { ReactNode } from 'react'
 import { useState } from 'react'
 
 import { Button } from '~/components/ui/button'
+import { ButtonGroup } from '~/components/ui/button-group'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '~/components/ui/dropdown-menu'
 import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover'
 import { Spinner } from '~/components/ui/spinner'
 import { cn } from '~/lib/cn'
@@ -17,6 +25,13 @@ import type { ChatRuntimeCompactUiSlotState } from '../capabilities/chat-capabil
 import { ContextUsageDetailPanel } from '../context/context-usage-detail-panel'
 import type { ComposerAttachmentController } from './composer-attachment-state'
 import { ComposerAttachmentButton } from './composer-attachments'
+
+export interface ComposerSendVariantAction {
+  id: string
+  label: string
+  icon?: ReactNode
+  onSelect: () => void
+}
 
 const TOKEN_CIRCLE_RADIUS = 7
 const TOKEN_CIRCUMFERENCE = 2 * Math.PI * TOKEN_CIRCLE_RADIUS
@@ -146,6 +161,7 @@ export function ComposerActions({
   sessionContextWindow,
   compactState,
   sendButtonAriaLabel,
+  sendVariants,
 }: {
   actionsClassName?: string
   attachButtonClassName?: string
@@ -171,6 +187,7 @@ export function ComposerActions({
   sessionContextWindow?: number | null
   compactState?: ChatRuntimeCompactUiSlotState | null
   sendButtonAriaLabel?: string
+  sendVariants?: ComposerSendVariantAction[]
 }) {
   const isPlanSendMode = Boolean(isPlanMode && !isBangMode)
   const sendButtonSize = isPlanSendMode ? 'xs' : 'icon-xs'
@@ -192,6 +209,54 @@ export function ComposerActions({
       'dark:bg-amber-400 dark:text-amber-950 dark:hover:bg-amber-300',
     ],
   )
+  const sendButton = (
+    <Button
+      variant="default"
+      size={sendButtonSize}
+      disabled={disabled || sendDisabled || sendBlocked || !hasDraft}
+      onClick={() => onSend()}
+      aria-label={sendButtonLabel ?? 'Send message'}
+      className={sendButtonChrome}
+      data-testid={sendButtonTestId}
+    >
+      <ComposerSendIcon isBangMode={isBangMode} isPlanMode={isPlanMode} isSending={isSending} />
+      {isPlanSendMode && <span className="text-[11px] font-semibold">Plan</span>}
+    </Button>
+  )
+  const sendVariantsAvailable = !!sendVariants && sendVariants.length > 0 && !isBangMode && !isPlanSendMode
+  const sendButtonNode = sendVariantsAvailable && sendVariants
+    ? (
+      <ButtonGroup>
+        {sendButton}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="default"
+              size="icon-xs"
+              disabled={disabled || sendDisabled || sendBlocked || !hasDraft}
+              aria-label={sendButtonLabel ? `${sendButtonLabel} options` : 'Send options'}
+              className={cn(sendButtonClassName, 'px-1')}
+              data-testid={`${sendButtonTestId}-variants`}
+            >
+              <ChevronDownIcon className="size-3" aria-hidden />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            {sendVariants.map(variant => (
+              <DropdownMenuItem
+                key={variant.id}
+                onSelect={() => variant.onSelect()}
+                disabled={disabled || sendDisabled || sendBlocked || !hasDraft}
+              >
+                {variant.icon}
+                <span>{variant.label}</span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </ButtonGroup>
+    )
+    : sendButton
 
   return (
     <div className={cn('flex items-center gap-1', actionsClassName)}>
@@ -241,20 +306,7 @@ export function ComposerActions({
               <SquareIcon className="size-3" aria-hidden="true" />
             </Button>
           )
-        : (
-            <Button
-              variant="default"
-              size={sendButtonSize}
-              disabled={disabled || sendDisabled || sendBlocked || !hasDraft}
-              onClick={() => onSend()}
-              aria-label={sendButtonLabel ?? 'Send message'}
-              className={sendButtonChrome}
-              data-testid={sendButtonTestId}
-            >
-              <ComposerSendIcon isBangMode={isBangMode} isPlanMode={isPlanMode} isSending={isSending} />
-              {isPlanSendMode && <span className="text-[11px] font-semibold">Plan</span>}
-            </Button>
-          )}
+        : sendButtonNode}
     </div>
   )
 }

--- a/apps/web/src/features/chat/composer/composer.tsx
+++ b/apps/web/src/features/chat/composer/composer.tsx
@@ -56,9 +56,17 @@ import { PromptEditor } from './prompt-editor'
 
 export type { ComposerSendHandler } from './composer-submit'
 
+export interface ComposerSendVariant {
+  id: string
+  label: string
+  icon?: React.ReactNode
+  submitHandler: ComposerSendHandler
+}
+
 export interface ComposerSendController {
   submit: ComposerSendHandler
   submitInNewWindow?: ComposerSendHandler
+  sendVariants?: ComposerSendVariant[]
   stop?: () => void
   isStreaming?: boolean
   isSending?: boolean
@@ -207,6 +215,7 @@ export function Composer({
   const {
     submit,
     submitInNewWindow,
+    sendVariants,
     isStreaming,
     isSending,
     disabled,
@@ -565,6 +574,16 @@ export function Composer({
     surfaceId,
   ])
 
+  const sendVariantActions = useMemo(
+    () => (sendVariants ?? []).map(variant => ({
+      id: variant.id,
+      label: variant.label,
+      icon: variant.icon,
+      onSelect: () => handleSend(undefined, variant.submitHandler),
+    })),
+    [sendVariants, handleSend],
+  )
+
   const toggleRuntimeInteractionMode = useCallback(() => {
     if (!runtimeInteractionMode || runtimeSettingsDisabled || !onRuntimeSettingsChange) {
       return false
@@ -877,6 +896,7 @@ export function Composer({
               compactState={compactState}
               contextBar={contextBar}
               disabled={effectiveDisabled}
+              sendVariants={sendVariantActions}
               hasDraft={hasDraft}
               isBangMode={isBangMode}
               isPlanMode={isPlanMode}

--- a/apps/web/src/features/chat/composer/draft-chat-composer.tsx
+++ b/apps/web/src/features/chat/composer/draft-chat-composer.tsx
@@ -1,4 +1,4 @@
-import { Settings2Line as SettingsIcon } from '@mingcute/react'
+import { Settings2Line as SettingsIcon, ShieldLine as ShieldIcon } from '@mingcute/react'
 import type { FileUIPart } from 'ai'
 import { m } from 'motion/react'
 import type { ReactNode } from 'react'
@@ -97,6 +97,7 @@ interface DraftChatComposerProps {
   onDraftChange?: (draft: string) => void
   onSend: DraftChatComposerSendHandler
   onSendInNewWindow?: DraftChatComposerSendHandler
+  onSendIsolated?: DraftChatComposerSendHandler
   testIdPrefix?: string
 }
 
@@ -138,6 +139,7 @@ function DraftChatComposerContent({
   onDraftChange,
   onSend,
   onSendInNewWindow,
+  onSendIsolated,
   testIdPrefix = 'draft-chat',
   composerState,
 }: DraftChatComposerContentProps) {
@@ -375,6 +377,23 @@ function DraftChatComposerContent({
       : handleSend(text, files, contextParts)
   }
 
+  const handleSendIsolated = (text: string, files: FileUIPart[], contextParts: ChatContextPart[]) => {
+    return onSendIsolated
+      ? handleSendWithTarget(onSendIsolated, text, files, contextParts)
+      : handleSend(text, files, contextParts)
+  }
+
+  const sendVariants = onSendIsolated && workspaceId
+    ? [
+      {
+        id: 'worktree',
+        label: t('send.inWorktree'),
+        icon: <ShieldIcon className="size-3.5" aria-hidden />,
+        submitHandler: handleSendIsolated,
+      },
+    ]
+    : undefined
+
   const handleSlashCommandAction = async (
     command: ChatComposerSlashCommand,
     _context: ComposerSlashCommandActionContext,
@@ -460,6 +479,7 @@ function DraftChatComposerContent({
         send={{
           submit: handleSend,
           submitInNewWindow: handleSendInNewWindow,
+          sendVariants,
           isSending: sending,
           sendDisabled,
           allowEmptySend: allowEmptySubmit,

--- a/apps/web/src/features/new-chat/new-chat-page.tsx
+++ b/apps/web/src/features/new-chat/new-chat-page.tsx
@@ -3,7 +3,6 @@ import {
   FolderLine as FolderIcon,
   Message1Line as MessageSquareIcon,
   NewFolderLine as FolderPlusIcon,
-  ShieldLine as ShieldIcon,
 } from '@mingcute/react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useSearch } from '@tanstack/react-router'
@@ -17,18 +16,16 @@ import { postSessions, postSessionsByIdIsolationStart } from '~/api-gen/sdk.gen'
 import type { PostSessionsData } from '~/api-gen/types.gen'
 import { useRegisterLayoutSlots } from '~/components/layout/use-layout-slots'
 import { Button } from '~/components/ui/button'
-import { toastManager } from '~/components/ui/toast'
 import { DitheredGradientDecoration } from '~/components/ui/canvas-art'
 import { Menu, MenuGroup, MenuGroupLabel, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from '~/components/ui/menu'
-import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip'
 import { runtimeComposerUsesCollapsedInput } from '~/features/agent-runtime/use-runtime-catalog'
 import type { DraftChatComposerSubmitOptions } from '~/features/chat/composer/draft-chat-composer'
 import { DraftChatComposerWithState } from '~/features/chat/composer/draft-chat-composer'
-import { DEFAULT_CHAT_RUNTIME_SETTINGS } from '~/features/chat/commands/runtime-settings-command'
 import type { ChatContextPart } from '~/features/chat/context/chat-context-parts'
 import { startOptimisticChatResponse } from '~/features/chat/session/optimistic-chat-turn'
 import { useComposerState } from '~/features/composer-toolbar'
-import { IssueIsolationStartDialog, type IssueIsolationStartChoice } from '~/features/new-chat/issue-isolation-start-dialog'
+import type { IssueIsolationStartChoice } from '~/features/new-chat/issue-isolation-start-dialog'
+import { IssueIsolationStartDialog } from '~/features/new-chat/issue-isolation-start-dialog'
 import {
   useIssueIsolationContext,
 } from '~/features/session/use-session-isolation'
@@ -96,12 +93,10 @@ function useNewChatPageOwner(
     options: DraftChatComposerSubmitOptions
     target: 'tab' | 'window'
   } | null>(null)
-  const nextIsolationChoiceRef = useRef<IssueIsolationStartChoice | null>(null)
   const { workspaces, loading: workspacesLoading } = useWorkspaces()
   const { addFromPicker, adding: addingWorkspace } = useAddWorkspace()
   const queryClient = useQueryClient()
   const composerState = useComposerState({ context: 'new-chat', enableAgents: true })
-  const lastRuntimeSettings = useNewChatStore(s => s.lastRuntimeSettings ?? DEFAULT_CHAT_RUNTIME_SETTINGS)
 
   const [draft, setDraft] = useState('')
   const [quickActionText, setQuickActionText] = useState<string | undefined>(undefined)
@@ -167,10 +162,6 @@ function useNewChatPageOwner(
     isolation?: { choice: IssueIsolationStartChoice, worktreeId?: string },
   ) => {
     const trimmedText = text.trim()
-    const isolatedSessionOnly = isolation?.choice === 'new-isolated'
-      && trimmedText.length === 0
-      && files.length === 0
-      && contextParts.length === 0
     try {
       const linkedIssueFields = issueId ? { linkedIssueId: issueId } : {}
       const worktreeFields = isolation?.choice === 'continue' && isolation.worktreeId
@@ -268,29 +259,27 @@ function useNewChatPageOwner(
         modelId: options.modelId ?? null,
         runtimeKind: options.runtimeKind,
       }, { promote: true })
-      if (!isolatedSessionOnly) {
-        startOptimisticChatResponse({
-          sessionId: session.id,
-          queryClient,
-          body: {
-            text: trimmedText,
-            files,
-            contextParts,
-            modelId: options.modelId,
-            thinkingEffort: options.thinkingEffort,
-            runtimeSettings: options.runtimeSettings,
-          },
-          onAccepted: () => {
-            void Promise.all([
-              queryClient.invalidateQueries({ queryKey: sessionsQueryKey(session.workspaceId ?? selectedProjectWorkspaceId) }),
-              queryClient.invalidateQueries({ queryKey: sessionsQueryKey() }),
-            ])
-          },
-          onError: (err) => {
-            console.error('[NewChatPage] start response failed:', err)
-          },
-        })
-      }
+      startOptimisticChatResponse({
+        sessionId: session.id,
+        queryClient,
+        body: {
+          text: trimmedText,
+          files,
+          contextParts,
+          modelId: options.modelId,
+          thinkingEffort: options.thinkingEffort,
+          runtimeSettings: options.runtimeSettings,
+        },
+        onAccepted: () => {
+          void Promise.all([
+            queryClient.invalidateQueries({ queryKey: sessionsQueryKey(session.workspaceId ?? selectedProjectWorkspaceId) }),
+            queryClient.invalidateQueries({ queryKey: sessionsQueryKey() }),
+          ])
+        },
+        onError: (err) => {
+          console.error('[NewChatPage] start response failed:', err)
+        },
+      })
       void Promise.all([
         queryClient.invalidateQueries({ queryKey: sessionsQueryKey(session.workspaceId ?? selectedProjectWorkspaceId) }),
         queryClient.invalidateQueries({ queryKey: sessionsQueryKey() }),
@@ -347,64 +336,7 @@ function useNewChatPageOwner(
     setIsolationDialogOpen(false)
   }, [])
 
-  const handleStartIsolatedChat = useCallback(async () => {
-    const cs = composerState
-    if (!selectedProjectWorkspaceId) {
-      return false
-    }
-    if (runtimeComposerUsesCollapsedInput(cs.runtimeComposer)) {
-      if (!cs.effectiveAgent) {
-        toastManager.add({ type: 'error', title: t('isolatedProviderRequired') })
-        return false
-      }
-      return handleSendToTarget('', [], [], {
-        runtimeKind: cs.selection.runtimeKind,
-        providerBinding: cs.providerBinding,
-        runtimeComposer: cs.runtimeComposer,
-        agentId: cs.effectiveAgent.id,
-        agentName: cs.effectiveAgent.name,
-        runtimeSettings: lastRuntimeSettings,
-      }, 'tab', { choice: 'new-isolated' })
-    }
-    if (!cs.effectiveProfile) {
-      toastManager.add({ type: 'error', title: t('isolatedProviderRequired') })
-      return false
-    }
-    const started = await handleSendToTarget('', [], [], {
-      runtimeKind: cs.selection.runtimeKind,
-      providerBinding: cs.providerBinding,
-      runtimeComposer: cs.runtimeComposer,
-      providerTargetId: cs.effectiveProfile.id,
-      providerTargetName: cs.effectiveProfile.name,
-      modelId: cs.selection.modelId ?? cs.effectiveModel?.id,
-      thinkingEffort: cs.selection.thinkingEffort ?? undefined,
-      runtimeSettings: lastRuntimeSettings,
-    }, 'tab', { choice: 'new-isolated' })
-    if (started) {
-      toastManager.add({
-        type: 'success',
-        title: t('isolatedDefaultTitle'),
-        description: t('isolatedActionTooltip'),
-      })
-    }
-    return started
-  }, [composerState, handleSendToTarget, lastRuntimeSettings, selectedProjectWorkspaceId, t])
-
-  const handleSendIsolated = useCallback((
-    text: string,
-    files: FileUIPart[],
-    contextParts: ChatContextPart[],
-    options: DraftChatComposerSubmitOptions,
-  ) => {
-    return handleSendToTarget(text, files, contextParts, options, 'tab', { choice: 'new-isolated' })
-  }, [handleSendToTarget])
-
   const handleSend = useCallback((text: string, files: FileUIPart[], contextParts: ChatContextPart[], options: DraftChatComposerSubmitOptions) => {
-    const isolationChoice = nextIsolationChoiceRef.current
-    nextIsolationChoiceRef.current = null
-    if (isolationChoice) {
-      return handleSendToTarget(text, files, contextParts, options, 'tab', { choice: isolationChoice })
-    }
     return handleSendToTarget(text, files, contextParts, options, 'tab')
   }, [handleSendToTarget])
 
@@ -412,10 +344,9 @@ function useNewChatPageOwner(
     return handleSendToTarget(text, files, contextParts, options, 'window')
   }, [handleSendToTarget])
 
-  const handleIsolationDialogDismiss = useCallback(() => {
-    pendingSendRef.current = null
-    setIsolationDialogOpen(false)
-  }, [])
+  const handleSendIsolated = useCallback((text: string, files: FileUIPart[], contextParts: ChatContextPart[], options: DraftChatComposerSubmitOptions) => {
+    return handleSendToTarget(text, files, contextParts, options, 'tab', { choice: 'new-isolated' })
+  }, [handleSendToTarget])
 
   const handleQuickAction = useCallback((prompt: string) => {
     setQuickActionText(prompt)
@@ -434,12 +365,10 @@ function useNewChatPageOwner(
     handleSend,
     handleSendInNewWindow,
     handleSendIsolated,
-    handleStartIsolatedChat,
     handleIsolationDialogConfirm,
     dismissIsolationDialog,
     isolationDialogOpen,
     issueIsolationGroups: issueIsolationContext.data?.groups ?? [],
-    nextIsolationChoiceRef,
     isReady,
     now,
     recentSessions,
@@ -480,39 +409,12 @@ function NewChatComposerCard({
     setSelectedWorkspaceId,
     setDraft,
     selectedWorkspace,
-    selectedProjectWorkspaceId,
     t,
     workspaces,
   } = owner
 
-  const isolatedAction = selectedProjectWorkspaceId
-    ? (
-      <Tooltip>
-        <TooltipTrigger
-          render={(
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              className="text-muted-foreground"
-              data-testid="new-chat-isolated-start"
-              onClick={() => {
-                void owner.handleStartIsolatedChat()
-              }}
-            >
-              <ShieldIcon className="size-3 shrink-0" aria-hidden />
-              <span className="max-w-28 truncate">{t('isolatedAction')}</span>
-            </Button>
-          )}
-        />
-        <TooltipContent>{t('isolatedActionTooltip')}</TooltipContent>
-      </Tooltip>
-    )
-    : null
-
   const workspaceSelector = (
     <div className="flex items-center gap-1">
-      {isolatedAction}
     <Menu>
       <MenuTrigger render={<Button variant="ghost" size="xs" className="text-foreground hover:text-foreground" />} data-testid="new-chat-workspace-selector">
         <FolderIcon className="size-3 shrink-0" />
@@ -560,6 +462,7 @@ function NewChatComposerCard({
       workspaceId={selectedWorkspace?.id ?? null}
       active={active}
       contextBar={workspaceSelector}
+      onSendIsolated={handleSendIsolated}
       replaceText={quickActionText}
       replaceTextKey={quickActionKey}
       onDraftChange={setDraft}

--- a/apps/web/src/locales/default/new-chat.ts
+++ b/apps/web/src/locales/default/new-chat.ts
@@ -35,6 +35,7 @@ export default {
   'workspace.adding': 'Adding...',
   'workspace.group': 'Workspaces',
   'send.tooltip': 'Send',
+  'send.inWorktree': 'Send in worktree',
   'isolatedAction': 'New isolated chat',
   'isolatedActionTooltip': 'Create a session in an isolated git worktree',
   'isolatedDefaultTitle': 'Isolated chat',

--- a/apps/web/src/locales/en-US/new-chat.json
+++ b/apps/web/src/locales/en-US/new-chat.json
@@ -26,6 +26,7 @@
   "relative.minutesAgo": "{{count}} minutes ago",
   "relative.monthsAgo": "{{count}} months ago",
   "send.tooltip": "Send",
+  "send.inWorktree": "Send in worktree",
   "isolatedAction": "New isolated chat",
   "isolatedActionTooltip": "Create a session in an isolated git worktree",
   "isolatedDefaultTitle": "Isolated chat",

--- a/apps/web/src/locales/zh-CN/new-chat.json
+++ b/apps/web/src/locales/zh-CN/new-chat.json
@@ -26,6 +26,7 @@
   "relative.minutesAgo": "{{count}} 分钟前",
   "relative.monthsAgo": "{{count}} 个月前",
   "send.tooltip": "发送",
+  "send.inWorktree": "在 worktree 中发送",
   "isolatedAction": "新建隔离环境",
   "isolatedActionTooltip": "在隔离 git worktree 中创建会话",
   "isolatedDefaultTitle": "隔离会话",


### PR DESCRIPTION
## Summary

Replaces the isolation entry in the new-chat launcher with a **split-button send control**. The send button becomes `[Send][▾]` (a `ButtonGroup`); the `▾` menu offers **"in worktree"**, which creates the session + starts isolation + sends the first prompt in one shot.

Isolation is now a one-shot choice made **at send time, on the send button itself** — no toggle state, no empty-session navigation.

## Why

This went through two earlier iterations, both wrong:

1. **Standalone shield button** — clicking it created an empty session and jumped straight into the chat-session page, bypassing composition entirely. Conflicted with the launcher's job and with the Cursor `/worktree` semantics the design doc claims to align to.
2. **Footer toggle** next to the workspace selector — placement was off (isolation is a "how to run" mode but sat on the opposite side from `RuntimeSettingsControl`), the label read as an action not a state, the affordance was weak, and toggle semantics don't fit a one-shot-per-chat decision.

The split-button puts the choice on the send button (where the decision actually happens), is one-shot, and uses a `ButtonGroup` as requested.

## Changes

- **`composer-actions.tsx`** — Extract `sendButton`; when `sendVariants` is non-empty, wrap it in a `ButtonGroup` with a dropdown caret listing the variants. Caret is hidden in plan/bang/streaming modes. With no variants, the send button renders exactly as before, so `chat` / `side-conversation` / `jarvis` (which don't pass `sendVariants`) are unaffected.
- **`composer.tsx`** — New `ComposerSendVariant` type + `sendVariants?` on `ComposerSendController`; each variant is mapped to `onSelect: () => handleSend(undefined, submitHandler)`.
- **`draft-chat-composer.tsx`** — `onSendIsolated` prop + `handleSendIsolated`; builds `sendVariants = [{ id: 'worktree', label: t('send.inWorktree'), icon: ShieldIcon }]`, gated on a project workspace being selected.
- **`new-chat-page.tsx`** — Removes the toggle entirely; re-adds `handleSendIsolated` (now wired to the split-button, not dead code); footer workspace selector reverts to a plain `<div>`.
- **`ISOLATION-DESIGN.md`** — "New chat" section rewritten to split-button semantics; Operations table + phase B aligned.
- **i18n** — Adds `send.inWorktree` (en / zh).

## Verification

- ✅ `eslint` on the 4 changed code files: 0 errors.
- ✅ `tsc --noEmit` on the changed files: 0 errors.
- ⚠️ Two **pre-existing** typecheck errors exist on `main` (`use-kanban.ts:882`, `navigation-commands.ts:57`) — verified via stash that they are unrelated to this PR.
- ⚠️ UI not exercised here; needs manual check:
  - Select a project workspace → `▾` appears next to Send → type a prompt → `▾` → "in worktree" → lands in an isolated session **with** the first message.
  - Ad-hoc (no workspace) → no `▾`.
  - Plan / bang / streaming modes → no `▾`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)