### PR TITLE
feat(web): add maximum-scale to viewport

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -98,7 +98,7 @@
       }
     </style>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <title>Cradle</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
Add maximum-scale=1 to the main Cradle web app viewport meta tag to prevent automatic page zoom beyond 1.

## Test plan
Verified the viewport metadata contains maximum-scale=1 and ran git diff --check.

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)