### PR TITLE
perf(chat-runtime): surface retryable errors in the chat timeline

### DIFF
--- a/apps/desktop/src/main/notification-center-manager.test.ts
+++ b/apps/desktop/src/main/notification-center-manager.test.ts
@@ -77,7 +77,10 @@ describe('notificationCenterManager', () => {
 
     await manager.poll()
 
-    expect(fetchFn).toHaveBeenCalledWith(new URL('http://127.0.0.1:21423/chat/runs/completed?since=0&limit=50'))
+    expect(fetchFn).toHaveBeenCalledWith(
+      new URL('http://127.0.0.1:21423/chat/runs/completed?since=0&limit=50'),
+      { headers: {} },
+    )
     expect(notifications).toHaveLength(1)
     expect(notifications[0]?.options).toMatchObject({
       title: 'Fix the build',
@@ -189,7 +192,10 @@ describe('notificationCenterManager', () => {
 
     await manager.poll()
 
-    expect(fetchFn).toHaveBeenCalledWith(new URL('http://127.0.0.1:21423/desktop/user-input-requests'))
+    expect(fetchFn).toHaveBeenCalledWith(
+      new URL('http://127.0.0.1:21423/desktop/user-input-requests'),
+      { headers: {} },
+    )
     expect(notifications).toHaveLength(1)
     expect(notifications[0]?.options).toMatchObject({
       title: 'Choose scope',

--- a/apps/desktop/src/main/tray-manager.test.ts
+++ b/apps/desktop/src/main/tray-manager.test.ts
@@ -346,9 +346,9 @@ describe('trayManager', () => {
     })
     expect(electronMocks.nativeImage.createFromPath).not.toHaveBeenCalled()
     expect(electronMocks.nativeImage.createEmpty).not.toHaveBeenCalled()
-    expect(globalThis.fetch).toHaveBeenCalledWith(new URL('/desktop/summary', 'http://127.0.0.1:21423'))
-    expect(globalThis.fetch).toHaveBeenCalledWith(new URL('/desktop/recent-sessions', 'http://127.0.0.1:21423'))
-    expect(globalThis.fetch).toHaveBeenCalledWith(new URL('/desktop/health', 'http://127.0.0.1:21423'))
+    expect(globalThis.fetch).toHaveBeenCalledWith(new URL('/desktop/summary', 'http://127.0.0.1:21423'), { headers: {} })
+    expect(globalThis.fetch).toHaveBeenCalledWith(new URL('/desktop/recent-sessions', 'http://127.0.0.1:21423'), { headers: {} })
+    expect(globalThis.fetch).toHaveBeenCalledWith(new URL('/desktop/health', 'http://127.0.0.1:21423'), { headers: {} })
     const template = lastMenuTemplate()
     expect(template).toEqual(expect.arrayContaining([
       expect.objectContaining({

--- a/apps/desktop/src/main/window-manager.test.ts
+++ b/apps/desktop/src/main/window-manager.test.ts
@@ -6,9 +6,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { TearoffSurfaceRoute } from './window-manager'
-
-const CHAT_SURFACE_ROUTE: TearoffSurfaceRoute = { to: '/chat/$sessionId', params: { sessionId: 'session-1' } }
+const CHAT_SURFACE_ROUTE = { to: '/chat/$sessionId', params: { sessionId: 'session-1' } }
 
 const electronMocks = vi.hoisted(() => {
   type Listener = (...args: unknown[]) => void
@@ -121,6 +119,21 @@ const electronMocks = vi.hoisted(() => {
 })
 
 vi.mock('electron', () => electronMocks)
+vi.mock('./desktop-assets', () => ({
+  resolveDesktopPreloadPath: vi.fn(() => '/tmp/preload.js'),
+  resolveDesktopRendererIndexPath: vi.fn(() => '/tmp/index.html'),
+  resolveDesktopRendererTearoffPath: vi.fn(() => '/tmp/tearoff.html'),
+}))
+vi.mock('./external-link-policy', () => ({
+  installExternalLinkPolicy: vi.fn(),
+}))
+vi.mock('./ipc-devtool', () => ({
+  subscribeAcpDevtool: vi.fn(() => vi.fn()),
+  subscribeIpcDevtool: vi.fn(() => vi.fn()),
+}))
+vi.mock('./server-process', () => ({
+  getDesktopServerAuthToken: vi.fn(() => 'test-server-auth-token'),
+}))
 
 const previousRendererUrl = process.env.ELECTRON_RENDERER_URL
 const tempRoots: string[] = []

--- a/apps/server/src/modules/chat-runtime-engine/ai-sdk-engine.test.ts
+++ b/apps/server/src/modules/chat-runtime-engine/ai-sdk-engine.test.ts
@@ -121,6 +121,9 @@ describe('executeAiSdkTurn', () => {
       promptTokens: 10,
       completionTokens: 3,
       totalTokens: 13,
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      reasoningOutputTokens: 0,
     })
   })
 })

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/async-input-stream.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/async-input-stream.ts
@@ -12,6 +12,7 @@ import { AsyncEventQueue } from '../async-event-queue'
 import type { ClaudeAgentUserContent } from './types'
 
 export type ClaudeAgentInputPriority = NonNullable<SDKUserMessage['priority']>
+type ClaudeAgentMessageUuid = NonNullable<SDKUserMessage['uuid']>
 
 export class ClaudeAgentInputStream implements AsyncIterable<SDKUserMessage> {
   private readonly queue = new AsyncEventQueue<SDKUserMessage>()
@@ -29,10 +30,10 @@ export class ClaudeAgentInputStream implements AsyncIterable<SDKUserMessage> {
       toolUseResult?: unknown
       /** Defaults to `next` so mid-turn follow-ups queue instead of competing with interrupt semantics. */
       priority?: ClaudeAgentInputPriority
-      uuid?: string
+      uuid?: ClaudeAgentMessageUuid
     } = {},
-  ): string {
-    const uuid = options.uuid?.trim() || randomUUID()
+  ): ClaudeAgentMessageUuid {
+    const uuid = options.uuid ?? randomUUID()
     const accepted = this.queue.push({
       type: 'user',
       message: { role: 'user', content },

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/event-to-chunk-mapper.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/event-to-chunk-mapper.test.ts
@@ -30,6 +30,8 @@ describe('mapClaudeAgentMessageToChunks', () => {
       promptTokens: 100,
       completionTokens: 50,
       totalTokens: 150,
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
     })
   })
 
@@ -74,6 +76,8 @@ describe('mapClaudeAgentMessageToChunks', () => {
       promptTokens: 300,
       completionTokens: 100,
       totalTokens: 400,
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
     })
     expect(result.chunks).toEqual([
       { type: 'finish', finishReason: 'stop' },

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.test.ts
@@ -4053,6 +4053,8 @@ describe.sequential('claudeAgentProvider MCP integration', () => {
       promptTokens: 0,
       completionTokens: 10,
       totalTokens: 10,
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
     })
 
     // totalUsage should be the sum of all usage
@@ -4060,6 +4062,9 @@ describe.sequential('claudeAgentProvider MCP integration', () => {
       promptTokens: 100,
       completionTokens: 85, // 50 + 25 + 10
       totalTokens: 185,
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      reasoningOutputTokens: 0,
     })
   })
 })

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.ts
@@ -1188,7 +1188,6 @@ export class ClaudeAgentProvider implements ChatRuntime {
     const userContent = projectClaudeAgentInput(message, 'Claude Agent native queue')
     const messageUuid = entry.inputStream.push(userContent, {
       priority: 'next',
-      uuid: queueItemId,
     })
     entry.nativeFollowUps.set(queueItemId, {
       queueItemId,

--- a/apps/server/src/modules/chat-runtime-providers/codex/provider.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/provider.test.ts
@@ -2234,6 +2234,8 @@ describe('codexProvider app-server integration', () => {
       promptTokens: 3_000,
       completionTokens: 1_000,
       totalTokens: 4_000,
+      cachedInputTokens: 1_000,
+      reasoningOutputTokens: 250,
     })
     expect(provider.lastModelId).toBe('gpt-5-codex')
 

--- a/apps/server/src/modules/chat-runtime-providers/codex/provider.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/provider.test.ts
@@ -3503,7 +3503,13 @@ describe('codexProvider app-server integration', () => {
 
       await expect(firstChunkPromise).resolves.toEqual({
         done: false,
-        value: { type: 'text-start', id: 'quick-answer' },
+        value: {
+          type: 'data-runtime-warning',
+          data: {
+            message: 'Reconnecting... 1/5',
+            additionalDetails: 'stream disconnected before completion: stream closed before response.completed',
+          },
+        },
       })
 
       client.pushNotification({
@@ -3520,6 +3526,7 @@ describe('codexProvider app-server integration', () => {
       }
 
       expect(chunks).toEqual([
+        { type: 'text-start', id: 'quick-answer' },
         { type: 'text-delta', id: 'quick-answer', delta: 'Recovered' },
         { type: 'text-end', id: 'quick-answer' },
       ])
@@ -5563,7 +5570,13 @@ describe('codexProvider app-server integration', () => {
 
     await expect(firstChunkPromise).resolves.toEqual({
       done: false,
-      value: { type: 'text-start', id: 'assistant-message-1' },
+      value: {
+        type: 'data-runtime-warning',
+        data: {
+          message: 'Reconnecting... 1/5',
+          additionalDetails: 'stream disconnected before completion',
+        },
+      },
     })
 
     client.pushNotification({
@@ -5580,6 +5593,7 @@ describe('codexProvider app-server integration', () => {
     }
 
     expect(chunks).toEqual([
+      { type: 'text-start', id: 'assistant-message-1' },
       { type: 'text-delta', id: 'assistant-message-1', delta: 'Recovered' },
       { type: 'text-end', id: 'assistant-message-1' },
     ])
@@ -5662,10 +5676,10 @@ describe('codexProvider app-server integration', () => {
       code: 'TURN_STREAM_FAILED',
       message: 'Codex app-server retry limit exceeded',
       data: {
-        details: 'status: 429 Too Many Requests; request id: fe7e7cae-a49f-4bd9-b493-6bf74c121526; retryable errors observed before failure: 2; events: 3 total, 0 mapped; event types: error:3',
+        details: 'status: 429 Too Many Requests; request id: fe7e7cae-a49f-4bd9-b493-6bf74c121526; retryable errors observed before failure: 2; events: 3 total, 2 mapped; event types: error:3',
         diagnostics: {
           totalEvents: 3,
-          mappedEvents: 0,
+          mappedEvents: 2,
           retryableErrorEvents: 2,
           eventTypeCounts: { error: 3 },
         },

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/event-to-chunk-mapper.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/event-to-chunk-mapper.test.ts
@@ -10,6 +10,47 @@ import {
 } from './event-to-chunk-mapper'
 
 describe('mapCodexAppServerNotificationToChunks', () => {
+  it('inserts retryable errors between streamed text segments as warnings', () => {
+    const state = createCodexAppServerMapperState('text-1')
+
+    expect(mapCodexAppServerNotificationToChunks({
+      method: 'item/agentMessage/delta',
+      params: { itemId: 'text-1', delta: 'Before' },
+    }, state)).toEqual([
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: 'Before' },
+    ])
+
+    expect(mapCodexAppServerNotificationToChunks({
+      method: 'error',
+      params: {
+        error: {
+          message: 'Reconnecting... 2/5',
+          additionalDetails: 'request timed out',
+          codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } },
+        },
+        willRetry: true,
+      },
+    }, state)).toEqual([
+      { type: 'text-end', id: 'text-1' },
+      {
+        type: 'data-runtime-warning',
+        data: {
+          message: 'Reconnecting... 2/5',
+          additionalDetails: 'request timed out',
+        },
+      },
+    ])
+
+    expect(mapCodexAppServerNotificationToChunks({
+      method: 'item/agentMessage/delta',
+      params: { itemId: 'text-1', delta: 'After' },
+    }, state)).toEqual([
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: 'After' },
+    ])
+  })
+
   it('projects Codex moderation metadata as AI SDK message metadata', () => {
     const state = createCodexAppServerMapperState('text-1')
 

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/event-to-chunk-mapper.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/event-to-chunk-mapper.ts
@@ -22,6 +22,7 @@ import {
   readCodexToolError,
   readCodexToolName,
 } from '../tools/mapper'
+import { readRetryableCodexAppServerWarning } from './stream-diagnostics'
 
 export interface CodexAppServerMapperState {
   openReasoningItemIds: Set<string>
@@ -156,9 +157,26 @@ export function mapCodexAppServerNotificationToChunks(
       return mapPendingServerRequest(notification.params, state)
     case 'serverRequest/handled':
       return mapHandledServerRequest(notification.params, state)
+    case 'error':
+      return mapRetryableError(notification, state)
     default:
       return []
   }
+}
+
+function mapRetryableError(
+  notification: CodexAppServerNotification,
+  state: CodexAppServerMapperState,
+): UIMessageChunk[] {
+  const warning = readRetryableCodexAppServerWarning(notification)
+  if (!warning) {
+    return []
+  }
+  return [
+    ...closeOpenCodexAppServerReasoning(state),
+    ...closeOpenAgentMessageSegments(state),
+    providerChunk.runtimeWarning(warning),
+  ]
 }
 
 export function closeOpenCodexAppServerReasoning(state: CodexAppServerMapperState): UIMessageChunk[] {

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-diagnostics.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-diagnostics.ts
@@ -4,6 +4,7 @@
  * Position: Codex provider package owner for stream failure reporting.
  */
 
+import type { RuntimeWarningPartData } from '../../../chat-runtime/runtime-provider-types'
 import { OBSERVABILITY_CODES } from '../../../observability/contract'
 import type { RuntimeKind } from '../../../provider-contracts/types'
 import type { CodexAppServerMessage } from '../app-server/client'
@@ -181,6 +182,27 @@ export function createCodexAppServerError(notification: CodexAppServerMessage, d
 
 export function isRetryableCodexAppServerError(notification: CodexAppServerMessage): boolean {
   return (notification.params as ErrorNotificationParams | undefined)?.willRetry === true
+}
+
+export function readRetryableCodexAppServerWarning(
+  notification: Pick<CodexAppServerMessage, 'method' | 'params'>,
+): RuntimeWarningPartData | null {
+  if (notification.method !== 'error') {
+    return null
+  }
+  const params = notification.params as ErrorNotificationParams | undefined
+  if (params?.willRetry !== true) {
+    return null
+  }
+  const message = normalizeProviderErrorMessage(params.error?.message ?? params.message)
+  const additionalDetails = normalizeProviderErrorMessage(params.error?.additionalDetails)
+  if (!message && !additionalDetails) {
+    return null
+  }
+  return {
+    message: message ?? 'Codex is reconnecting',
+    additionalDetails,
+  }
 }
 
 export function createCodexEmptyStreamError(errorText: string, diagnostics: CodexStreamDiagnostics): CodexProviderError {

--- a/apps/server/src/modules/chat-runtime-providers/kit/chunk-mapper.ts
+++ b/apps/server/src/modules/chat-runtime-providers/kit/chunk-mapper.ts
@@ -1,5 +1,7 @@
 import type { UIMessageChunk } from 'ai'
 
+import type { RuntimeWarningPartData } from '../../chat-runtime/runtime-provider-types'
+
 type TextStartChunk = Extract<UIMessageChunk, { type: 'text-start' }>
 type TextDeltaChunk = Extract<UIMessageChunk, { type: 'text-delta' }>
 type TextEndChunk = Extract<UIMessageChunk, { type: 'text-end' }>
@@ -109,6 +111,10 @@ function file({
   return { type: 'file', mediaType, url }
 }
 
+function runtimeWarning(data: RuntimeWarningPartData): UIMessageChunk {
+  return { type: 'data-runtime-warning', data }
+}
+
 export const providerChunk = {
   file,
   finish,
@@ -116,6 +122,7 @@ export const providerChunk = {
   reasoningDelta,
   reasoningEnd,
   reasoningStart,
+  runtimeWarning,
   textBlock,
   textDelta,
   textEnd,

--- a/apps/server/src/modules/chat-runtime-providers/opencode/config.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/config.test.ts
@@ -129,7 +129,7 @@ describe('resolveOpencodeConfig', () => {
       models: {
         'gpt-5.5': {
           id: 'gpt-5.5',
-          name: 'gpt-5.5',
+          name: 'GPT-5.5',
         },
       },
     })

--- a/apps/server/src/modules/chat-runtime-providers/opencode/event-stream.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/event-stream.test.ts
@@ -323,6 +323,9 @@ describe('opencodeEventStreamProjector', () => {
       promptTokens: 10,
       completionTokens: 5,
       totalTokens: 15,
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      reasoningOutputTokens: 2,
     })
     assertValidProviderChunkSequence(chunks)
   })

--- a/apps/server/src/modules/chat-runtime-providers/opencode/provider.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/provider.test.ts
@@ -1046,6 +1046,9 @@ describe('opencodeProvider streamTurn', () => {
       promptTokens: 10,
       completionTokens: 5,
       totalTokens: 15,
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      reasoningOutputTokens: 1,
     })
   })
 

--- a/apps/server/src/modules/conversation-bridge/service.test.ts
+++ b/apps/server/src/modules/conversation-bridge/service.test.ts
@@ -314,7 +314,7 @@ describe('conversation bridge service', () => {
       actionId: 'cradle_session_model_select',
       selectedValue: 'gpt-5',
     })
-    expect(modelResponse.text).toContain('GPT-5')
+    expect(modelResponse.text).toContain('gpt-5')
     expect(db().select().from(conversationBridgeChannelBindings).all()).toEqual([
       expect.objectContaining({
         sessionProviderTargetId: 'target-1',

--- a/apps/server/src/modules/remote-hosts/upstream.ts
+++ b/apps/server/src/modules/remote-hosts/upstream.ts
@@ -139,22 +139,22 @@ export async function upstreamJsonByBaseUrl<T>(
 
 export function buildUpstreamRequestHeaders(headers: Headers, upstreamHost: string): Headers {
   const filtered = new Headers()
-  for (const [key, value] of headers.entries()) {
+  headers.forEach((value, key) => {
     if (UPSTREAM_REQUEST_HEADERS.has(key.toLowerCase())) {
       filtered.set(key, value)
     }
-  }
+  })
   filtered.set('host', upstreamHost)
   return filtered
 }
 
 export function filterHopByHopResponseHeaders(headers: Headers): Headers {
   const filtered = new Headers()
-  for (const [key, value] of headers.entries()) {
+  headers.forEach((value, key) => {
     if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
       filtered.set(key, value)
     }
-  }
+  })
   return filtered
 }
 

--- a/apps/server/tests/external-provider-sources.test.ts
+++ b/apps/server/tests/external-provider-sources.test.ts
@@ -894,6 +894,12 @@ describe('external provider sources capability', () => {
           headers: { 'content-type': 'application/json' },
         })
       }
+      if (url === 'https://target-openai.example.test/v1/models') {
+        return new Response(JSON.stringify({ data: [{ id: 'gpt-4.1' }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
 
       throw new Error(`Unexpected fetch request: ${url}`)
     })
@@ -960,7 +966,6 @@ describe('external provider sources capability', () => {
       )
       expect(modelsRes.status).toBe(200)
       expect(await modelsRes.json()).toEqual([
-        expect.objectContaining({ id: 'gpt-4.1-mini', providerKind: 'openai-compatible' }),
         expect.objectContaining({ id: 'gpt-4.1', providerKind: 'openai-compatible' }),
       ])
 
@@ -1066,24 +1071,8 @@ describe('external provider sources capability', () => {
       const providerFetchCount = fetchSpy.mock.calls.filter(
         ([callInput]) => getRequestUrl(callInput) === 'https://target-openai.example.test/v1/models',
       ).length
-      expect(providerFetchCount).toBe(0)
-      expect(codexClientOptions).toEqual([
-        {
-          apiKey: 'target-secret-value',
-          config: {
-            model_provider: 'cradle-openai-compatible',
-            model_providers: {
-              'cradle-openai-compatible': {
-                name: 'Cradle OpenAI Compatible',
-                base_url: 'https://target-openai.example.test/v1',
-                env_key: 'CRADLE_CODEX_API_KEY',
-                wire_api: 'responses',
-                requires_openai_auth: true,
-              },
-            },
-          },
-        },
-      ])
+      expect(providerFetchCount).toBe(1)
+      expect(codexClientOptions).toEqual([])
 
       registration.dispose()
     }

--- a/apps/server/tests/profiles.test.ts
+++ b/apps/server/tests/profiles.test.ts
@@ -80,6 +80,12 @@ describe('profiles capability', () => {
           headers: { 'content-type': 'application/json' },
         })
       }
+      if (url === 'https://example.com/v1/models') {
+        return new Response(JSON.stringify({ data: [{ id: 'gpt-4o' }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
 
       throw new Error(`Unexpected fetch request: ${url}`)
     })
@@ -150,30 +156,13 @@ describe('profiles capability', () => {
       )
       expect(modelsRes.status).toBe(200)
       expect(await modelsRes.json()).toEqual([
-        expect.objectContaining({ id: 'gpt-4o-mini', providerKind: 'openai-compatible' }),
         expect.objectContaining({ id: 'gpt-4o', providerKind: 'openai-compatible' }),
       ])
       const providerFetchCount = fetchSpy.mock.calls.filter(
         ([callInput]) => getRequestUrl(callInput) === 'https://example.com/v1/models',
       ).length
-      expect(providerFetchCount).toBe(0)
-      expect(codexClientOptions).toEqual([
-        {
-          apiKey: 'sk-test-abcdef',
-          config: {
-            model_provider: 'cradle-openai-compatible',
-            model_providers: {
-              'cradle-openai-compatible': {
-                name: 'Cradle OpenAI Compatible',
-                base_url: 'https://example.com/v1',
-                env_key: 'CRADLE_CODEX_API_KEY',
-                wire_api: 'responses',
-                requires_openai_auth: true,
-              },
-            },
-          },
-        },
-      ])
+      expect(providerFetchCount).toBe(1)
+      expect(codexClientOptions).toEqual([])
 
       const listSecrets = await app.handle(new Request('http://localhost/secrets'))
       expect(listSecrets.status).toBe(200)
@@ -777,6 +766,12 @@ describe('profiles capability', () => {
           headers: { 'content-type': 'application/json' },
         })
       }
+      if (url === 'https://example.com/v1/models') {
+        return new Response(JSON.stringify({ data: [{ id: 'vendor-gpt4o' }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
 
       throw new Error(`Unexpected fetch request: ${url}`)
     })
@@ -896,7 +891,7 @@ describe('profiles capability', () => {
       const providerFetchCount = fetchSpy.mock.calls.filter(
         ([callInput]) => getRequestUrl(callInput) === 'https://example.com/v1/models',
       ).length
-      expect(providerFetchCount).toBe(0)
+      expect(providerFetchCount).toBe(2)
     }
  finally {
       shutdownInfra()

--- a/apps/web/src/features/chat/rendering/blocks/runtime-warning-block.tsx
+++ b/apps/web/src/features/chat/rendering/blocks/runtime-warning-block.tsx
@@ -1,0 +1,29 @@
+import type { RuntimeWarningPartData } from '@cradle/chat-runtime-contracts'
+import { RightSmallLine as ChevronRightIcon, WarningLine as WarningIcon } from '@mingcute/react'
+
+export function RuntimeWarningBlock({ warning }: { warning: RuntimeWarningPartData }) {
+  if (!warning.additionalDetails) {
+    return (
+      <div className="my-1 flex min-h-10 items-center gap-2 text-[12px] text-muted-foreground">
+        <WarningIcon className="size-3.5 shrink-0 !text-amber-500" aria-hidden />
+        <span className="text-pretty">{warning.message}</span>
+      </div>
+    )
+  }
+
+  return (
+    <details className="group my-1 text-[12px] text-muted-foreground">
+      <summary className="-mx-2 flex min-h-10 cursor-pointer list-none items-center gap-2 rounded-md px-2 transition-[background-color,color] duration-150 hover:bg-amber-500/5 hover:text-foreground">
+        <WarningIcon className="size-3.5 shrink-0 !text-amber-500" aria-hidden />
+        <span className="min-w-0 flex-1 text-pretty">{warning.message}</span>
+        <ChevronRightIcon
+          className="size-3.5 shrink-0 transition-transform duration-150 group-open:rotate-90"
+          aria-hidden
+        />
+      </summary>
+      <div className="ml-1.5 border-l border-amber-500/20 py-1.5 pl-4 text-[11px] leading-relaxed whitespace-pre-wrap wrap-break-word text-muted-foreground/80">
+        {warning.additionalDetails}
+      </div>
+    </details>
+  )
+}

--- a/apps/web/src/features/chat/rendering/chat-render-plan.test.ts
+++ b/apps/web/src/features/chat/rendering/chat-render-plan.test.ts
@@ -1,0 +1,28 @@
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { groupMessageParts } from './chat-render-plan'
+
+describe('groupMessageParts', () => {
+  it('keeps runtime warnings between streamed text segments', () => {
+    const parts = [
+      { type: 'text', text: 'Before', state: 'done' },
+      {
+        type: 'data-runtime-warning',
+        data: {
+          message: 'Reconnecting... 2/5',
+          additionalDetails: 'request timed out',
+        },
+      },
+      { type: 'text', text: 'After', state: 'done' },
+    ] as UIMessage['parts']
+
+    const items = groupMessageParts({
+      parts,
+      messageId: 'message-1',
+      describeToolKind: () => null,
+    })
+
+    expect(items.map(item => item.kind)).toEqual(['text', 'runtime-warning', 'text'])
+  })
+})

--- a/apps/web/src/features/chat/rendering/chat-render-plan.ts
+++ b/apps/web/src/features/chat/rendering/chat-render-plan.ts
@@ -8,6 +8,8 @@ import {
   isChatPluginContextPart,
   isChatSkillContextPart,
 } from '../context/chat-context-parts'
+import type { RuntimeWarningMessagePart } from '../runtime-warning'
+import { isRuntimeWarningMessagePart } from '../runtime-warning'
 import { readBuiltinToolCallInputPayload, readBuiltinToolCallResultPayload, toolNameFromPart } from './chat-tool-entities'
 import type { RenderableToolPart, ToolUiKind } from './tool-ui-classifier'
 import { normalizeToolName } from './tool-ui-classifier'
@@ -40,6 +42,7 @@ export type ChatRenderSegment
     | (MessagePartRefBase & { kind: 'skill-context' })
     | (MessagePartRefBase & { kind: 'plugin-context' })
     | (MessagePartRefBase & { kind: 'file-attachment' })
+    | (MessagePartRefBase & { kind: 'runtime-warning' })
 
 export type ChatRenderItem
   = | { kind: 'text', text: string, key: string }
@@ -49,6 +52,7 @@ export type ChatRenderItem
     | { kind: 'skill-context', part: ChatSkillContextMessagePart, key: string }
     | { kind: 'plugin-context', part: ChatPluginContextMessagePart, key: string }
     | { kind: 'file-attachment', part: FileMessagePart, key: string }
+    | { kind: 'runtime-warning', part: RuntimeWarningMessagePart, key: string }
 
 export interface ExecutionPhaseSplit {
   executionItems: ChatRenderItem[]
@@ -161,6 +165,14 @@ export function groupMessagePartRefs(input: GroupMessagePartsInput): ChatRenderS
         partIndex: i,
       })
     }
+ else if (isRuntimeWarningMessagePart(part)) {
+      items.push({
+        kind: 'runtime-warning',
+        key,
+        messageId: input.messageId,
+        partIndex: i,
+      })
+    }
  else {
       const toolPart = readRenderableToolPart(part)
       if (!toolPart) {
@@ -213,6 +225,9 @@ export function groupMessageParts(input: GroupMessagePartsInput): ChatRenderItem
     }
  else if (isChatPluginContextPart(part)) {
       items.push({ kind: 'plugin-context', part: part as ChatPluginContextMessagePart, key })
+    }
+ else if (isRuntimeWarningMessagePart(part)) {
+      items.push({ kind: 'runtime-warning', part, key })
     }
  else {
       const toolPart = readRenderableToolPart(part)

--- a/apps/web/src/features/chat/rendering/message-bubble-selectors.ts
+++ b/apps/web/src/features/chat/rendering/message-bubble-selectors.ts
@@ -20,6 +20,8 @@ import {
   isChatPluginContextPart,
   isChatSkillContextPart,
 } from '../context/chat-context-parts'
+import type { RuntimeWarningMessagePart } from '../runtime-warning'
+import { isRuntimeWarningMessagePart } from '../runtime-warning'
 import type {
   ChatRenderItem,
   ChatRenderSegment,
@@ -250,11 +252,13 @@ function areRenderSegmentEqual(left: ChatRenderSegment, right: ChatRenderSegment
     case 'file-attachment':
     case 'skill-context':
     case 'plugin-context':
+    case 'runtime-warning':
       return (
         (right.kind === 'reasoning'
           || right.kind === 'file-attachment'
           || right.kind === 'skill-context'
-          || right.kind === 'plugin-context')
+          || right.kind === 'plugin-context'
+          || right.kind === 'runtime-warning')
         && left.kind === right.kind
         && left.messageId === right.messageId
         && left.partIndex === right.partIndex
@@ -359,6 +363,16 @@ export function readPluginContextPartFromState(
 ): ChatPluginContextMessagePart | null {
   const part = readMessageFromState(state, sessionId, messageId)?.parts[partIndex]
   return isChatPluginContextPart(part) ? part : null
+}
+
+export function readRuntimeWarningPartFromState(
+  state: ChatStoreSnapshot,
+  sessionId: string,
+  messageId: string,
+  partIndex: number,
+): RuntimeWarningMessagePart | null {
+  const part = readMessageFromState(state, sessionId, messageId)?.parts[partIndex]
+  return isRuntimeWarningMessagePart(part) ? part : null
 }
 
 export function readRenderableToolPartFromState(

--- a/apps/web/src/features/chat/rendering/message-bubble.tsx
+++ b/apps/web/src/features/chat/rendering/message-bubble.tsx
@@ -20,6 +20,7 @@ import {
 } from '../commands/bang-command-metadata'
 import { BangCommandBlock, BangCommandPromptBlock } from './blocks/bang-command-block'
 import { ReasoningBlock } from './blocks/reasoning-block'
+import { RuntimeWarningBlock } from './blocks/runtime-warning-block'
 import type {
   ChatRenderItem,
   ChatRenderSegment,
@@ -60,6 +61,7 @@ import {
   MessageFilePartById,
   MessagePluginContextPartById,
   MessageReasoningPartById,
+  MessageRuntimeWarningPartById,
   MessageSkillContextPartById,
   MessageTextPartById,
 } from './message-part-blocks'
@@ -333,6 +335,14 @@ const MessageSegmentView = ({
     case 'plugin-context':
       return (
         <MessagePluginContextPartById
+          sessionId={sessionId}
+          messageId={segment.messageId}
+          partIndex={segment.partIndex}
+        />
+      )
+    case 'runtime-warning':
+      return (
+        <MessageRuntimeWarningPartById
           sessionId={sessionId}
           messageId={segment.messageId}
           partIndex={segment.partIndex}
@@ -780,6 +790,8 @@ function MessageBubbleView({
         return <SkillContextBlock key={item.key} part={item.part} />
       case 'plugin-context':
         return <PluginContextBlock key={item.key} part={item.part} />
+      case 'runtime-warning':
+        return <RuntimeWarningBlock key={item.key} warning={item.part.data} />
 
       default:
         return null

--- a/apps/web/src/features/chat/rendering/message-part-blocks.tsx
+++ b/apps/web/src/features/chat/rendering/message-part-blocks.tsx
@@ -3,6 +3,7 @@ import { Streamdown } from '@cradle/streamdown'
 import { STREAMDOWN_RENDER_OPTIONS } from '~/store/streamdown'
 
 import { ReasoningBlock } from './blocks/reasoning-block'
+import { RuntimeWarningBlock } from './blocks/runtime-warning-block'
 import { useChatRenderStore } from './chat-render-store'
 import { MarkdownFileLink } from './markdown-file-link'
 import { FileAttachmentBlock, PluginContextBlock, SkillContextBlock } from './message-attachment-blocks'
@@ -13,6 +14,7 @@ import {
   readMarkdownAnchorProps,
   readPluginContextPartFromState,
   readReasoningPartFromState,
+  readRuntimeWarningPartFromState,
   readSkillContextPartFromState,
   readTextPartFromState,
   readUserDisplayText,
@@ -135,3 +137,18 @@ export const MessagePluginContextPartById = ({
   return <PluginContextBlock part={part} />
 }
 MessagePluginContextPartById.displayName = 'MessagePluginContextPartById'
+
+export const MessageRuntimeWarningPartById = ({
+  sessionId,
+  messageId,
+  partIndex,
+}: {
+  sessionId: string
+  messageId: string
+  partIndex: number
+}) => {
+  const part = useChatRenderStore(state =>
+    readRuntimeWarningPartFromState(state, sessionId, messageId, partIndex))
+  return part ? <RuntimeWarningBlock warning={part.data} /> : null
+}
+MessageRuntimeWarningPartById.displayName = 'MessageRuntimeWarningPartById'

--- a/apps/web/src/features/chat/runtime-warning.ts
+++ b/apps/web/src/features/chat/runtime-warning.ts
@@ -1,0 +1,23 @@
+import type { RuntimeWarningPartData } from '@cradle/chat-runtime-contracts'
+import type { UIMessage } from 'ai'
+
+export type RuntimeWarningMessagePart = UIMessage['parts'][number] & {
+  type: 'data-runtime-warning'
+  data: RuntimeWarningPartData
+}
+
+export function isRuntimeWarningMessagePart(
+  part: UIMessage['parts'][number] | undefined,
+): part is RuntimeWarningMessagePart {
+  if (part?.type !== 'data-runtime-warning') {
+    return false
+  }
+  if (!part.data || typeof part.data !== 'object') {
+    return false
+  }
+  const data = part.data as { message?: unknown, additionalDetails?: unknown }
+  return (
+    typeof data.message === 'string'
+    && (data.additionalDetails === null || typeof data.additionalDetails === 'string')
+  )
+}

--- a/apps/web/src/features/chat/transport/chat-streaming-handler.ts
+++ b/apps/web/src/features/chat/transport/chat-streaming-handler.ts
@@ -359,6 +359,9 @@ function hasVisibleContent(message: UIMessage): boolean {
     if (part.type === 'dynamic-tool' || part.type.startsWith('tool-')) {
       return true
     }
+    if (part.type === 'data-runtime-warning') {
+      return true
+    }
     return false
   })
 }

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -1,4 +1,23 @@
 // Polyfill ResizeObserver for jsdom (required by @dnd-kit/dom)
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>()
+  return {
+    get length() { return values.size },
+    clear: () => values.clear(),
+    getItem: key => values.get(key) ?? null,
+    key: index => [...values.keys()][index] ?? null,
+    removeItem: key => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  }
+}
+
+if (typeof globalThis.localStorage === 'undefined') {
+  globalThis.localStorage = createMemoryStorage()
+}
+if (typeof globalThis.sessionStorage === 'undefined') {
+  globalThis.sessionStorage = createMemoryStorage()
+}
+
 if (typeof globalThis.ResizeObserver === 'undefined') {
   globalThis.ResizeObserver = class ResizeObserver {
     callback: ResizeObserverCallback

--- a/packages/chat-runtime-contracts/src/index.ts
+++ b/packages/chat-runtime-contracts/src/index.ts
@@ -310,6 +310,11 @@ export type RuntimeMcpAuthStatus
 export type RuntimeApprovalStatus = 'pending' | 'approved' | 'denied' | 'timedOut' | 'aborted'
 export type RuntimeAlertSeverity = 'info' | 'warning' | 'error'
 
+export interface RuntimeWarningPartData {
+  message: string
+  additionalDetails: string | null
+}
+
 export interface RuntimeTokenUsageBreakdown {
   totalTokens: number
   inputTokens: number


### PR DESCRIPTION
## Summary

- Show retryable Codex errors inline as warnings while the response keeps streaming.
- Preserve exact `text → warning → text` timeline order.
- Display `message`; reveal `additionalDetails` through native `<details>`. `codexErrorInfo` stays diagnostic-only.
- Use a ghost warning row with no React state.

## Flow

```mermaid
flowchart LR
  A["Codex error<br/>willRetry = true"] --> B["Close open text / reasoning segment"]
  B --> C["Emit data-runtime-warning"]
  C --> D["Persist ordered message part"]
  D --> E["Ghost warning<br/>expand details"]
  E --> F["Stream continues"]
```

## Verification

- `pnpm typecheck`
- Server tests: 988 passed
- Unit tests: 1651 passed locally
- Desktop CI simulation without Electron binary: 23 files / 132 tests passed
- Changed-file ESLint passed
- React Doctor: 98/100