### PR TITLE
Add VibeLoft Web Telemetry script

### DIFF
--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -27,6 +27,11 @@
 
   <link rel="preload" as="image" href="/icon-192.webp" type="image/webp" fetchpriority="high" />
   <script defer src="https://u.wibus.ren/script.js" data-website-id="6f0186bb-bfa3-419a-9d1c-6ee59cf059be"></script>
+  <script defer
+    src="https://vibeloft.ai/telemetry/v1.js"
+    data-vl-product-id="071a38f6-597f-4bff-9e6f-4f3ebb649cd5"
+    data-vl-auth-key="vl_web.znGritojdyIDn-agGCbutT9JCbXYu-U2FRTv-_87muE"
+  ></script>
   <title>Cradle — AI Development Orchestrator</title>
   <style>
     /* Always dark: the site commits to a dark, shader-backed aesthetic. */


### PR DESCRIPTION
## Summary
Added the official VibeLoft Web Telemetry script to apps/landing/index.html <head>. No CSP changes needed (none exists in codebase). Auth key and product ID embedded per spec.

## Test plan
Deploy to production, open https://cradle.wibus.ren/, browse a page. Then check VibeLoft boarding-pass Deployment Verification tab for first valid event time.