### PR TITLE
feat(chat): add local Light OCR fallback for image-incapable models

### DIFF
--- a/apps/server/desktop-runtime.externals.json
+++ b/apps/server/desktop-runtime.externals.json
@@ -1,6 +1,7 @@
 {
   "packages": [
     "@anthropic-ai/claude-agent-sdk",
+    "@arcships/light-ocr",
     "@ff-labs/fff-node",
     "@node-rs/jieba",
     "better-sqlite3",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,6 +35,7 @@
     "@ai-sdk/google": "^3.0.72",
     "@ai-sdk/openai": "^3.0.53",
     "@anthropic-ai/claude-agent-sdk": "^0.3.207",
+    "@arcships/light-ocr": "0.1.0",
     "@cradle/chat-runtime-contracts": "workspace:*",
     "@cradle/db": "workspace:*",
     "@cradle/plugin-sdk": "workspace:*",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -31,6 +31,7 @@ import { externalWorkImport } from './modules/external-work-import'
 import { filesystem } from './modules/filesystem'
 import { git } from './modules/git'
 import { health } from './modules/health'
+import { imageOcr } from './modules/image-ocr'
 import { issue } from './modules/issue'
 import { issueAgent } from './modules/issue-agent'
 import { kanban } from './modules/kanban'
@@ -143,10 +144,12 @@ export async function createServerContractApp(options: CreateServerContractAppOp
     }),
   )
   app.use(createRequestIdPlugin())
