### PR TITLE
feat(web): kanban delegate checkbox upgraded to Work execution

### DIFF
--- a/apps/server/src/modules/issue-agent/service.ts
+++ b/apps/server/src/modules/issue-agent/service.ts
@@ -10,6 +10,7 @@ import * as ChatRuntime from '../chat-runtime/runtime'
 import * as Issue from '../issue/service'
 import * as Session from '../session/service'
 import * as WorkflowRules from '../workflow-rules/service'
+import * as Work from '../work/service'
 import * as Worktree from '../worktree/service'
 
 // ── types ──
@@ -18,6 +19,7 @@ interface ActiveAgentRun {
   runId: string
   chatSessionId: string | null
   aborted: boolean
+  workId?: string
 }
 
 interface IssueAgentSessionView extends AgentSession {
@@ -214,6 +216,9 @@ function settleTrackedRunCompletion(
       body: 'Completed work on issue',
       signal: 'run.completed',
     })
+    if (tracked.workId) {
+      void prepareWorkAfterCompletion(tracked.workId, agentSessionId)
+    }
     return true
   }
 
@@ -238,6 +243,34 @@ function settleTrackedRunCompletion(
     })
   }
   return true
+}
+
+
+async function prepareWorkAfterCompletion(workId: string, agentSessionId: string): Promise<void> {
+  try {
+    await Work.prepare({
+      id: workId,
+      title: 'Completed issue work',
+      summary: 'Automatically prepared after issue agent completion.',
+      testPlan: 'Reviewed by issue agent.',
+    })
+    AgentInteraction.createActivity({
+      agentSessionId,
+      type: 'response',
+      body: 'Work prepared for review',
+      signal: 'work.prepared',
+    })
+  }
+  catch {
+    // prepare can fail if the checkout is clean with no commits ahead —
+    // that is fine; the Work is still available for manual preparation.
+    AgentInteraction.createActivity({
+      agentSessionId,
+      type: 'thought',
+      body: 'Work auto-prepare skipped (no deliverable changes or already prepared).',
+      signal: 'work.prepare.skipped',
+    })
+  }
 }
 
 function hasQueuedContinuationWork(chatSessionId: string): boolean {
@@ -392,30 +425,45 @@ async function runSession(
       return
     }
 
-    const chatSession = await Session.create({
-      workspaceId: issue.workspaceId,
-      title: `Issue: ${issue.title}`,
-      origin: 'cradle-issue',
-      providerTargetId: session.providerTargetId,
-      modelId: agent.modelId,
-      thinkingEffort: agent.thinkingEffort,
-      agentId: session.agentId,
-      linkedIssueId: issue.id,
-      configJson: JSON.stringify({ permissionMode: 'bypassPermissions' }),
-    })
-
-    AgentInteraction.attachChatSession({ agentSessionId, chatSessionId: chatSession.id })
-    updateActiveRunChatSession(agentSessionId, chatSession.id)
+    let chatSessionId: string
 
     if (options.runInIsolation) {
-      await Worktree.startSessionIsolation({
-        sessionId: chatSession.id,
-        slug: issue.title,
+      const workDetail = await Work.create({
+        workspaceId: issue.workspaceId,
+        title: `Issue: ${issue.title}`,
+        objective: buildIssuePrompt(issue, workflowRules),
+        linkedIssueId: issue.id,
+        providerTargetId: session.providerTargetId,
+        modelId: agent.modelId,
+        thinkingEffort: agent.thinkingEffort,
+        agentId: session.agentId,
+        configJson: JSON.stringify({ permissionMode: 'bypassPermissions' }),
+      })
+      chatSessionId = workDetail.primaryThread.id
+      activeRuns.set(agentSessionId, {
+        ...activeRuns.get(agentSessionId)!,
+        workId: workDetail.work.id,
       })
       if (consumePendingRunAbort(agentSessionId)) {
         return
       }
+    } else {
+      const created = await Session.create({
+        workspaceId: issue.workspaceId,
+        title: `Issue: ${issue.title}`,
+        origin: 'cradle-issue',
+        providerTargetId: session.providerTargetId,
+        modelId: agent.modelId,
+        thinkingEffort: agent.thinkingEffort,
+        agentId: session.agentId,
+        linkedIssueId: issue.id,
+        configJson: JSON.stringify({ permissionMode: 'bypassPermissions' }),
+      })
+      chatSessionId = created.id
     }
+
+    AgentInteraction.attachChatSession({ agentSessionId, chatSessionId })
+    updateActiveRunChatSession(agentSessionId, chatSessionId)
 
     AgentInteraction.updateSessionStatus(agentSessionId, 'active')
     AgentInteraction.createActivity({
@@ -426,7 +474,7 @@ async function runSession(
     })
 
     const run = await ChatRuntime.createRun({
-      sessionId: chatSession.id,
+      sessionId: chatSessionId,
       text: buildIssuePrompt(issue, workflowRules),
     })
     trackedRunId = run.runId
@@ -443,7 +491,7 @@ async function runSession(
 
     activeRuns.set(agentSessionId, {
       runId: run.runId,
-      chatSessionId: chatSession.id,
+      chatSessionId: chatSessionId,
       aborted: false,
     })
 

--- a/apps/web/src/locales/default/session-isolation.ts
+++ b/apps/web/src/locales/default/session-isolation.ts
@@ -43,5 +43,5 @@ export default {
   'newChat.cancel': 'Cancel',
   'newChat.sessionCount': '{{count}} linked sessions',
   'newChat.isolatedAction': 'New isolated chat',
-  'delegate.runInIsolation': 'Run in isolated environment',
+  'delegate.runInIsolation': 'Run as Work (isolated + deliverable)',
 } as const

--- a/apps/web/src/locales/en-US/session-isolation.json
+++ b/apps/web/src/locales/en-US/session-isolation.json
@@ -23,7 +23,7 @@
   "chrome.siblingHint": "Shared environment",
   "chrome.unhealthyBadge": "Isolation issue",
   "chrome.unknownBranch": "unknown branch",
-  "delegate.runInIsolation": "Run in isolated environment",
+  "delegate.runInIsolation": "Run as Work (isolated + deliverable)",
   "missing.abandon": "Abandon and clean up",
   "missing.description": "The git worktree for this session is missing or out of sync. Choose how to recover before continuing.",
   "missing.errorTitle": "Could not recover isolation",

--- a/apps/web/src/locales/es-ES/session-isolation.json
+++ b/apps/web/src/locales/es-ES/session-isolation.json
@@ -23,7 +23,7 @@
   "chrome.siblingHint": "Entorno compartido",
   "chrome.unhealthyBadge": "Problema de aislamiento",
   "chrome.unknownBranch": "rama desconocida",
-  "delegate.runInIsolation": "Ejecutar en entorno aislado",
+  "delegate.runInIsolation": "Ejecutar como Work (aislado + entregable)",
   "missing.abandon": "Abandonar y limpiar",
   "missing.description": "El worktree git de esta sesión falta o no está sincronizado. Elige cómo recuperarte antes de continuar.",
   "missing.errorTitle": "No se pudo recuperar el aislamiento",

--- a/apps/web/src/locales/ja-JP/session-isolation.json
+++ b/apps/web/src/locales/ja-JP/session-isolation.json
@@ -23,7 +23,7 @@
   "chrome.siblingHint": "共有環境",
   "chrome.unhealthyBadge": "隔離の問題",
   "chrome.unknownBranch": "不明なブランチ",
-  "delegate.runInIsolation": "隔離環境で実行",
+  "delegate.runInIsolation": "Work として実行（隔離 + 交付）",
   "missing.abandon": "放棄してクリーンアップ",
   "missing.description": "このセッションの git ワークツリーが見つからないか、同期されていません。続行する前に回復方法を選択してください。",
   "missing.errorTitle": "隔離を回復できませんでした",

--- a/apps/web/src/locales/zh-CN/session-isolation.json
+++ b/apps/web/src/locales/zh-CN/session-isolation.json
@@ -39,5 +39,5 @@
   "newChat.cancel": "取消",
   "newChat.sessionCount": "{{count}} 个关联会话",
   "newChat.isolatedAction": "新建隔离环境",
-  "delegate.runInIsolation": "在隔离环境里运行"
+  "delegate.runInIsolation": "作为 Work 执行（隔离 + 交付）"
 }


### PR DESCRIPTION
## Summary
Upgraded the existing runInIsolation checkbox to create a full Cradle Work instead of bare session isolation. Changes: (1) i18n text updated across 5 locales to Work semantics, (2) backend runSession now routes through Work.create() for managed worktree + Work delivery chain, (3) work_prepare is auto-called after run completion via prepareWorkAfterCompletion().

## Test plan
pnpm --filter @cradle/server typecheck; verify delegate checkbox creates a Work with linkedIssueId; verify non-isolation path still uses plain Session.create(); verify prepareWorkAfterCompletion fires on run.complete and handles missing commits gracefully.

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)