### PR TITLE
Fix Claude Agent permission mode switching

### DIFF
--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/input-projector.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/input-projector.ts
@@ -212,7 +212,9 @@ export function buildClaudeQueryOptions(input: {
   const queryOptions: Options = {
     abortController: input.abortController,
     cwd: runtimeContext.cwd,
-    permissionMode,
+    // The SDK process must start in bypass mode so a later live switch back to it works reliably.
+    // streamTurn syncs the user's actual mode immediately after creating the query.
+    permissionMode: 'bypassPermissions',
     allowDangerouslySkipPermissions: readClaudeAgentAllowDangerouslySkipPermissions(runtimeSettings),
     maxTurns: config.maxTurns,
     additionalDirectories: uniquePaths([

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.test.ts
@@ -574,6 +574,39 @@ describe.sequential('claudeAgentProvider MCP integration', () => {
     }))
   })
 
+  it('starts restricted SDK modes from bypass permissions before syncing the desired mode', async () => {
+    const activeQuery = createAsyncQuery([
+      {
+        type: 'result',
+        session_id: 'claude-session-default-permissions',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    ])
+    sdkMocks.query.mockReturnValue(activeQuery)
+
+    const provider = new ClaudeAgentProvider({
+      readSecret: () => 'sk-ant-test',
+    })
+    for await (const _chunk of provider.streamTurn({
+      runId: 'run-claude-agent-default-permissions',
+      runtimeSession: createRuntimeSession(),
+      profile: createProfile(),
+      message: createUserMessage('Require approval'),
+      workspaceId: 'workspace-1',
+      providerOptions: {
+        runtimeSettings: { permissionMode: 'default' },
+      },
+    })) {
+      // Drain stream.
+    }
+
+    expect(readQueryOptions(0)).toEqual(expect.objectContaining({
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+    }))
+    expect(activeQuery.setPermissionMode).toHaveBeenCalledWith('default')
+  })
+
   it('passes Volcengine Anthropic credentials through ANTHROPIC_AUTH_TOKEN', async () => {
     sdkMocks.query.mockReturnValue(createAsyncQuery([
       {
@@ -1066,13 +1099,14 @@ describe.sequential('claudeAgentProvider MCP integration', () => {
 
   it('leaves Claude disallowed tools empty and captures ExitPlanMode through Cradle', async () => {
     const requestToolApproval = vi.fn()
-    sdkMocks.query.mockReturnValue(createAsyncQuery([
+    const activeQuery = createAsyncQuery([
       {
         type: 'result',
         session_id: 'claude-session-plan-permission',
         usage: { input_tokens: 1, output_tokens: 1 },
       },
-    ]))
+    ])
+    sdkMocks.query.mockReturnValue(activeQuery)
 
     const provider = new ClaudeAgentProvider({
       readSecret: () => 'sk-ant-test',
@@ -1093,10 +1127,11 @@ describe.sequential('claudeAgentProvider MCP integration', () => {
 
     const options = readQueryOptions(0)
     expect(options).toEqual(expect.objectContaining({
-      permissionMode: 'plan',
+      permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: false,
       systemPrompt: { type: 'preset', preset: 'claude_code' },
     }))
+    expect(activeQuery.setPermissionMode).toHaveBeenCalledWith('plan')
     expect(options.disallowedTools).toEqual([])
     expect(options.disallowedTools).not.toContain('AskUserQuestion')
     expect(options.disallowedTools).not.toContain('EnterPlanMode')
@@ -1129,13 +1164,14 @@ describe.sequential('claudeAgentProvider MCP integration', () => {
   })
 
   it('resumes the provider session in plan mode to preserve prompt cache continuity', async () => {
-    sdkMocks.query.mockReturnValue(createAsyncQuery([
+    const activeQuery = createAsyncQuery([
       {
         type: 'result',
         session_id: 'claude-session-plan-resume',
         usage: { input_tokens: 1, output_tokens: 1 },
       },
-    ]))
+    ])
+    sdkMocks.query.mockReturnValue(activeQuery)
 
     const provider = new ClaudeAgentProvider({
       readSecret: () => 'sk-ant-test',
@@ -1155,9 +1191,10 @@ describe.sequential('claudeAgentProvider MCP integration', () => {
 
     expect(readQueryOptions(0)).toEqual(expect.objectContaining({
       resume: 'claude-session-1',
-      permissionMode: 'plan',
+      permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: false,
     }))
+    expect(activeQuery.setPermissionMode).toHaveBeenCalledWith('plan')
   })
 
   it('routes AskUserQuestion through requestUserInput regardless of plan mode', async () => {
@@ -1451,7 +1488,7 @@ describe.sequential('claudeAgentProvider MCP integration', () => {
       }
 
       expect(readQueryOptions(0)).toEqual(expect.objectContaining({
-        permissionMode: 'plan',
+        permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: false,
       }))
       const originalCanUseTool = readQueryOptions(0).canUseTool as CanUseTool

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.ts
@@ -154,7 +154,6 @@ type ActiveClaudeQuery = {
   closed: boolean
   pumpRunning: boolean
   stderrSink: ClaudeStderrSink
-  allowDangerouslySkipPermissions: boolean
 }
 
 type ActiveClaudeTurn = {
@@ -236,12 +235,6 @@ interface ClaudeSubagentProjectedEntry {
   turn: ProviderThreadTurn
   message: UIMessage
   rawMessages: ClaudeSubagentSessionMessage[]
-}
-
-function readActiveClaudeQueryPermissionMode(
-  permissionMode: ReturnType<typeof buildClaudeQueryOptions>['permissionMode'],
-): Options['permissionMode'] {
-  return permissionMode ?? 'bypassPermissions'
 }
 
 function closeClaudeQuery(activeQuery: Query): void {
@@ -496,19 +489,14 @@ export class ClaudeAgentProvider implements ChatRuntime {
       this.closeSessionQuery(sessionId, activeEntry)
       activeEntry = undefined
     }
-    const planModeActive = readClaudeAgentPermissionMode(input.providerOptions?.runtimeSettings) === 'plan'
-    // Only recreate when the in-memory query was built with skip=true; new options still resume
-    // the same provider session so prompt cache and thread continuity are preserved.
-    if (activeEntry && planModeActive && (activeEntry.allowDangerouslySkipPermissions ?? true)) {
-      this.closeSessionQuery(sessionId, activeEntry)
-      activeEntry = undefined
-    }
     const permissionBridgeState = activeEntry?.permissionBridgeState ?? createClaudeAgentPermissionBridgeState({
       runtimeInput: input,
       permissionMode: 'bypassPermissions',
       runtimeSettings: input.providerOptions?.runtimeSettings,
     })
-    let turnPermissionMode: Options['permissionMode'] = 'bypassPermissions'
+    const turnPermissionMode: Options['permissionMode'] = readClaudeAgentPermissionMode(
+      input.providerOptions?.runtimeSettings,
+    )
     // Reuse the long-lived query's stderr sink when the session already exists;
     // otherwise create one for the new query. The sink must outlive the
     // pump loop so it can enrich the surfaced error when the process exits.
@@ -522,16 +510,15 @@ export class ClaudeAgentProvider implements ChatRuntime {
       emitToolApprovalRequest: request => this.emitClaudeAgentToolApprovalRequest(sessionId, request),
       onStderr: stderrSink.onStderr,
     })
-    turnPermissionMode = readActiveClaudeQueryPermissionMode(queryOptions.permissionMode)
-
     if (!activeEntry) {
       this.activePermissionModesBySession.set(sessionId, turnPermissionMode)
       const inputStream = new ClaudeAgentInputStream()
       const activeQuery = query({ prompt: inputStream, options: queryOptions })
-      if (turnPermissionMode === 'plan') {
-        void activeQuery.setPermissionMode('plan').catch((error) => {
-          this.deps.logger?.warn?.('Claude Agent failed to sync SDK plan permission mode after query start', {
+      if (turnPermissionMode !== 'bypassPermissions') {
+        void activeQuery.setPermissionMode(turnPermissionMode).catch((error) => {
+          this.deps.logger?.warn?.('Claude Agent failed to sync SDK permission mode after query start', {
             error,
+            permissionMode: turnPermissionMode,
             sessionId,
             resumed: shouldResumeProviderSession,
           })
@@ -559,7 +546,6 @@ export class ClaudeAgentProvider implements ChatRuntime {
         closed: false,
         pumpRunning: true,
         stderrSink,
-        allowDangerouslySkipPermissions: queryOptions.allowDangerouslySkipPermissions ?? true,
       }
       this.activeQueries.set(sessionId, activeEntry)
       const registeredEntry = activeEntry


### PR DESCRIPTION
## Summary
Create Claude Agent SDK queries in bypassPermissions, immediately sync non-bypass user modes with setPermissionMode, preserve live queries across plan transitions, and update regression coverage.

## Test plan
pnpm --filter @cradle/server exec vitest run src/modules/chat-runtime-providers/claude-agent/provider.test.ts src/modules/chat-runtime-providers/claude-agent/input-projector.test.ts (67 passed); pnpm --filter @cradle/server typecheck; pnpm --filter @cradle/server test (1184 passed).

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)