-  app.use(createAuthPlugin({
-    ...loadServerAuthConfig(),
-    listRelayAuthTokens: listActiveRelayAuthTokens,
-  }))
+  app.use(
+    createAuthPlugin({
+      ...loadServerAuthConfig(),
+      listRelayAuthTokens: listActiveRelayAuthTokens,
+    }),
+  )
   if (includeRuntimeHttpPlugins) {
     const [{ createRequestLoggerPlugin }, { createErrorHandler }] = await Promise.all([
       import('./http/request-logger'),
@@ -187,6 +190,7 @@ export async function createServerContractApp(options: CreateServerContractAppOp
   app.use(sessionGroup)
   app.use(sessionAwait)
   app.use(issue)
+  app.use(imageOcr)
   app.use(kanban)
   app.use(linkPreview)
   app.use(search)
@@ -243,6 +247,7 @@ export async function createServerApp(options: CreateServerAppOptions = {}) {
     { stopOpencodeServer },
     { initHostConnectorService, getHostConnectorService },
     { shutdownRemoteHostConnections },
+    { shutdownImageOcr },
   ] = await Promise.all([
     import('./infra'),
     import('./modules/chat-runtime/runtime'),
@@ -260,6 +265,7 @@ export async function createServerApp(options: CreateServerAppOptions = {}) {
     import('./modules/chat-runtime-providers/opencode/runtime-context'),
     import('./modules/relay-transport/host-connector'),
     import('./modules/remote-hosts/service'),
+    import('./modules/image-ocr/service'),
   ])
   if (recoverPersistedRunsOnCreate) {
     recoverPersistedRunProjections()
@@ -281,23 +287,68 @@ export async function createServerApp(options: CreateServerAppOptions = {}) {
   await activateServerPlugins(app)
   reconcileExternalIssueSourceRegistrations()
 
-const runtimeResources = new RuntimeResourceRegistry()
-  runtimeResources.register({ name: 'active-run-snapshots', phase: 'drain', stop: flushAllActiveRunSnapshots })
+  const runtimeResources = new RuntimeResourceRegistry()
+  runtimeResources.register({
+    name: 'active-run-snapshots',
+    phase: 'drain',
+    stop: flushAllActiveRunSnapshots,
+  })
   runtimeResources.register({ name: 'active-chat-runs', phase: 'drain', stop: abortAllRuns })
-  runtimeResources.register({ name: 'side-conversations', phase: 'stop', stop: clearSideConversations })
-  runtimeResources.register({ name: 'conversation-bridge', phase: 'stop', stop: () => conversationBridgeSupervisor.stopAllConversationBridgeConnections() })
+  runtimeResources.register({
+    name: 'side-conversations',
+    phase: 'stop',
+    stop: clearSideConversations,
+  })
+  runtimeResources.register({
+    name: 'conversation-bridge',
+    phase: 'stop',
+    stop: () => conversationBridgeSupervisor.stopAllConversationBridgeConnections(),
+  })
   runtimeResources.register({ name: 'plugins', phase: 'stop', stop: deactivateAllPlugins })
-  runtimeResources.register({ name: 'provider-runtime', phase: 'stop', stop: () => providerRuntimeHostManager.shutdown() })
+  runtimeResources.register({
+    name: 'provider-runtime',
+    phase: 'stop',
+    stop: () => providerRuntimeHostManager.shutdown(),
+  })
   runtimeResources.register({ name: 'opencode-server', phase: 'stop', stop: stopOpencodeServer })
-  runtimeResources.register({ name: 'local-relayd', phase: 'stop', stop: () => localRelaydSupervisor.stopManagedLocalRelayd() })
-  runtimeResources.register({ name: 'background-job-poller', phase: 'cancel', stop: () => BackgroundJobPoller.stop() })
-  runtimeResources.register({ name: 'relay-host-connector', phase: 'cancel', stop: () => getHostConnectorService()?.stopAll() })
-  runtimeResources.register({ name: 'remote-host-connections', phase: 'cancel', stop: shutdownRemoteHostConnections })
-  runtimeResources.register({ name: 'chronicle-scheduler', phase: 'stop', stop: () => chronicleService.stopActivityPipelineScheduler() })
-  runtimeResources.register({ name: 'chronicle-slack-sync', phase: 'stop', stop: () => chronicleService.stopSlackBackgroundSync() })
+  runtimeResources.register({
+    name: 'local-relayd',
+    phase: 'stop',
+    stop: () => localRelaydSupervisor.stopManagedLocalRelayd(),
+  })
+  runtimeResources.register({
+    name: 'background-job-poller',
+    phase: 'cancel',
+    stop: () => BackgroundJobPoller.stop(),
+  })
+  runtimeResources.register({
+    name: 'relay-host-connector',
+    phase: 'cancel',
+    stop: () => getHostConnectorService()?.stopAll(),
+  })
+  runtimeResources.register({
+    name: 'remote-host-connections',
+    phase: 'cancel',
+    stop: shutdownRemoteHostConnections,
+  })
+  runtimeResources.register({
+    name: 'chronicle-scheduler',
+    phase: 'stop',
+    stop: () => chronicleService.stopActivityPipelineScheduler(),
+  })
+  runtimeResources.register({
+    name: 'chronicle-slack-sync',
+    phase: 'stop',
+    stop: () => chronicleService.stopSlackBackgroundSync(),
+  })
   runtimeResources.register({ name: 'chronicle-daemon', phase: 'stop', stop: chronicleCleanup })
   runtimeResources.register({ name: 'trace-streams', phase: 'stop', stop: shutdownTraceStreams })
-  runtimeResources.register({ name: 'workspace-indexes', phase: 'stop', stop: destroyWorkspaceFileIndexes })
+  runtimeResources.register({
+    name: 'workspace-indexes',
+    phase: 'stop',
+    stop: destroyWorkspaceFileIndexes,
+  })
+  runtimeResources.register({ name: 'image-ocr', phase: 'stop', stop: shutdownImageOcr })
   runtimeResources.register({ name: 'infrastructure', phase: 'close', stop: shutdownInfra })
   app.onStop(() => runtimeResources.shutdown())
 
@@ -337,7 +388,7 @@ const runtimeResources = new RuntimeResourceRegistry()
     try {
       hostConnector.startAll()
     }
-    catch (error) {
+ catch (error) {
       console.error('[relay-host-connector] startAll failed:', error)
     }
   }

--- a/apps/server/src/modules/chat-runtime/interaction/steer-turn.ts
+++ b/apps/server/src/modules/chat-runtime/interaction/steer-turn.ts
@@ -14,11 +14,8 @@ import type {
 import { serializeChatError } from '../run/errors'
 import { annotateContinuationMessage, insertCompletedUserMessage } from '../run/turn-draft'
 import { runRegistry } from '../run-registry'
-import {
-  assertRuntimeCompatibleTarget,
-  getSessionRunContext,
-} from '../runtime-session-context'
-import { createUserMessage } from '../ui-message'
+import { assertRuntimeCompatibleTarget, getSessionRunContext } from '../runtime-session-context'
+import { createUserMessage, projectLightOcrMessage } from '../ui-message'
 
 export interface SubmitSessionSteerTurnDeps {
   finalizeInterruptedPersistedStreamingSessionIfIdle: (sessionId: string) => Promise<void>
@@ -44,7 +41,8 @@ async function enqueueSteerRequestAsQueueItem(
     providerTargetId: input.providerTargetId,
   }
   const queueItem: ChatSessionQueueItemDto = await enqueueSessionQueueItem(enqueueInput, {
-    finalizeInterruptedPersistedStreamingSessionIfIdle: deps.finalizeInterruptedPersistedStreamingSessionIfIdle,
+    finalizeInterruptedPersistedStreamingSessionIfIdle:
+      deps.finalizeInterruptedPersistedStreamingSessionIfIdle,
     scheduleSessionQueueDrain: deps.scheduleSessionQueueDrain,
   })
   return {
@@ -111,7 +109,12 @@ export async function submitSessionSteerTurn(
   // `queue-fallback` runtimes always queue; `native` runtimes queue only when there's no active
   // run they can actually steer (not started yet, already finished, or targeting a different
   // provider context) rather than rejecting the request outright.
-  if (runtime.capabilities.steer === 'queue-fallback' || !activeRun || !steerHook || !hasMatchingActiveRun) {
+  if (
+    runtime.capabilities.steer === 'queue-fallback'
+    || !activeRun
+    || !steerHook
+    || !hasMatchingActiveRun
+  ) {
     return await enqueueSteerRequestAsQueueItem(input, deps)
   }
 
@@ -125,7 +128,7 @@ export async function submitSessionSteerTurn(
     await steerHook.call(activeRun.runtime, {
       runtimeSession: activeRun.runtimeSession,
       profile: context.profile,
-      message: steerMessage,
+      message: projectLightOcrMessage(steerMessage),
     })
   }
  catch (error) {
@@ -139,7 +142,11 @@ export async function submitSessionSteerTurn(
       code: 'chat_steer_rejected',
       status: 409,
       message: 'Runtime rejected live steer',
-      details: { sessionId: input.sessionId, runId: activeRun.runId, error: serializeChatError(error).text },
+      details: {
+        sessionId: input.sessionId,
+        runId: activeRun.runId,
+        error: serializeChatError(error).text,
+      },
     })
   }
 

--- a/apps/server/src/modules/chat-runtime/run/run-coordinator.ts
+++ b/apps/server/src/modules/chat-runtime/run/run-coordinator.ts
@@ -24,24 +24,17 @@ import {
   readSessionRequestedThinkingEffort,
   resolveRuntimeSessionForContext,
 } from '../runtime-session-context'
-import {
-  readSessionRuntimeSettings,
-  resolveRunRuntimeSettings,
-} from '../runtime-settings'
+import { readSessionRuntimeSettings, resolveRunRuntimeSettings } from '../runtime-settings'
 import { isChatStreamTraceEnabled, recordChatStreamTrace } from '../stream-trace'
 import {
   createAssistantMessage,
   createUserMessage,
+  projectLightOcrMessage,
+  projectLightOcrMessages,
 } from '../ui-message'
-import {
-  createFinalMessageProjectionState,
-} from './final-message-projection'
+import { createFinalMessageProjectionState } from './final-message-projection'
 import { cancelPendingRuntimeGoalContinuation } from './runtime-goal-continuation'
-import {
-  createDraftTurn,
-  createDraftTurnFromUserMessage,
-  startRun,
-} from './turn-draft'
+import { createDraftTurn, createDraftTurnFromUserMessage, startRun } from './turn-draft'
 import type { ExecuteRunInput } from './turn-executor'
 
 export interface CreateRunInput {
@@ -189,14 +182,13 @@ export async function createRun(
     }
     const runtimeRequestMessages = requestMessages
 
-    const sessionRuntimeSettings = readSessionRuntimeSettings(runtimeKind, context.session.configJson)
+    const sessionRuntimeSettings = readSessionRuntimeSettings(
+      runtimeKind,
+      context.session.configJson,
+    )
     const runtimeSettings = input.runtimeSettingsOverride
       ? { ...input.runtimeSettingsOverride }
-      : resolveRunRuntimeSettings(
-          runtimeKind,
-          sessionRuntimeSettings,
-          input.runtimeSettings,
-        )
+      : resolveRunRuntimeSettings(runtimeKind, sessionRuntimeSettings, input.runtimeSettings)
     const requestedModelId
       = input.modelId !== undefined
         ? input.modelId
@@ -228,10 +220,7 @@ export async function createRun(
             userMessageId: '',
             assistantMessageId: randomUUID(),
             userMessage: runtimeGoalContinuation!.annotateContinuationMessage({
-              message: createUserMessage(
-                randomUUID(),
-                runtimeGoalContinuation!.continuationPrompt,
-              ),
+              message: createUserMessage(randomUUID(), runtimeGoalContinuation!.continuationPrompt),
             }),
           }
         : lastRequestMessage?.role === 'assistant'
@@ -379,7 +368,7 @@ export async function createRun(
         })
 
     deps.executeRun(activeRun, {
-      message: draft.userMessage,
+      message: projectLightOcrMessage(draft.userMessage),
       profile: context.profile,
       modelId:
         requestedModelId !== undefined
@@ -389,8 +378,10 @@ export async function createRun(
       runtimeSettings,
       systemPrompt: turnContext.systemPrompt,
       transcript: turnContext.transcript,
-      history: turnContext.history?.length ? turnContext.history : undefined,
-      originalMessages: runtimeRequestMessages,
+      history: turnContext.history?.length
+        ? projectLightOcrMessages(turnContext.history)
+        : undefined,
+      originalMessages: projectLightOcrMessages(runtimeRequestMessages),
       workspaceId: context.session.workspaceId,
       workspacePath: context.workspacePath,
       agentId: context.session.agentId,

--- a/apps/server/src/modules/chat-runtime/side-chat/response.ts
+++ b/apps/server/src/modules/chat-runtime/side-chat/response.ts
@@ -17,11 +17,8 @@ import {
   assertRunnableSession,
   assertRuntimeCompatibleTarget,
 } from '../runtime-session-context'
-import {
-  readSessionRuntimeSettings,
-  resolveRunRuntimeSettings,
-} from '../runtime-settings'
-import { createUserMessage } from '../ui-message'
+import { readSessionRuntimeSettings, resolveRunRuntimeSettings } from '../runtime-settings'
+import { createUserMessage, projectLightOcrMessage, projectLightOcrMessages } from '../ui-message'
 import { createLiveSideConversationStream } from './live-stream'
 
 export interface StreamSideConversationResponseInput {
@@ -95,7 +92,10 @@ export async function streamSideConversationResponse(
   const assistantMessageId = randomUUID()
   const userMessageId = randomUUID()
   const runtimeKind = parentContext.session.runtimeKind ?? 'standard'
-  const parentRuntimeSettings = readSessionRuntimeSettings(runtimeKind, parentContext.session.configJson)
+  const parentRuntimeSettings = readSessionRuntimeSettings(
+    runtimeKind,
+    parentContext.session.configJson,
+  )
   const runtimeSettings = resolveRunRuntimeSettings(
     runtimeKind,
     parentRuntimeSettings,
@@ -116,13 +116,13 @@ export async function streamSideConversationResponse(
       runtime,
       runtimeSession: record.runtimeSession,
       profile: parentContext.profile,
-      message,
+      message: projectLightOcrMessage(message),
       responseMessageId: assistantMessageId,
       modelId,
       thinkingEffort: input.thinkingEffort,
       runtimeSettings,
       systemPrompt: resolveSessionSystemPrompt(parentContext.session),
-      history: record.history,
+      history: projectLightOcrMessages(record.history),
       onComplete: assistantMessage =>
         appendSideConversationHistory(input.sideConversationId, [message, assistantMessage]),
       workspaceId: parentContext.session.workspaceId,

--- a/apps/server/src/modules/chat-runtime/ui-message.test.ts
+++ b/apps/server/src/modules/chat-runtime/ui-message.test.ts
@@ -1,0 +1,59 @@
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { projectLightOcrMessage } from './ui-message'
+
+describe('projectLightOcrMessage', () => {
+  it('keeps the transcript attachment while replacing it with local OCR text for provider input', () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      parts: [
+        { type: 'text', text: 'What does this say?' },
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          filename: 'receipt.png',
+          url: 'file:///tmp/receipt.png',
+          providerMetadata: {
+            cradle: {
+              lightOcr: { version: 1, text: 'Total: $12.00' },
+            },
+          },
+        },
+      ],
+    } as UIMessage
+
+    const projected = projectLightOcrMessage(message)
+
+    expect(message.parts[1]?.type).toBe('file')
+    expect(projected.parts).toEqual([
+      { type: 'text', text: 'What does this say?' },
+      {
+        type: 'text',
+        text: [
+          'Text recognized locally from receipt.png:',
+          '<cradle-local-image-ocr>',
+          'Total: $12.00',
+          '</cradle-local-image-ocr>',
+        ].join('\n'),
+      },
+    ])
+  })
+
+  it('does not rewrite ordinary attachments', () => {
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      parts: [
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          url: 'file:///tmp/image.png',
+        },
+      ],
+    } as UIMessage
+
+    expect(projectLightOcrMessage(message)).toBe(message)
+  })
+})

--- a/apps/server/src/modules/chat-runtime/ui-message.ts
+++ b/apps/server/src/modules/chat-runtime/ui-message.ts
@@ -9,19 +9,24 @@ export function parseStoredMessageSnapshot(raw: string): UIMessage {
 }
 
 export function normalizeMessageSnapshot(message: UIMessage): UIMessage {
-  if (message.role !== 'user' || !message.parts.some(part => isChatContextPart(part) && typeof readChatContextPart(part)?.position === 'number')) {
+  if (
+    message.role !== 'user'
+    || !message.parts.some(
+      part => isChatContextPart(part) && typeof readChatContextPart(part)?.position === 'number',
+    )
+  ) {
     return message
   }
 
-  const text = message.parts
-    .flatMap(part => part.type === 'text' ? [part.text] : [])
-    .join('')
+  const text = message.parts.flatMap(part => (part.type === 'text' ? [part.text] : [])).join('')
   const contextParts = message.parts.flatMap((part) => {
     const contextPart = readChatContextPart(part)
     return contextPart ? [contextPart] : []
   })
   const orderedParts = toOrderedUserMessageParts(text, contextParts) as UIMessage['parts']
-  orderedParts.push(...message.parts.filter(part => part.type !== 'text' && !isChatContextPart(part)))
+  orderedParts.push(
+    ...message.parts.filter(part => part.type !== 'text' && !isChatContextPart(part)),
+  )
 
   return {
     ...message,
@@ -29,7 +34,10 @@ export function normalizeMessageSnapshot(message: UIMessage): UIMessage {
   }
 }
 
-export function createAssistantMessage(messageId: string, parts: UIMessage['parts'] = []): UIMessage {
+export function createAssistantMessage(
+  messageId: string,
+  parts: UIMessage['parts'] = [],
+): UIMessage {
   return {
     id: messageId,
     role: 'assistant',
@@ -37,7 +45,12 @@ export function createAssistantMessage(messageId: string, parts: UIMessage['part
   }
 }
 
-export function createUserMessage(messageId: string, text: string, files: FileUIPart[] = [], contextParts: ChatContextPart[] = []): UIMessage {
+export function createUserMessage(
+  messageId: string,
+  text: string,
+  files: FileUIPart[] = [],
+  contextParts: ChatContextPart[] = [],
+): UIMessage {
   const parts = toOrderedUserMessageParts(text, contextParts) as UIMessage['parts']
   parts.push(...files)
 
@@ -46,6 +59,54 @@ export function createUserMessage(messageId: string, text: string, files: FileUI
     role: 'user',
     parts,
   }
+}
+
+/**
+ * Replaces image file parts explicitly prepared by the local Light OCR flow
+ * with text before a provider sees the message. The original message remains
+ * unchanged for the transcript and attachment UI.
+ */
+export function projectLightOcrMessage(message: UIMessage): UIMessage {
+  if (message.role !== 'user') {
+    return message
+  }
+
+  let usedLightOcr = false
+  const parts = message.parts.flatMap((part): UIMessage['parts'] => {
+    if (part.type !== 'file') {
+      return [part]
+    }
+    const metadata = readObjectRecord(part.providerMetadata)
+    const cradle = readObjectRecord(metadata.cradle)
+    const lightOcr = readObjectRecord(cradle.lightOcr)
+    const text = typeof lightOcr.text === 'string' ? lightOcr.text.trim() : null
+    if (text === null) {
+      return [part]
+    }
+
+    usedLightOcr = true
+    const label = part.filename?.trim() || 'attached image'
+    const content = text || '[No readable text was found in this image.]'
+    return [
+      {
+        type: 'text',
+        text: [
+          `Text recognized locally from ${label}:`,
+          '<cradle-local-image-ocr>',
+          content,
+          '</cradle-local-image-ocr>',
+        ].join('\n'),
+      } as UIMessage['parts'][number],
+    ]
+  })
+
+  return usedLightOcr ? { ...message, parts } : message
+}
+
+export function projectLightOcrMessages(
+  messages: UIMessage[] | undefined,
+): UIMessage[] | undefined {
+  return messages?.map(projectLightOcrMessage)
 }
 
 export function annotateGoalMessage(message: UIMessage, objective: string): UIMessage {
@@ -88,7 +149,10 @@ export interface BangCommandResultMetadata {
   truncated: boolean
 }
 
-export function annotateBangResultMessage(message: UIMessage, result: BangCommandResultMetadata): UIMessage {
+export function annotateBangResultMessage(
+  message: UIMessage,
+  result: BangCommandResultMetadata,
+): UIMessage {
   const metadata = readObjectRecord((message as { metadata?: unknown }).metadata)
   const cradleMetadata = readObjectRecord(metadata.cradle)
   return {
@@ -114,7 +178,5 @@ export function readGoalMessageObjective(message: UIMessage): string | null {
 
 export function extractMessageText(message: UIMessage): string {
   const parsedMessage = normalizeMessageSnapshot(message)
-  return parsedMessage.parts
-    .flatMap(part => part.type === 'text' ? [part.text] : [])
-    .join('')
+  return parsedMessage.parts.flatMap(part => (part.type === 'text' ? [part.text] : [])).join('')
 }

--- a/apps/server/src/modules/image-ocr/README.md
+++ b/apps/server/src/modules/image-ocr/README.md
@@ -1,0 +1,8 @@
+# Image OCR
+
+`image-ocr` owns local OCR for images attached to Cradle conversations.
+
+- `POST /image-ocr/recognize` accepts existing chat file parts and returns ordered Light OCR text.
+- Source images must be `data:image/...;base64,...` values or local `file:` URLs. The service never fetches remote URLs.
+- The PP-OCRv6 Small engine is process-local and closed through the server runtime-resource registry.
+- Chat runtime owns the separate concern of projecting the returned OCR metadata into text-only provider input; this module does not send prompts or persist messages.

--- a/apps/server/src/modules/image-ocr/index.ts
+++ b/apps/server/src/modules/image-ocr/index.ts
@@ -1,0 +1,15 @@
+import { Elysia } from 'elysia'
+
+import { ImageOcrModel } from './model'
+import { recognizeImages } from './service'
+
+export const imageOcr = new Elysia({
+  prefix: '/image-ocr',
+  detail: { tags: ['image-ocr'] },
+}).post('/recognize', async ({ body }) => ({ items: await recognizeImages(body.files) }), {
+  detail: {
+    summary: 'Recognize text in local image attachments with Light OCR',
+  },
+  body: ImageOcrModel.recognizeBody,
+  response: { 200: ImageOcrModel.recognizeResponse },
+})

--- a/apps/server/src/modules/image-ocr/model.ts
+++ b/apps/server/src/modules/image-ocr/model.ts
@@ -1,0 +1,25 @@
+import { t } from 'elysia'
+
+import { filePartSchema } from '../chat-runtime/model/common-schemas'
+
+export const ImageOcrModel = {
+  recognizeBody: t.Object(
+    {
+      files: t.Array(filePartSchema, { minItems: 1, maxItems: 8 }),
+    },
+    { additionalProperties: false },
+  ),
+  recognizeResponse: t.Object({
+    items: t.Array(
+      t.Object(
+        {
+          index: t.Number({ minimum: 0 }),
+          text: t.String(),
+          lineCount: t.Number({ minimum: 0 }),
+          modelBundleId: t.String(),
+        },
+        { additionalProperties: false },
+      ),
+    ),
+  }),
+}

--- a/apps/server/src/modules/image-ocr/service.ts
+++ b/apps/server/src/modules/image-ocr/service.ts
@@ -1,0 +1,165 @@
+import { readFile, stat } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+import { createEngine, OcrError } from '@arcships/light-ocr'
+import sharp from 'sharp'
+
+import { AppError } from '../../errors/app-error'
+
+export interface ImageOcrFile {
+  mediaType: string
+  filename?: string
+  url: string
+}
+
+export interface RecognizedImageText {
+  index: number
+  text: string
+  lineCount: number
+  modelBundleId: string
+}
+
+const MAX_SOURCE_BYTES = 16 * 1024 * 1024
+const MAX_IMAGE_COUNT = 8
+const BASE64_DATA_URL_RE = /^data:image\/[a-z0-9.+-]+;base64,([a-z0-9+/=\s]+)$/i
+
+let enginePromise: ReturnType<typeof createEngine> | null = null
+
+async function getEngine() {
+  enginePromise ??= createEngine({
+    queueCapacity: 2,
+    maxPendingInputBytes: MAX_SOURCE_BYTES * 2,
+  })
+  const pendingEngine = enginePromise
+  try {
+    return await pendingEngine
+  }
+  catch (error) {
+    if (enginePromise === pendingEngine) {
+      enginePromise = null
+    }
+    throw error
+  }
+}
+
+function rejectInvalidImage(message: string, details?: Record<string, unknown>): never {
+  throw new AppError({ code: 'image_ocr_invalid_image', status: 422, message, details })
+}
+
+function assertImageFile(file: ImageOcrFile): void {
+  if (!file.mediaType.startsWith('image/')) {
+    rejectInvalidImage('Light OCR accepts image attachments only', { mediaType: file.mediaType })
+  }
+}
+
+async function readImageBytes(file: ImageOcrFile): Promise<Buffer> {
+  const dataUrl = BASE64_DATA_URL_RE.exec(file.url)
+  if (dataUrl) {
+    const encoded = dataUrl[1]!.replace(/\s/g, '')
+    const bytes = Buffer.from(encoded, 'base64')
+    if (bytes.length === 0 || bytes.length > MAX_SOURCE_BYTES) {
+      rejectInvalidImage('Image data exceeds the OCR input limit', { maxBytes: MAX_SOURCE_BYTES })
+    }
+    return bytes
+  }
+
+  if (!file.url.startsWith('file:')) {
+    rejectInvalidImage('Light OCR requires a local image attachment')
+  }
+
+  let filePath: string
+  try {
+    filePath = fileURLToPath(file.url)
+  }
+  catch {
+    rejectInvalidImage('Image attachment has an invalid local file URL')
+  }
+  const info = await stat(filePath).catch(() => null)
+  if (!info?.isFile()) {
+    rejectInvalidImage('Image attachment is no longer available locally')
+  }
+  if (info.size > MAX_SOURCE_BYTES) {
+    rejectInvalidImage('Image file exceeds the OCR input limit', { maxBytes: MAX_SOURCE_BYTES })
+  }
+  return await readFile(filePath)
+}
+
+async function decodeForLightOcr(bytes: Buffer) {
+  try {
+    return await sharp(bytes)
+      .rotate()
+      .removeAlpha()
+      .toColourspace('srgb')
+      .raw()
+      .toBuffer({ resolveWithObject: true })
+  }
+ catch {
+    rejectInvalidImage('Image format cannot be decoded for OCR')
+  }
+}
+
+export async function recognizeImages(
+  files: ImageOcrFile[],
+  signal?: AbortSignal,
+): Promise<RecognizedImageText[]> {
+  if (files.length > MAX_IMAGE_COUNT) {
+    throw new AppError({
+      code: 'image_ocr_limit_exceeded',
+      status: 413,
+      message: `Light OCR accepts at most ${MAX_IMAGE_COUNT} images at once`,
+    })
+  }
+
+  const engine = await getEngine()
+  return await Promise.all(
+    files.map(async (file, index) => {
+      assertImageFile(file)
+      const bytes = await readImageBytes(file)
+      const decoded = await decodeForLightOcr(bytes)
+      if (decoded.info.channels !== 3) {
+        rejectInvalidImage('Image could not be normalized to RGB pixels')
+      }
+      try {
+        const result = await engine.recognize(
+          {
+            data: decoded.data,
+            width: decoded.info.width,
+            height: decoded.info.height,
+            stride: decoded.info.width * decoded.info.channels,
+            pixelFormat: 'rgb8',
+          },
+          { signal },
+        )
+        const lines = result.lines.map(line => line.text.trim()).filter(Boolean)
+        return {
+          index,
+          text: lines.join('\n'),
+          lineCount: lines.length,
+          modelBundleId: result.modelBundleId,
+        }
+      }
+      catch (error) {
+        if (error instanceof OcrError) {
+          throw new AppError({
+            code: 'image_ocr_failed',
+            status: error.code === 'resource_limit_exceeded' ? 413 : 422,
+            message: `Light OCR could not read this image: ${error.message}`,
+            details: { code: error.code },
+          })
+        }
+        throw error
+      }
+    }),
+  )
+}
+
+export async function shutdownImageOcr(): Promise<void> {
+  const engine = enginePromise
+  enginePromise = null
+  if (engine) {
+    await engine.then(
+      instance => instance.close(),
+      () => undefined,
+    )
+  }
+}

--- a/apps/web/src/features/chat/composer/composer-actions.tsx
+++ b/apps/web/src/features/chat/composer/composer-actions.tsx
@@ -70,8 +70,21 @@ function TokenProgress({
           className="size-6 cursor-pointer rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
           aria-label={`Context usage: ${label}`}
         >
-          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" style={{ transform: 'rotate(-90deg)' }}>
-            <circle cx="9" cy="9" r={TOKEN_CIRCLE_RADIUS} strokeWidth="2" className="stroke-muted" fill="none" />
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 18 18"
+            fill="none"
+            style={{ transform: 'rotate(-90deg)' }}
+          >
+            <circle
+              cx="9"
+              cy="9"
+              r={TOKEN_CIRCLE_RADIUS}
+              strokeWidth="2"
+              className="stroke-muted"
+              fill="none"
+            />
             {contextWindow && (
               <circle
                 cx="9"
@@ -81,7 +94,11 @@ function TokenProgress({
                 fill="none"
                 className={cn(
                   'transition-[stroke] duration-150',
-                  isDanger ? 'stroke-destructive/70' : isWarning ? 'stroke-warning/70' : 'stroke-primary/50',
+                  isDanger
+                    ? 'stroke-destructive/70'
+                    : isWarning
+                      ? 'stroke-warning/70'
+                      : 'stroke-primary/50',
                 )}
                 strokeDasharray={TOKEN_CIRCUMFERENCE}
                 strokeDashoffset={offset}
@@ -91,7 +108,12 @@ function TokenProgress({
           </svg>
         </Button>
       </PopoverTrigger>
-      <PopoverContent side="top" align="end" sideOffset={12} className="w-auto border-0 bg-transparent p-0 shadow-none ring-0">
+      <PopoverContent
+        side="top"
+        align="end"
+        sideOffset={12}
+        className="w-auto border-0 bg-transparent p-0 shadow-none ring-0"
+      >
         <ContextUsageDetailPanel
           sessionId={sessionId ?? null}
           compactState={compactState}
@@ -115,23 +137,18 @@ function ComposerSendIcon({
     return <Spinner className="size-3" aria-hidden="true" />
   }
 
-  const iconClassName = (active: boolean) => cn(
-    'absolute inset-0 size-3.5 transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none',
-    active ? 'scale-100 opacity-100 blur-0' : 'scale-[0.25] opacity-0 blur-[4px]',
-  )
+  const iconClassName = (active: boolean) =>
+    cn(
+      'absolute inset-0 size-3.5 transition-[opacity,transform,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none',
+      active ? 'scale-100 opacity-100 blur-0' : 'scale-[0.25] opacity-0 blur-[4px]',
+    )
   const showPlanIcon = Boolean(!isBangMode && isPlanMode)
 
   return (
     <span className="relative size-3.5" aria-hidden="true">
-      <SendHorizonalIcon
-        className={iconClassName(!isBangMode && !isPlanMode)}
-      />
-      <RouteIcon
-        className={iconClassName(showPlanIcon)}
-      />
-      <SquareTerminalIcon
-        className={iconClassName(Boolean(isBangMode))}
-      />
+      <SendHorizonalIcon className={iconClassName(!isBangMode && !isPlanMode)} />
+      <RouteIcon className={iconClassName(showPlanIcon)} />
+      <SquareTerminalIcon className={iconClassName(Boolean(isBangMode))} />
     </span>
   )
 }
@@ -156,6 +173,7 @@ export function ComposerActions({
   sendButtonTestId,
   stopButtonTestId,
   attachmentController,
+  usesLightOcr,
   sessionId,
   sessionTokens,
   sessionContextWindow,
@@ -183,6 +201,7 @@ export function ComposerActions({
   sendButtonTestId: string
   stopButtonTestId: string
   attachmentController: ComposerAttachmentController | null
+  usesLightOcr?: boolean
   sessionId?: string | null
   sessionTokens?: number
   sessionContextWindow?: number | null
@@ -228,9 +247,11 @@ export function ComposerActions({
       {showCustomSendText && <span className="text-[11px] font-semibold">{sendButtonText}</span>}
     </Button>
   )
-  const sendVariantsAvailable = !!sendVariants && sendVariants.length > 0 && !isBangMode && !isPlanSendMode
-  const sendButtonNode = sendVariantsAvailable && sendVariants
-    ? (
+  const sendVariantsAvailable
+    = !!sendVariants && sendVariants.length > 0 && !isBangMode && !isPlanSendMode
+  const sendButtonNode
+    = sendVariantsAvailable && sendVariants
+? (
       <ButtonGroup>
         {sendButton}
         <DropdownMenu>
@@ -261,7 +282,9 @@ export function ComposerActions({
         </DropdownMenu>
       </ButtonGroup>
     )
-    : sendButton
+: (
+      sendButton
+    )
 
   return (
     <div className={cn('flex items-center gap-1', actionsClassName)}>
@@ -273,17 +296,21 @@ export function ComposerActions({
           iconClassName={attachIconClassName}
           onPickFiles={attachmentController.pickFiles}
           supportsAttachments={attachmentController.supportsAttachments}
+          usesLightOcr={usesLightOcr}
           testId={attachButtonTestId}
         />
       )}
-      {sessionTokens != null && sessionTokens > 0 && sessionContextWindow != null && sessionContextWindow > 0 && (
-        <TokenProgress
-          tokens={sessionTokens}
-          contextWindow={sessionContextWindow}
-          sessionId={sessionId}
-          compactState={compactState}
-        />
-      )}
+      {sessionTokens != null
+        && sessionTokens > 0
+        && sessionContextWindow != null
+        && sessionContextWindow > 0 && (
+          <TokenProgress
+            tokens={sessionTokens}
+            contextWindow={sessionContextWindow}
+            sessionId={sessionId}
+            compactState={compactState}
+          />
+        )}
       {isStreaming && hasDraft && (
         <Button
           variant="outline"
@@ -299,19 +326,21 @@ export function ComposerActions({
         </Button>
       )}
       {isStreaming
-        ? (
-            <Button
-              variant="default"
-              size="icon-xs"
-              onClick={onStop}
-              aria-label="Stop generation"
-              className={sendButtonClassName}
-              data-testid={stopButtonTestId}
-            >
-              <SquareIcon className="size-3" aria-hidden="true" />
-            </Button>
-          )
-        : sendButtonNode}
+? (
+        <Button
+          variant="default"
+          size="icon-xs"
+          onClick={onStop}
+          aria-label="Stop generation"
+          className={sendButtonClassName}
+          data-testid={stopButtonTestId}
+        >
+          <SquareIcon className="size-3" aria-hidden="true" />
+        </Button>
+      )
+: (
+        sendButtonNode
+      )}
     </div>
   )
 }

--- a/apps/web/src/features/chat/composer/composer-attachment-state.ts
+++ b/apps/web/src/features/chat/composer/composer-attachment-state.ts
@@ -90,6 +90,10 @@ export function modelSupportsAttachments(model: ModelDescriptor | null | undefin
   return modalities.some(modality => modality !== 'text')
 }
 
+export function modelSupportsImageInput(model: ModelDescriptor | null | undefined): boolean {
+  return model?.capabilities.inputModalities?.includes('image') ?? false
+}
+
 export function useComposerAttachments({
   supportsAttachments = false,
 }: ComposerAttachmentConfig = {}): ComposerAttachmentController {

--- a/apps/web/src/features/chat/composer/composer-attachments.tsx
+++ b/apps/web/src/features/chat/composer/composer-attachments.tsx
@@ -6,9 +6,11 @@ import {
 import type { FileUIPart } from 'ai'
 import { m } from 'motion/react'
 import type { ChangeEvent, RefObject } from 'react'
+import { useState } from 'react'
 
 import { Button } from '~/components/ui/button'
 import { Input } from '~/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip'
 import { cn } from '~/lib/cn'
 
@@ -21,6 +23,7 @@ interface ComposerAttachmentInputProps {
   fileInputRef: RefObject<HTMLInputElement | null>
   onFilesSelected: (event: ChangeEvent<HTMLInputElement>) => Promise<void>
   supportsAttachments: boolean
+  imageOnly?: boolean
   testId?: string
 }
 
@@ -30,6 +33,7 @@ interface ComposerAttachmentButtonProps {
   iconClassName?: string
   onPickFiles: () => void
   supportsAttachments: boolean
+  usesLightOcr?: boolean
   testId?: string
 }
 
@@ -52,6 +56,7 @@ export function ComposerAttachmentInput({
   fileInputRef,
   onFilesSelected,
   supportsAttachments,
+  imageOnly = false,
   testId = 'chat-file-input',
 }: ComposerAttachmentInputProps) {
   return (
@@ -59,7 +64,7 @@ export function ComposerAttachmentInput({
       ref={fileInputRef}
       type="file"
       multiple
-      accept={supportsAttachments ? undefined : ''}
+      accept={supportsAttachments ? (imageOnly ? 'image/*' : undefined) : ''}
       className="hidden"
       tabIndex={-1}
       aria-label="Attach files"
@@ -75,24 +80,56 @@ export function ComposerAttachmentButton({
   iconClassName,
   onPickFiles,
   supportsAttachments,
+  usesLightOcr = false,
   testId = 'chat-attach-btn',
 }: ComposerAttachmentButtonProps) {
+  const [ocrPopoverOpen, setOcrPopoverOpen] = useState(false)
+  const attachmentButton = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      disabled={disabled || !supportsAttachments}
+      onClick={usesLightOcr ? undefined : onPickFiles}
+      aria-label={usesLightOcr ? 'Attach image with local text recognition' : 'Attach files'}
+      className={className}
+      data-testid={testId}
+    >
+      <PaperclipIcon className={cn('size-3.5', iconClassName)} aria-hidden="true" />
+    </Button>
+  )
+
+  if (usesLightOcr) {
+    return (
+      <Popover open={ocrPopoverOpen} onOpenChange={setOcrPopoverOpen}>
+        <PopoverTrigger asChild>{attachmentButton}</PopoverTrigger>
+        <PopoverContent side="top" align="start" className="w-72 gap-3 p-3">
+          <div className="space-y-1">
+            <p className="font-medium text-foreground">Use local image text recognition?</p>
+            <p className="text-pretty text-xs leading-5 text-muted-foreground">
+              This model cannot see images. Cradle will extract their text locally and send only
+              that text to the model.
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="xs"
+            className="self-end"
+            onClick={() => {
+              setOcrPopoverOpen(false)
+              onPickFiles()
+            }}
+          >
+            Choose images
+          </Button>
+        </PopoverContent>
+      </Popover>
+    )
+  }
+
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          disabled={disabled || !supportsAttachments}
-          onClick={onPickFiles}
-          aria-label="Attach files"
-          className={className}
-          data-testid={testId}
-        >
-          <PaperclipIcon className={cn('size-3.5', iconClassName)} aria-hidden="true" />
-        </Button>
-      </TooltipTrigger>
+      <TooltipTrigger asChild>{attachmentButton}</TooltipTrigger>
       <TooltipContent side="top" className="text-[11px]">
         {supportsAttachments ? 'Attach files' : 'Current model does not accept file input'}
       </TooltipContent>
@@ -152,15 +189,17 @@ export function ComposerAttachmentList({
                 transition={{ duration: 0.18, ease: [0.2, 0, 0, 1] }}
               >
                 {isImage && !isFileUrl
-                  ? (
-                      <img
-                        src={attachment.url}
-                        alt={label}
-                        className="size-10 shrink-0 rounded-[4px] object-cover shadow-[inset_0_0_0_1px_rgba(0,0,0,0.10)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.10)]"
-                        data-testid="chat-attachment-image-preview"
-                      />
-                    )
-                  : <FileIcon className="size-3.5 shrink-0" aria-hidden="true" />}
+? (
+                  <img
+                    src={attachment.url}
+                    alt={label}
+                    className="size-10 shrink-0 rounded-[4px] object-cover shadow-[inset_0_0_0_1px_rgba(0,0,0,0.10)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.10)]"
+                    data-testid="chat-attachment-image-preview"
+                  />
+                )
+: (
+                  <FileIcon className="size-3.5 shrink-0" aria-hidden="true" />
+                )}
                 <span className="min-w-0 truncate">{label}</span>
                 <Button
                   type="button"
@@ -184,8 +223,8 @@ export function ComposerAttachmentList({
 
 function PendingAppshotSlot({ pending }: { pending: PendingAppshotAttachment }) {
   const height = pending.transitionSnapshotHeightResolved
-      ? (pending.transitionSnapshotHeight ?? APPSHOT_FALLBACK_HEIGHT)
-      : 0
+    ? (pending.transitionSnapshotHeight ?? APPSHOT_FALLBACK_HEIGHT)
+    : 0
   const transition = {
     type: 'spring' as const,
     visualDuration: pending.transitionSpringResponse ?? 0.35,

--- a/apps/web/src/features/chat/composer/composer.tsx
+++ b/apps/web/src/features/chat/composer/composer.tsx
@@ -112,6 +112,7 @@ export interface ComposerCommandController {
 
 export interface ComposerAttachmentIntegration {
   supportsAttachments?: boolean
+  usesLightOcr?: boolean
   /** File parts injected externally, for example from native Appshot capture. */
   appendFileParts?: FileUIPart[]
   /** Used together with appendFileParts to re-trigger the append. */
@@ -263,6 +264,7 @@ export function Composer({
   const slashCommands = commands?.commands ?? EMPTY_SLASH_COMMANDS
   const onSlashCommandAction = commands?.runAction
   const supportsAttachments = attachments?.supportsAttachments
+  const usesLightOcr = attachments?.usesLightOcr ?? false
   const appendExternalFileParts = attachments?.appendFileParts
   const appendExternalFilePartsKey = attachments?.appendFilePartsKey
   const pendingAppshots = attachments?.pendingAppshots ?? []
@@ -1044,6 +1046,7 @@ export function Composer({
               fileInputRef={attachmentController.fileInputRef}
               onFilesSelected={attachmentController.handleFilesSelected}
               supportsAttachments={attachmentController.supportsAttachments}
+              imageOnly={usesLightOcr}
               testId={fileInputTestId}
             />
           )}
@@ -1172,6 +1175,7 @@ export function Composer({
               isSending={isSending}
               isStreaming={isStreaming}
               attachmentController={inputCollapsed ? null : attachmentController}
+              usesLightOcr={usesLightOcr}
               onSend={handleSend}
               onStop={send.stop}
               sendDisabled={sendDisabled}

--- a/apps/web/src/features/chat/composer/draft-chat-composer.tsx
+++ b/apps/web/src/features/chat/composer/draft-chat-composer.tsx
@@ -31,12 +31,18 @@ import { openSettingsSection as openSettingsRouteSection } from '~/navigation/na
 import { useNewChatStore } from '~/store/new-chat'
 import { useSettingsOverlayStore } from '~/store/settings-overlay'
 
-import type { RuntimeSettingsPatch, RuntimeSettingsPatchValue } from '../commands/chat-response-command'
+import type {
+  RuntimeSettingsPatch,
+  RuntimeSettingsPatchValue,
+} from '../commands/chat-response-command'
 import type { ChatContextPart } from '../context/chat-context-parts'
 import type { MentionItem } from '../mentions/mention-panel'
 import { searchPluginMentions } from '../mentions/plugin-mentions'
 import type { SkillMentionItem } from '../mentions/skill-mention-panel'
-import { useDraftClaudeAgentModelAliases, useProviderTargetClaudeAgentModelAliases } from '../runtime/claude-session-model-matrix-control'
+import {
+  useDraftClaudeAgentModelAliases,
+  useProviderTargetClaudeAgentModelAliases,
+} from '../runtime/claude-session-model-matrix-control'
 import { RuntimeSettingsControl } from '../runtime/runtime-settings-control'
 import {
   mergeRuntimeSettings,
@@ -52,9 +58,14 @@ import {
 } from '../slash-commands/chat-slash-commands'
 import { useRuntimeComposerSlashCommands } from '../slash-commands/use-runtime-composer-slash-commands'
 import { Composer } from './composer'
-import type { ComposerSlashCommandActionContext, ComposerSlashCommandActionResult, ComposerSlashCommandActionTools } from './composer-action-context'
-import { modelSupportsAttachments } from './composer-attachment-state'
+import type {
+  ComposerSlashCommandActionContext,
+  ComposerSlashCommandActionResult,
+  ComposerSlashCommandActionTools,
+} from './composer-action-context'
+import { modelSupportsAttachments, modelSupportsImageInput } from './composer-attachment-state'
 import { ComposerSlotStates } from './composer-slot-states'
+import { prepareLightOcrAttachments } from './light-ocr'
 import { useComposerAppshotCapture } from './use-composer-appshot-capture'
 
 type ChatThinkingEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
@@ -63,7 +74,10 @@ interface DraftClaudeAgentConfig {
   modelAliases: ClaudeAgentModelAliases
 }
 
-export type DraftChatRuntimeSettings = Record<string, RuntimeSettingsPatchValue | DraftClaudeAgentConfig | undefined> & {
+export type DraftChatRuntimeSettings = Record<
+  string,
+  RuntimeSettingsPatchValue | DraftClaudeAgentConfig | undefined
+> & {
   claudeAgent?: DraftClaudeAgentConfig | null
 }
 
@@ -169,7 +183,9 @@ function DraftChatComposerContent({
   const { selection, effectiveAgent, effectiveProfile, effectiveModel } = composerState
   const runtimeCatalogItem = resolveRuntimeCatalogItem(runtimes, selection.runtimeKind)
   const defaultRuntimeSettings = readDefaultRuntimeSettings(runtimeCatalogItem)
-  const storedRuntimeSettings = useNewChatStore(s => s.lastRuntimeSettingsByKind[selection.runtimeKind])
+  const storedRuntimeSettings = useNewChatStore(
+    s => s.lastRuntimeSettingsByKind[selection.runtimeKind],
+  )
   const patchRuntimeSettings = useNewChatStore(s => s.patchLastRuntimeSettings)
   const runtimeSettings = mergeRuntimeSettings(defaultRuntimeSettings, storedRuntimeSettings ?? {})
   const claudeAgentByProfile = useNewChatStore(s => s.lastClaudeAgentByProfile)
@@ -204,7 +220,11 @@ function DraftChatComposerContent({
         disabled: false,
       }
     }
-    if (selection.targetMode === 'provider' && composerState.providerBinding !== 'runtime-owned' && !effectiveProfile) {
+    if (
+      selection.targetMode === 'provider'
+      && composerState.providerBinding !== 'runtime-owned'
+      && !effectiveProfile
+    ) {
       return {
         key: 'providers',
         icon: SettingsIcon,
@@ -223,7 +243,10 @@ function DraftChatComposerContent({
     return searchWorkspaceFiles({ workspaceId, query, limit: 30, signal })
   }
 
-  const searchSkills = async (_query: string, signal?: AbortSignal): Promise<SkillMentionItem[]> => {
+  const searchSkills = async (
+    _query: string,
+    signal?: AbortSignal,
+  ): Promise<SkillMentionItem[]> => {
     const { data } = await getSkills({
       query: {
         workspaceId: workspaceId ?? undefined,
@@ -260,17 +283,25 @@ function DraftChatComposerContent({
     if (!selection.profileId) {
       return
     }
-    setClaudeAgentForProfile(selection.profileId, hasClaudeAgentModelAliases(next) ? { modelAliases: next } : null)
+    setClaudeAgentForProfile(
+      selection.profileId,
+      hasClaudeAgentModelAliases(next) ? { modelAliases: next } : null,
+    )
   }
 
   const selectedProviderKind = effectiveProfile?.providerKind
-  const selectedApiProviderKind: ApiProviderKind | null = selectedProviderKind && selectedProviderKind !== 'cli-tool'
-    ? selectedProviderKind
+  const selectedApiProviderKind: ApiProviderKind | null
+    = selectedProviderKind && selectedProviderKind !== 'cli-tool' ? selectedProviderKind : null
+  const claudeAgent = selection.profileId
+    ? (claudeAgentByProfile[selection.profileId] ?? null)
     : null
-  const claudeAgent = selection.profileId ? claudeAgentByProfile[selection.profileId] ?? null : null
-  const inputCollapsed = selection.targetMode === 'agent' && runtimeComposerUsesCollapsedInput(composerState.runtimeComposer)
+  const inputCollapsed
+    = selection.targetMode === 'agent'
+      && runtimeComposerUsesCollapsedInput(composerState.runtimeComposer)
   const allowEmptySubmit = runtimeComposerAllowsEmptySubmit(composerState.runtimeComposer)
-  const usesAliasMatrixModelSelection = runtimeComposerUsesAliasMatrixModelSelection(composerState.runtimeComposer)
+  const usesAliasMatrixModelSelection = runtimeComposerUsesAliasMatrixModelSelection(
+    composerState.runtimeComposer,
+  )
 
   const providerTargetAliases = useProviderTargetClaudeAgentModelAliases({
     providerTargetId: selection.profileId,
@@ -289,7 +320,8 @@ function DraftChatComposerContent({
   const claudeModelAliases = claudeModelAliasesSlot
     ? { slot: claudeModelAliasesSlot, providerSettingsLoading: providerTargetAliases.isLoading }
     : null
-  const supportsAttachments = modelSupportsAttachments(effectiveModel)
+  const usesLightOcr = !modelSupportsImageInput(effectiveModel)
+  const supportsAttachments = modelSupportsAttachments(effectiveModel) || usesLightOcr
   const appshotRuntime = useComposerAppshotCapture({
     active,
     supportsAttachments,
@@ -313,10 +345,14 @@ function DraftChatComposerContent({
 
     return [appshotCommand]
   })()
-  const slashCommands = useRuntimeComposerSlashCommands(selection.runtimeKind, composerState.runtimeComposer, cradleSlashCommands)
-  const sendDisabled = remoteConnectionBlocked || (selection.targetMode === 'agent'
-    ? !effectiveAgent || sending
-    : !effectiveProfile || sending)
+  const slashCommands = useRuntimeComposerSlashCommands(
+    selection.runtimeKind,
+    composerState.runtimeComposer,
+    cradleSlashCommands,
+  )
+  const sendDisabled
+    = remoteConnectionBlocked
+      || (selection.targetMode === 'agent' ? !effectiveAgent || sending : !effectiveProfile || sending)
 
   const toolbar = (
     <div className="flex min-w-0 items-center gap-1">
@@ -339,11 +375,7 @@ function DraftChatComposerContent({
           onChange={updateRuntimeSettings}
         />
       </div>
-      {contextBar && (
-        <div className="flex min-w-0 justify-end">
-          {contextBar}
-        </div>
-      )}
+      {contextBar && <div className="flex min-w-0 justify-end">{contextBar}</div>}
     </div>
   )
 
@@ -355,9 +387,11 @@ function DraftChatComposerContent({
   ) => {
     const trimmedText = text.trim()
     const hasDraft = trimmedText.length > 0 || files.length > 0 || contextParts.length > 0
-    const canSubmit = !remoteConnectionBlocked && (selection.targetMode === 'agent'
-      ? !!effectiveAgent && (allowEmptySubmit || hasDraft) && !sending
-      : !!effectiveProfile && hasDraft && !sending)
+    const canSubmit
+      = !remoteConnectionBlocked
+        && (selection.targetMode === 'agent'
+        ? !!effectiveAgent && (allowEmptySubmit || hasDraft) && !sending
+        : !!effectiveProfile && hasDraft && !sending)
 
     if (!canSubmit) {
       return false
@@ -366,7 +400,9 @@ function DraftChatComposerContent({
     setSending(true)
     const submitRuntimeSettings: DraftChatRuntimeSettings = {
       ...runtimeSettings,
-      ...(selection.targetMode === 'provider' && usesAliasMatrixModelSelection && claudeAgent ? { claudeAgent } : {}),
+      ...(selection.targetMode === 'provider' && usesAliasMatrixModelSelection && claudeAgent
+        ? { claudeAgent }
+        : {}),
     }
     const submitOptions: DraftChatComposerSubmitOptions = {
       runtimeKind: selection.runtimeKind,
@@ -381,15 +417,21 @@ function DraftChatComposerContent({
             providerTargetId: effectiveProfile?.id,
             providerTargetName: effectiveProfile?.name,
             modelId: usesAliasMatrixModelSelection
-              ? selection.modelId ?? undefined
-              : selection.modelId ?? effectiveModel?.id,
+              ? (selection.modelId ?? undefined)
+              : (selection.modelId ?? effectiveModel?.id),
             thinkingEffort: selection.thinkingEffort ?? undefined,
           }),
       runtimeSettings: submitRuntimeSettings,
     }
 
     return Promise.resolve()
-      .then(() => sendTarget(trimmedText, files, contextParts, submitOptions))
+      .then(async () =>
+        sendTarget(
+          trimmedText,
+          usesLightOcr ? await prepareLightOcrAttachments(files) : files,
+          contextParts,
+          submitOptions,
+        ))
       .then(() => true)
       .finally(() => {
         setSending(false)
@@ -400,28 +442,37 @@ function DraftChatComposerContent({
     return handleSendWithTarget(onSend, text, files, contextParts)
   }
 
-  const handleSendInNewWindow = (text: string, files: FileUIPart[], contextParts: ChatContextPart[]) => {
+  const handleSendInNewWindow = (
+    text: string,
+    files: FileUIPart[],
+    contextParts: ChatContextPart[],
+  ) => {
     return onSendInNewWindow
       ? handleSendWithTarget(onSendInNewWindow, text, files, contextParts)
       : handleSend(text, files, contextParts)
   }
 
-  const handleSendIsolated = (text: string, files: FileUIPart[], contextParts: ChatContextPart[]) => {
+  const handleSendIsolated = (
+    text: string,
+    files: FileUIPart[],
+    contextParts: ChatContextPart[],
+  ) => {
     return onSendIsolated
       ? handleSendWithTarget(onSendIsolated, text, files, contextParts)
       : handleSend(text, files, contextParts)
   }
 
-  const sendVariants = onSendIsolated && workspaceId
-    ? [
-      {
-        id: 'worktree',
-        label: t('send.inWorktree'),
-        icon: <ShieldIcon className="size-3.5" aria-hidden />,
-        submitHandler: handleSendIsolated,
-      },
-    ]
-    : undefined
+  const sendVariants
+    = onSendIsolated && workspaceId
+      ? [
+          {
+            id: 'worktree',
+            label: t('send.inWorktree'),
+            icon: <ShieldIcon className="size-3.5" aria-hidden />,
+            submitHandler: handleSendIsolated,
+          },
+        ]
+      : undefined
 
   const handleSlashCommandAction = async (
     command: ChatComposerSlashCommand,
@@ -459,7 +510,7 @@ function DraftChatComposerContent({
       await appshotRuntime.capture({ tools })
       return { insertText: '' }
     }
-    catch (error) {
+ catch (error) {
       toastManager.add({
         type: 'error',
         title: 'Appshot capture failed',
@@ -472,7 +523,10 @@ function DraftChatComposerContent({
     void handleSend(prompt, [], [])
   }
 
-  const resolveCodexReviewMergeBase = async (baseBranch: string, repositoryPath?: string | null) => {
+  const resolveCodexReviewMergeBase = async (
+    baseBranch: string,
+    repositoryPath?: string | null,
+  ) => {
     if (!workspaceId) {
       return null
     }
@@ -489,21 +543,17 @@ function DraftChatComposerContent({
     return result.data.mergeBaseSha
   }
 
-  const reviewSlot = ({
+  const reviewSlot = {
     open: reviewModeOpen,
     workspaceId,
     onDismiss: () => setReviewModeOpen(false),
     onSubmitPrompt: submitCodexReviewPrompt,
     resolveMergeBase: resolveCodexReviewMergeBase,
-  })
+  }
 
   return (
     <>
-      <ComposerSlotStates
-        slots={[]}
-        states={[]}
-        review={reviewSlot}
-      />
+      <ComposerSlotStates slots={[]} states={[]} review={reviewSlot} />
       <Composer
         send={{
           submit: handleSend,
@@ -520,6 +570,7 @@ function DraftChatComposerContent({
         }}
         attachments={{
           supportsAttachments,
+          usesLightOcr,
           appendFileParts: appshotRuntime.externalFileParts,
           appendFilePartsKey: appshotRuntime.externalFilePartsKey,
           pendingAppshots: appshotRuntime.pendingAppshots,
@@ -556,7 +607,8 @@ function DraftChatComposerContent({
             'focus-within:border-ring/50 focus-within:shadow-[var(--shadow-xs)]',
           ),
           textareaRows: 5,
-          textareaClassName: 'px-5 pt-5 pb-3 text-[15px] leading-[1.75] placeholder:text-muted-foreground/30 min-h-30 max-h-80 rounded-t-2xl disabled:opacity-30',
+          textareaClassName:
+            'px-5 pt-5 pb-3 text-[15px] leading-[1.75] placeholder:text-muted-foreground/30 min-h-30 max-h-80 rounded-t-2xl disabled:opacity-30',
           attachmentListClassName: 'border-border/60 px-3 py-2',
           actionBarClassName: cn(
             'px-2.5 py-2',
@@ -579,18 +631,18 @@ function DraftChatComposerContent({
         }}
       />
       {remoteConnectionBlocked
-        ? (
-            <div className="mt-2">
-              <RemoteHostConnectionNotice gate={remoteConnection.gate} />
-            </div>
-          )
-        : (
-            <DraftChatReadinessNotice
-              notice={readinessNotice}
-              onAction={openSettingsSection}
-              testIdPrefix={testIdPrefix}
-            />
-          )}
+? (
+        <div className="mt-2">
+          <RemoteHostConnectionNotice gate={remoteConnection.gate} />
+        </div>
+      )
+: (
+        <DraftChatReadinessNotice
+          notice={readinessNotice}
+          onAction={openSettingsSection}
+          testIdPrefix={testIdPrefix}
+        />
+      )}
     </>
   )
 }

--- a/apps/web/src/features/chat/composer/light-ocr.ts
+++ b/apps/web/src/features/chat/composer/light-ocr.ts
@@ -1,0 +1,87 @@
+import type { FileUIPart } from 'ai'
+
+import { getServerUrl } from '~/lib/electron'
+import { cradleFetch } from '~/lib/server-credential'
+
+interface LightOcrResponse {
+  items: Array<{
+    index: number
+    text: string
+    lineCount: number
+    modelBundleId: string
+  }>
+}
+
+interface LightOcrErrorResponse {
+  message?: string
+}
+
+type LightOcrFilePart = FileUIPart & {
+  providerMetadata?: Record<string, unknown>
+}
+
+function isImageAttachment(file: FileUIPart): boolean {
+  return file.mediaType.startsWith('image/')
+}
+
+function withLightOcrMetadata(
+  file: FileUIPart,
+  item: LightOcrResponse['items'][number],
+): FileUIPart {
+  const metadata = (file as LightOcrFilePart).providerMetadata ?? {}
+  const cradle = typeof metadata.cradle === 'object' && metadata.cradle !== null
+    ? (metadata.cradle as Record<string, unknown>)
+    : {}
+  return {
+    ...file,
+    providerMetadata: {
+      ...metadata,
+      cradle: {
+        ...cradle,
+        lightOcr: {
+          version: 1,
+          text: item.text,
+          lineCount: item.lineCount,
+          modelBundleId: item.modelBundleId,
+        },
+      },
+    },
+  }
+}
+
+export async function prepareLightOcrAttachments(files: FileUIPart[]): Promise<FileUIPart[]> {
+  const images = files.filter(isImageAttachment)
+  if (images.length === 0) {
+    return files
+  }
+
+  const response = await cradleFetch(new URL('/image-ocr/recognize', getServerUrl()), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ files: images }),
+  })
+  const payload = (await response.json().catch(() => null)) as
+    | LightOcrResponse
+    | LightOcrErrorResponse
+    | null
+  if (!response.ok || !payload || !('items' in payload)) {
+    const detail
+      = payload && 'message' in payload && typeof payload.message === 'string'
+        ? payload.message
+        : `Local image text recognition failed (${response.status}).`
+    throw new Error(detail)
+  }
+
+  const itemsByIndex = new Map(payload.items.map(item => [item.index, item]))
+  let imageIndex = 0
+  return files.map((file) => {
+    if (!isImageAttachment(file)) {
+      return file
+    }
+    const item = itemsByIndex.get(imageIndex++)
+    if (!item) {
+      throw new Error('Local image text recognition returned an incomplete result.')
+    }
+    return withLightOcrMetadata(file, item)
+  })
+}

--- a/apps/web/src/features/chat/composer/use-chat-composer-runtime.ts
+++ b/apps/web/src/features/chat/composer/use-chat-composer-runtime.ts
@@ -24,9 +24,7 @@ import type { ChatContextPart } from '../context/chat-context-parts'
 import { readRunRuntimeSettingsPatch } from '../runtime/runtime-settings-presenter'
 import type { SendMessageOptions, SendMessageResult } from '../session/use-chat-session'
 import { useSessionBinding } from '../session/use-session-binding'
-import type {
-  ChatComposerSlashCommand,
-} from '../slash-commands/chat-slash-commands'
+import type { ChatComposerSlashCommand } from '../slash-commands/chat-slash-commands'
 import {
   CRADLE_APPSHOT_SLASH_COMMAND,
   CRADLE_SIDE_CHAT_SLASH_COMMAND,
@@ -35,7 +33,8 @@ import {
   RUNTIME_USAGE_COMMAND_ACTION_ID,
   withSlashCommandAvailability,
 } from '../slash-commands/chat-slash-commands'
-import { modelSupportsAttachments } from './composer-attachment-state'
+import { modelSupportsAttachments, modelSupportsImageInput } from './composer-attachment-state'
+import { prepareLightOcrAttachments } from './light-ocr'
 
 interface ChatComposerSendOverrides {
   providerTargetId?: string
@@ -60,6 +59,7 @@ export interface ChatComposerRuntime {
   uiSlots: ChatRuntimeUiSlot[]
   slotStates: ChatRuntimeUiSlotState[]
   supportsAttachments: boolean
+  usesLightOcr: boolean
   tokenUsage: null | {
     tokens: number
     contextWindow: number
@@ -148,8 +148,12 @@ export function useChatComposerRuntime({
   const { runtimes } = useRuntimeCatalog()
   const runtimeSteerCapability = useMemo(() => {
     const runtimeKind = runtimeCapabilities?.runtimeKind
-    if (!runtimeKind) { return 'queue-fallback' }
-    return runtimes.find(r => r.runtimeKind === runtimeKind)?.capabilities?.steer ?? 'queue-fallback'
+    if (!runtimeKind) {
+      return 'queue-fallback'
+    }
+    return (
+      runtimes.find(r => r.runtimeKind === runtimeKind)?.capabilities?.steer ?? 'queue-fallback'
+    )
   }, [runtimeCapabilities?.runtimeKind, runtimes])
 
   const { data: runtimeUiSlotStates } = useQuery({
@@ -158,7 +162,9 @@ export function useChatComposerRuntime({
     enabled: sessionQueriesEnabled,
     staleTime: 2_000,
     refetchInterval: query =>
-      active && (isStreaming || shouldPollRuntimeSlotStates(query.state.data?.states ?? [])) ? 5_000 : false,
+      active && (isStreaming || shouldPollRuntimeSlotStates(query.state.data?.states ?? []))
+        ? 5_000
+        : false,
     retry: false,
   })
   const sessionBinding = useSessionBinding(sessionId, sessionQueriesEnabled)
@@ -171,14 +177,18 @@ export function useChatComposerRuntime({
   })
   const sessionModels = providerSessionModels
   const hasRuntimeCodeReviewSlot = useMemo(() => {
-    return Boolean(runtimeCapabilities?.uiSlots.some((slot) => {
-      return (
-        slot.commandAction?.kind === 'uiAction'
-        && slot.commandAction.actionId === RUNTIME_CODE_REVIEW_COMMAND_ACTION_ID
-      )
-    }))
+    return Boolean(
+      runtimeCapabilities?.uiSlots.some((slot) => {
+        return (
+          slot.commandAction?.kind === 'uiAction'
+          && slot.commandAction.actionId === RUNTIME_CODE_REVIEW_COMMAND_ACTION_ID
+        )
+      }),
+    )
   }, [runtimeCapabilities?.uiSlots])
-  const gitRepositoriesQuery = useGitRepositories(active && hasRuntimeCodeReviewSlot ? workspaceId : null)
+  const gitRepositoriesQuery = useGitRepositories(
+    active && hasRuntimeCodeReviewSlot ? workspaceId : null,
+  )
   const currentSessionModel = useMemo(() => {
     if (composerModel) {
       return composerModel
@@ -188,9 +198,13 @@ export function useChatComposerRuntime({
     }
     return sessionModels.find(candidate => candidate.id === sessionBinding.modelId) ?? null
   }, [composerModel, sessionBinding?.modelId, sessionModels])
+  const usesLightOcr = useMemo(
+    () => !modelSupportsImageInput(currentSessionModel),
+    [currentSessionModel],
+  )
   const supportsAttachments = useMemo(() => {
-    return modelSupportsAttachments(currentSessionModel)
-  }, [currentSessionModel])
+    return modelSupportsAttachments(currentSessionModel) || usesLightOcr
+  }, [currentSessionModel, usesLightOcr])
   const cradleSlashCommands = useMemo(() => {
     const appshotCommand = (() => {
       if (!isElectron || platform !== 'darwin') {
@@ -221,7 +235,8 @@ export function useChatComposerRuntime({
           readRuntimeCodeReviewAvailability({
             workspaceId,
             gitStatusLoading: gitRepositoriesQuery.isLoading,
-            gitStatusUnavailable: gitRepositoriesQuery.isError
+            gitStatusUnavailable:
+              gitRepositoriesQuery.isError
               || (gitRepositoriesQuery.isSuccess && (gitRepositoriesQuery.data?.length ?? 0) !== 1),
           }),
         )
@@ -287,7 +302,7 @@ export function useChatComposerRuntime({
   const slotStates = runtimeUiSlotStates?.states ?? EMPTY_RUNTIME_UI_SLOT_STATES
 
   const send = useCallback(
-    (
+    async (
       text: string,
       files: FileUIPart[],
       contextParts: ChatContextPart[],
@@ -307,7 +322,8 @@ export function useChatComposerRuntime({
         : defaultContinuationMode
       // Runtimes that lack native steer always queue — skip the round-trip.
       const continuationMode = runtimeSteerCapability === 'native' ? effectiveMode : 'queue'
-      return sendMessage(
+      const preparedFiles = usesLightOcr ? await prepareLightOcrAttachments(files) : files
+      return await sendMessage(
         text,
         {
           ...overrides,
@@ -316,11 +332,18 @@ export function useChatComposerRuntime({
             ? { runtimeSettings: readRunRuntimeSettingsPatch(options.runtimeSettings) }
             : {}),
         },
-        files,
+        preparedFiles,
         contextParts,
       )
     },
-    [chatPreferences?.continuationBehavior, isReady, runtimeSteerCapability, sendMessage, sendOverridesRef],
+    [
+      chatPreferences?.continuationBehavior,
+      isReady,
+      runtimeSteerCapability,
+      sendMessage,
+      sendOverridesRef,
+      usesLightOcr,
+    ],
   )
 
   return {
@@ -332,6 +355,7 @@ export function useChatComposerRuntime({
     uiSlots,
     slotStates,
     supportsAttachments,
+    usesLightOcr,
     tokenUsage,
     compactState: compactSlotState,
   }

--- a/apps/web/src/features/chat/ui/chat-composer-section.tsx
+++ b/apps/web/src/features/chat/ui/chat-composer-section.tsx
@@ -436,6 +436,7 @@ export function ChatComposerSection({
           }}
           attachments={{
             supportsAttachments: composerRuntime.supportsAttachments,
+            usesLightOcr: composerRuntime.usesLightOcr,
             appendFileParts: appshotRuntime.externalFileParts,
             appendFilePartsKey: appshotRuntime.externalFilePartsKey,
             pendingAppshots: appshotRuntime.pendingAppshots,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,15 +510,15 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.207
         version: 0.3.207(@anthropic-ai/sdk@0.81.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@arcships/light-ocr':
+        specifier: 0.1.0
+        version: 0.1.0
       '@cradle/chat-runtime-contracts':
         specifier: workspace:*
         version: link:../../packages/chat-runtime-contracts
       '@cradle/db':
         specifier: workspace:*
         version: link:../../packages/db
-      '@cradle/download-center':
-        specifier: workspace:*
-        version: link:../../packages/download-center
       '@cradle/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
@@ -1690,6 +1690,38 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@arcships/light-ocr-darwin-arm64@0.1.0':
+    resolution: {integrity: sha512-JUMGDJtviyFdYMErMlNu+vJDWFKQdskFdunnoRx5N0wvu9ZK/1vC99aPAX5dJxNiVnVB4X/HuEMwS+niID4H0A==}
+    engines: {node: ^22.0.0 || ^24.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@arcships/light-ocr-darwin-x64@0.1.0':
+    resolution: {integrity: sha512-vFQdFPwMXr+KLO+OSOFZBzCDoLtGT8GVBxQmQHkRhcKuE/eZjUwi9cmLgv3ZCHMWWZcv1suzddqmFc5C2fazJA==}
+    engines: {node: ^22.0.0 || ^24.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@arcships/light-ocr-linux-x64-gnu@0.1.0':
+    resolution: {integrity: sha512-pC9UcqoCbS7q8tMR4Zfn3omonWksPLNgwMTQrXMQdNb4leAMaZ6IXapShR7LeocPQbOkWD8C4Q6+MjW7KvtCJg==}
+    engines: {node: ^22.0.0 || ^24.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@arcships/light-ocr-model-ppocrv6-small@0.1.0':
+    resolution: {integrity: sha512-xp4h3P924QtS7RSrx36djTag+vTKmPUh6vL8lEeZar+zjR3rnwKWvQytAEqJo9Y6Z2i5b9K1yb4AcQLbWNb9ow==}
+
+  '@arcships/light-ocr-win32-x64@0.1.0':
+    resolution: {integrity: sha512-vJghMn0FlBJdXvHd5q9RdpXdrYhAhA2p3Dto5rds8oCkqQGyt6mdC/4DNeMtvY/BDGIPB39GEScei+hEf/pkxw==}
+    engines: {node: ^22.0.0 || ^24.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@arcships/light-ocr@0.1.0':
+    resolution: {integrity: sha512-54OUabOUvO2BYDaU5mLsM2f5cYWkvY258MzdOq+9lJHKXo4Aosj6zWyLhTCHZX00Vjz6Ky3mfv0K0TExZU+BaA==}
+    engines: {node: ^22.0.0 || ^24.0.0}
 
   '@asamuzakjp/css-color@5.1.10':
     resolution: {integrity: sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==}
@@ -14397,6 +14429,29 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
+
+  '@arcships/light-ocr-darwin-arm64@0.1.0':
+    optional: true
+
+  '@arcships/light-ocr-darwin-x64@0.1.0':
+    optional: true
+
+  '@arcships/light-ocr-linux-x64-gnu@0.1.0':
+    optional: true
+
+  '@arcships/light-ocr-model-ppocrv6-small@0.1.0': {}
+
+  '@arcships/light-ocr-win32-x64@0.1.0':
+    optional: true
+
+  '@arcships/light-ocr@0.1.0':
+    dependencies:
+      '@arcships/light-ocr-model-ppocrv6-small': 0.1.0
+    optionalDependencies:
+      '@arcships/light-ocr-darwin-arm64': 0.1.0
+      '@arcships/light-ocr-darwin-x64': 0.1.0
+      '@arcships/light-ocr-linux-x64-gnu': 0.1.0
+      '@arcships/light-ocr-win32-x64': 0.1.0
 
   '@asamuzakjp/css-color@5.1.10':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,5 +29,11 @@ minimumReleaseAgeExclude:
   - '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.205'
   - '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.205'
   - '@anthropic-ai/claude-agent-sdk@0.3.205'
+  - '@arcships/light-ocr-darwin-arm64@0.1.0'
+  - '@arcships/light-ocr-darwin-x64@0.1.0'
+  - '@arcships/light-ocr-linux-x64-gnu@0.1.0'
+  - '@arcships/light-ocr-model-ppocrv6-small@0.1.0'
+  - '@arcships/light-ocr-win32-x64@0.1.0'
+  - '@arcships/light-ocr@0.1.0'
 patchedDependencies:
   '@elysiajs/node@1.4.5': patches/@elysiajs__node@1.4.5.patch


### PR DESCRIPTION
## Summary
Integrates @arcships/light-ocr as a local server-owned OCR module. Models with image input retain original attachment handling. Models without image input now expose an image-only attachment path with a consent popover; selected images are OCRed locally and only the recognized text is projected to providers. Original image attachments remain intact in the transcript. The projection covers regular sends, queued runs, steer turns, and side conversations. Desktop runtime packaging now keeps the OCR native binding and model bundle as explicit external dependencies.

## Test plan
Verified: pnpm --filter @cradle/server typecheck (including module-boundary check); pnpm --filter @cradle/server exec vitest run src/modules/chat-runtime/ui-message.test.ts (2 tests passed); changed-file ESLint; git diff --check; real native OCR and service smoke test using a generated HELLO 123 image; pnpm --filter @cradle/server build:desktop-runtime, confirming the deployed runtime contains the Light OCR native binding and PP-OCRv6 model bundle. Web full typecheck remains blocked by missing apps/web/node_modules in this worktree, which produces unrelated dependency-resolution failures.

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)