### PR TITLE
perf: unify Cradle diff rendering surfaces

### DIFF
--- a/apps/web/src/components/common/README.md
+++ b/apps/web/src/components/common/README.md
@@ -14,4 +14,5 @@
 
 - **app-error-boundary.tsx**: App-wide React error boundary with a restrained fallback for renderer crashes; it logs caught render errors, allows history back, local retry, and full reload actions, and only shows stack details in development.
 - **beta-notice.tsx**: Shared app-level Beta/unstable feature notice. It owns the restrained warning treatment while callers provide feature-specific localized title and description copy.
+- **diff/**: Shared Cradle diff-rendering module. It owns Pierre worker/highlighter setup, patch parsing and path indexing, standard rendering options, layout controls, read-only patch rendering, and before/after content rendering. Feature modules retain data fetching and domain interactions such as review threads.
 - **workspace-file-icon.tsx**: Shared workspace file icon renderer backed by the `@pierre/trees` built-in complete icon resolver and sprite sheet, reused by file mentions and Git change rows.

--- a/apps/web/src/components/common/diff/diff-constants.ts
+++ b/apps/web/src/components/common/diff/diff-constants.ts
@@ -1,0 +1,2 @@
+export const DIFF_THEME = { dark: 'pierre-dark', light: 'pierre-light' } as const
+export const DIFF_LINE_HEIGHT = 18

--- a/apps/web/src/components/common/diff/diff-data.test.ts
+++ b/apps/web/src/components/common/diff/diff-data.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildDiffData, diffContentCacheKey } from './diff-data'
+
+describe('shared diff data', () => {
+  it('indexes current and previous paths for renamed files', () => {
+    const data = buildDiffData([
+      'diff --git a/src/old.ts b/src/new.ts',
+      'similarity index 75%',
+      'rename from src/old.ts',
+      'rename to src/new.ts',
+      '--- a/src/old.ts',
+      '+++ b/src/new.ts',
+      '@@ -1 +1 @@',
+      '-export const value = 1',
+      '+export const value = 2',
+    ].join('\n'))
+
+    expect(data.items).toHaveLength(1)
+    const itemId = data.items[0]?.id
+    expect(itemId).toBeDefined()
+    expect(data.pathToItemId.get('src/old.ts')).toBe(itemId)
+    expect(data.pathToItemId.get('src/new.ts')).toBe(itemId)
+    expect(data.itemIdToPath.get(itemId!)).toBe('src/new.ts')
+  })
+
+  it('marks whitespace-only changes once for both rename paths', () => {
+    const data = buildDiffData([
+      'diff --git a/src/old.ts b/src/new.ts',
+      'similarity index 75%',
+      'rename from src/old.ts',
+      'rename to src/new.ts',
+      '--- a/src/old.ts',
+      '+++ b/src/new.ts',
+      '@@ -1 +1 @@',
+      '-const value = 1',
+      '+const   value = 1',
+    ].join('\n'))
+
+    expect(data.whitespaceOnlyPaths).toEqual(new Set(['src/new.ts', 'src/old.ts']))
+  })
+
+  it('uses the complete content when creating cache keys', () => {
+    const prefix = 'same-prefix-and-suffix'.repeat(4)
+    const suffix = 'same-suffix'.repeat(8)
+    const first = `${prefix}first middle${suffix}`
+    const second = `${prefix}other middle${suffix}`
+    const firstKey = diffContentCacheKey('old', 'src/file.ts', first)
+    const secondKey = diffContentCacheKey('old', 'src/file.ts', second)
+
+    expect(firstKey).not.toBe(secondKey)
+  })
+})

--- a/apps/web/src/components/common/diff/diff-data.ts
+++ b/apps/web/src/components/common/diff/diff-data.ts
@@ -1,0 +1,105 @@
+import type { CodeViewItem } from '@pierre/diffs'
+import { parsePatchFiles } from '@pierre/diffs'
+
+export interface DiffData<TAnnotation = undefined> {
+  items: CodeViewItem<TAnnotation>[]
+  itemIdToPath: Map<string, string>
+  pathToItemId: Map<string, string>
+  whitespaceOnlyPaths: Set<string>
+}
+
+function hashText(value: string): number {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+function createItemId(
+  path: string,
+  itemIds: Set<string>,
+  nextCollisionSuffixByBase: Map<string, number>,
+): string {
+  if (!itemIds.has(path)) {
+    return path
+  }
+
+  let suffix = nextCollisionSuffixByBase.get(path) ?? 2
+  let itemId = `${path}?${suffix}`
+  while (itemIds.has(itemId)) {
+    suffix++
+    itemId = `${path}?${suffix}`
+  }
+  nextCollisionSuffixByBase.set(path, suffix + 1)
+  return itemId
+}
+
+function normalizeWhitespace(line: string): string {
+  return line.replace(/\s+/g, '')
+}
+
+function isWhitespaceOnlyFileDiff(
+  fileDiff: Extract<CodeViewItem, { type: 'diff' }>['fileDiff'],
+): boolean {
+  if (fileDiff.type === 'rename-pure') {
+    return false
+  }
+  const oldContent = fileDiff.deletionLines.map(normalizeWhitespace).join('\n')
+  const newContent = fileDiff.additionLines.map(normalizeWhitespace).join('\n')
+  return oldContent === newContent
+}
+
+export function buildDiffData<TAnnotation = undefined>(patch: string): DiffData<TAnnotation> {
+  if (patch.trim().length === 0) {
+    return emptyDiffData<TAnnotation>()
+  }
+
+  const patchVersion = hashText(patch)
+  const parsed = parsePatchFiles(
+    patch,
+    `cradle-diff-${patch.length.toString(36)}-${patchVersion.toString(36)}`,
+  )
+  const items: CodeViewItem<TAnnotation>[] = []
+  const itemIdToPath = new Map<string, string>()
+  const pathToItemId = new Map<string, string>()
+  const whitespaceOnlyPaths = new Set<string>()
+  const itemIds = new Set<string>()
+  const nextCollisionSuffixByBase = new Map<string, number>()
+
+  for (const parsedPatch of parsed) {
+    for (const fileDiff of parsedPatch.files) {
+      const itemId = createItemId(fileDiff.name, itemIds, nextCollisionSuffixByBase)
+      const whitespaceOnly = isWhitespaceOnlyFileDiff(fileDiff)
+      itemIds.add(itemId)
+      items.push({ id: itemId, type: 'diff', fileDiff, version: patchVersion })
+      itemIdToPath.set(itemId, fileDiff.name)
+      pathToItemId.set(fileDiff.name, itemId)
+      if (whitespaceOnly) {
+        whitespaceOnlyPaths.add(fileDiff.name)
+      }
+      if (fileDiff.prevName) {
+        pathToItemId.set(fileDiff.prevName, itemId)
+        if (whitespaceOnly) {
+          whitespaceOnlyPaths.add(fileDiff.prevName)
+        }
+      }
+    }
+  }
+
+  return { items, itemIdToPath, pathToItemId, whitespaceOnlyPaths }
+}
+
+export function emptyDiffData<TAnnotation = undefined>(): DiffData<TAnnotation> {
+  return {
+    items: [],
+    itemIdToPath: new Map(),
+    pathToItemId: new Map(),
+    whitespaceOnlyPaths: new Set(),
+  }
+}
+
+export function diffContentCacheKey(prefix: string, path: string, content: string): string {
+  return `${prefix}:${path}:${content.length.toString(36)}:${hashText(content).toString(36)}`
+}

--- a/apps/web/src/components/common/diff/diff-layout-toggle.tsx
+++ b/apps/web/src/components/common/diff/diff-layout-toggle.tsx
@@ -1,0 +1,49 @@
+import {
+  Columns2Line as Columns2Icon,
+  Rows3Line as Rows3Icon,
+} from '@mingcute/react'
+
+import { ToggleGroup, ToggleGroupItem } from '~/components/ui/toggle-group'
+import { cn } from '~/lib/cn'
+
+import type { DiffStyle } from './diff-options'
+
+interface DiffLayoutToggleProps {
+  value: DiffStyle
+  onValueChange: (value: DiffStyle) => void
+  disabled?: boolean
+  className?: string
+}
+
+export function DiffLayoutToggle({
+  value,
+  onValueChange,
+  disabled = false,
+  className,
+}: DiffLayoutToggleProps) {
+  return (
+    <ToggleGroup
+      type="single"
+      value={value}
+      onValueChange={(nextValue) => {
+        if (nextValue === 'split' || nextValue === 'unified') {
+          onValueChange(nextValue)
+        }
+      }}
+      variant="outline"
+      size="sm"
+      className={cn('h-5 shrink-0 gap-px', className)}
+      aria-label="Diff layout"
+      disabled={disabled}
+    >
+      <ToggleGroupItem value="split" aria-label="Split" className="h-5 gap-1 px-1.5 text-[10px]">
+        <Columns2Icon className="size-2.5" />
+        Split
+      </ToggleGroupItem>
+      <ToggleGroupItem value="unified" aria-label="Unified" className="h-5 gap-1 px-1.5 text-[10px]">
+        <Rows3Icon className="size-2.5" />
+        Unified
+      </ToggleGroupItem>
+    </ToggleGroup>
+  )
+}

--- a/apps/web/src/components/common/diff/diff-options.ts
+++ b/apps/web/src/components/common/diff/diff-options.ts
@@ -1,0 +1,37 @@
+import type { CodeViewOptions } from '@pierre/diffs'
+
+import { DIFF_LINE_HEIGHT, DIFF_THEME } from './diff-constants'
+
+export type DiffStyle = 'split' | 'unified'
+
+interface DiffInteractionOptions<TAnnotation> {
+  controlledSelection?: boolean
+  enableGutterUtility?: boolean
+  enableLineSelection?: boolean
+  onGutterUtilityClick?: CodeViewOptions<TAnnotation>['onGutterUtilityClick']
+}
+
+export function buildDiffOptions<TAnnotation = undefined>(
+  diffStyle: DiffStyle,
+  interaction: DiffInteractionOptions<TAnnotation> = {},
+): CodeViewOptions<TAnnotation> {
+  return {
+    theme: DIFF_THEME,
+    themeType: 'system',
+    diffStyle,
+    diffIndicators: 'bars',
+    overflow: 'scroll',
+    lineDiffType: 'word',
+    hunkSeparators: 'line-info-basic',
+    enableLineSelection: interaction.enableLineSelection,
+    controlledSelection: interaction.controlledSelection,
+    enableGutterUtility: interaction.enableGutterUtility,
+    onGutterUtilityClick: interaction.onGutterUtilityClick,
+    stickyHeaders: true,
+    pointerEventsOnScroll: false,
+    itemMetrics: {
+      hunkLineCount: 1,
+      lineHeight: DIFF_LINE_HEIGHT,
+    },
+  }
+}

--- a/apps/web/src/components/common/diff/diff-runtime.tsx
+++ b/apps/web/src/components/common/diff/diff-runtime.tsx
@@ -1,0 +1,28 @@
+import type { WorkerInitializationRenderOptions, WorkerPoolOptions } from '@pierre/diffs/react'
+import { WorkerPoolContextProvider } from '@pierre/diffs/react'
+import WorkerUrl from '@pierre/diffs/worker/worker.js?worker&url'
+import type { ReactNode } from 'react'
+
+import { DIFF_THEME } from './diff-constants'
+
+const WORKER_POOL_OPTIONS = {
+  workerFactory: () => new Worker(WorkerUrl, { type: 'module' }),
+  poolSize: 3,
+} satisfies WorkerPoolOptions
+
+const WORKER_HIGHLIGHTER_OPTIONS = {
+  lineDiffType: 'word',
+  theme: DIFF_THEME,
+  useTokenTransformer: false,
+} satisfies WorkerInitializationRenderOptions
+
+export function DiffWorkerProvider({ children }: { children: ReactNode }) {
+  return (
+    <WorkerPoolContextProvider
+      poolOptions={WORKER_POOL_OPTIONS}
+      highlighterOptions={WORKER_HIGHLIGHTER_OPTIONS}
+    >
+      {children}
+    </WorkerPoolContextProvider>
+  )
+}

--- a/apps/web/src/components/common/diff/file-contents-diff-view.tsx
+++ b/apps/web/src/components/common/diff/file-contents-diff-view.tsx
@@ -1,0 +1,64 @@
+import type { FileContents, MultiFileDiffProps } from '@pierre/diffs/react'
+import { MultiFileDiff } from '@pierre/diffs/react'
+import { useMemo } from 'react'
+
+import { cn } from '~/lib/cn'
+
+import { DIFF_THEME } from './diff-constants'
+import { diffContentCacheKey } from './diff-data'
+import type { DiffStyle } from './diff-options'
+
+type DiffOptions = NonNullable<MultiFileDiffProps<undefined>['options']>
+
+interface FileContentsDiffViewProps {
+  filePath: string
+  oldContent: string
+  newContent: string
+  diffStyle: DiffStyle
+  className?: string
+  showFileHeader?: boolean
+}
+
+export function FileContentsDiffView({
+  filePath,
+  oldContent,
+  newContent,
+  diffStyle,
+  className,
+  showFileHeader = false,
+}: FileContentsDiffViewProps) {
+  const oldFile = useMemo<FileContents>(() => ({
+    name: filePath,
+    contents: oldContent,
+    cacheKey: diffContentCacheKey('old', filePath, oldContent),
+  }), [filePath, oldContent])
+  const newFile = useMemo<FileContents>(() => ({
+    name: filePath,
+    contents: newContent,
+    cacheKey: diffContentCacheKey('new', filePath, newContent),
+  }), [filePath, newContent])
+  const options = useMemo<DiffOptions>(() => ({
+    theme: DIFF_THEME,
+    themeType: 'system',
+    diffStyle,
+    disableFileHeader: !showFileHeader,
+    disableBackground: false,
+    diffIndicators: 'bars',
+    hunkSeparators: 'line-info-basic',
+    lineDiffType: 'word',
+    overflow: 'scroll',
+    parseDiffOptions: { context: 3 },
+  }), [diffStyle, showFileHeader])
+
+  return (
+    <MultiFileDiff
+      oldFile={oldFile}
+      newFile={newFile}
+      options={options}
+      className={cn(
+        'max-h-128 overflow-auto [--diffs-font-size:11px] [--diffs-line-height:18px]',
+        className,
+      )}
+    />
+  )
+}

--- a/apps/web/src/components/common/diff/patch-diff-view.tsx
+++ b/apps/web/src/components/common/diff/patch-diff-view.tsx
@@ -1,0 +1,63 @@
+import type { CodeViewHandle } from '@pierre/diffs/react'
+import { CodeView, useStableCallback } from '@pierre/diffs/react'
+import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react'
+
+import { cn } from '~/lib/cn'
+
+import type { DiffData } from './diff-data'
+import type { DiffStyle } from './diff-options'
+import { buildDiffOptions } from './diff-options'
+
+export interface PatchDiffViewHandle {
+  scrollToPath: (path: string) => boolean
+}
+
+interface PatchDiffViewProps {
+  data: DiffData
+  diffStyle: DiffStyle
+  className?: string
+  enableLineSelection?: boolean
+}
+
+export const PatchDiffView = forwardRef<PatchDiffViewHandle, PatchDiffViewProps>(
+  ({ data, diffStyle, className, enableLineSelection = false }, ref) => {
+    const viewerRef = useRef<CodeViewHandle<undefined>>(null)
+    const options = useMemo(
+      () => buildDiffOptions(diffStyle, { enableLineSelection }),
+      [diffStyle, enableLineSelection],
+    )
+
+    const scrollToPath = useStableCallback((path: string): boolean => {
+      const viewer = viewerRef.current
+      const itemId = data.pathToItemId.get(path)
+      if (!viewer || !itemId) {
+        return false
+      }
+      const item = viewer.getItem(itemId)
+      if (item?.collapsed === true) {
+        viewer.updateItem({
+          ...item,
+          collapsed: false,
+          version: typeof item.version === 'number' ? item.version + 1 : 1,
+        })
+      }
+      viewer.scrollTo({ type: 'item', id: itemId, align: 'start', behavior: 'smooth' })
+      return true
+    })
+
+    useImperativeHandle(ref, () => ({ scrollToPath }), [scrollToPath])
+
+    return (
+      <CodeView
+        ref={viewerRef}
+        items={data.items}
+        options={options}
+        className={cn(
+          'min-h-0 overflow-auto overscroll-contain [overflow-anchor:none]',
+          '[--diffs-font-size:11px] [--diffs-line-height:18px]',
+          className,
+        )}
+      />
+    )
+  },
+)

--- a/apps/web/src/features/browser/workspace-diff-viewer.tsx
+++ b/apps/web/src/features/browser/workspace-diff-viewer.tsx
@@ -1,32 +1,20 @@
 // Renders workspace Git patches with Pierre's virtualized diff viewer.
 import {
-  Columns2Line as Columns2Icon,
   GitCompareLine as FileDiffIcon,
-  Rows3Line as Rows3Icon,
 } from '@mingcute/react'
-import type { CodeViewItem, CodeViewOptions } from '@pierre/diffs'
-import { parsePatchFiles } from '@pierre/diffs'
-import type {
-  CodeViewHandle,
-  WorkerInitializationRenderOptions,
-  WorkerPoolOptions,
-} from '@pierre/diffs/react'
-import {
-  CodeView,
-  useStableCallback,
-  WorkerPoolContextProvider,
-} from '@pierre/diffs/react'
-import WorkerUrl from '@pierre/diffs/worker/worker.js?worker&url'
-import { useDeferredValue, useEffect, useRef, useState, useTransition } from 'react'
+import { useStableCallback } from '@pierre/diffs/react'
+import { useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 
+import { buildDiffData } from '~/components/common/diff/diff-data'
+import { DiffLayoutToggle } from '~/components/common/diff/diff-layout-toggle'
+import type { DiffStyle } from '~/components/common/diff/diff-options'
+import { DiffWorkerProvider } from '~/components/common/diff/diff-runtime'
+import type { PatchDiffViewHandle } from '~/components/common/diff/patch-diff-view'
+import { PatchDiffView } from '~/components/common/diff/patch-diff-view'
 import { Spinner } from '~/components/ui/spinner'
-import { ToggleGroup, ToggleGroupItem } from '~/components/ui/toggle-group'
-import { cn } from '~/lib/cn'
 import { DEFAULT_BROWSER_PANEL_OWNER_ID, useBrowserPanelStore } from '~/store/browser-panel'
 
 import { useGitDiff } from '../git/use-git'
-
-type DiffStyle = 'split' | 'unified'
 
 interface WorkspaceDiffViewerProps {
   ownerId?: string | null
@@ -36,84 +24,11 @@ interface WorkspaceDiffViewerProps {
   paths?: string[]
 }
 
-interface WorkspaceDiffData {
-  items: CodeViewItem[]
-  pathToItemId: Map<string, string>
-}
-
-const DIFF_LINE_HEIGHT = 18
-
-const WORKER_POOL_OPTIONS = {
-  workerFactory: () => new Worker(WorkerUrl, { type: 'module' }),
-  poolSize: 3,
-} satisfies WorkerPoolOptions
-
-const WORKER_HIGHLIGHTER_OPTIONS = {
-  lineDiffType: 'word',
-  theme: { dark: 'pierre-dark', light: 'pierre-light' },
-  useTokenTransformer: false,
-} satisfies WorkerInitializationRenderOptions
-
-function buildItemsFromPatch(patch: string): WorkspaceDiffData {
-  const patchVersion = hashPatchVersion(patch)
-  const parsed = parsePatchFiles(
-    patch,
-    `workspace-diff-${patch.length.toString(36)}-${patchVersion.toString(36)}`,
-  )
-  const items: CodeViewItem[] = []
-  const pathToItemId = new Map<string, string>()
-  const itemIds = new Set<string>()
-  const nextCollisionSuffixByBase = new Map<string, number>()
-  for (const p of parsed) {
-    for (const fileDiff of p.files) {
-      const itemId = createItemId(fileDiff.name, itemIds, nextCollisionSuffixByBase)
-      itemIds.add(itemId)
-      items.push({ id: itemId, type: 'diff', fileDiff, version: patchVersion })
-      pathToItemId.set(fileDiff.name, itemId)
-      if (fileDiff.prevName) {
-        pathToItemId.set(fileDiff.prevName, itemId)
-      }
-    }
-  }
-  return { items, pathToItemId }
-}
-
-function hashPatchVersion(patch: string): number {
-  let hash = 2166136261
-  for (let index = 0; index < patch.length; index++) {
-    hash ^= patch.charCodeAt(index)
-    hash = Math.imul(hash, 16777619)
-  }
-  return hash >>> 0
-}
-
-function createItemId(
-  path: string,
-  itemIds: Set<string>,
-  nextCollisionSuffixByBase: Map<string, number>,
-): string {
-  if (!itemIds.has(path)) {
-    return path
-  }
-
-  let suffix = nextCollisionSuffixByBase.get(path) ?? 2
-  let itemId = `${path}?${suffix}`
-  while (itemIds.has(itemId)) {
-    suffix++
-    itemId = `${path}?${suffix}`
-  }
-  nextCollisionSuffixByBase.set(path, suffix + 1)
-  return itemId
-}
-
 export function WorkspaceDiffViewer(props: WorkspaceDiffViewerProps) {
   return (
-    <WorkerPoolContextProvider
-      poolOptions={WORKER_POOL_OPTIONS}
-      highlighterOptions={WORKER_HIGHLIGHTER_OPTIONS}
-    >
+    <DiffWorkerProvider>
       <WorkspaceDiffViewerContent {...props} />
-    </WorkerPoolContextProvider>
+    </DiffWorkerProvider>
   )
 }
 
@@ -122,15 +37,10 @@ function WorkspaceDiffViewerContent({ ownerId, tabId, workspaceId, repositoryPat
   const deferredPatch = useDeferredValue(patch)
   const [diffStyle, setDiffStyle] = useState<DiffStyle>('split')
   const [isDiffStylePending, startDiffStyleTransition] = useTransition()
-  const viewerRef = useRef<CodeViewHandle<undefined>>(null)
+  const viewerRef = useRef<PatchDiffViewHandle>(null)
   const pendingScrollRef = useRef<string | null>(null)
 
-  const diffData = ((): WorkspaceDiffData => {
-    if (!deferredPatch || deferredPatch.trim().length === 0) {
-      return { items: [], pathToItemId: new Map() }
-    }
-    return buildItemsFromPatch(deferredPatch)
-  })()
+  const diffData = useMemo(() => buildDiffData(deferredPatch ?? ''), [deferredPatch])
   const { items, pathToItemId } = diffData
 
   // Listen for scroll-to-file requests from the Changes Panel
@@ -139,24 +49,16 @@ function WorkspaceDiffViewerContent({ ownerId, tabId, workspaceId, repositoryPat
   const clearScrollToFilePath = useBrowserPanelStore(s => s.clearScrollToFilePath)
 
   const scrollToPath = useStableCallback((path: string) => {
-    const viewer = viewerRef.current
-    if (viewer == null || items.length === 0) {
+    if (items.length === 0) {
       pendingScrollRef.current = path
       return
     }
-    const itemId = pathToItemId.get(path)
-    if (!itemId) {
+    if (!pathToItemId.has(path)) {
       return
     }
-    const item = viewer.getItem(itemId)
-    if (item != null && item.collapsed === true) {
-      viewer.updateItem({
-        ...item,
-        collapsed: false,
-        version: typeof item.version === 'number' ? item.version + 1 : 1,
-      })
+    if (!viewerRef.current?.scrollToPath(path)) {
+      pendingScrollRef.current = path
     }
-    viewer.scrollTo({ type: 'item', id: itemId, align: 'start', behavior: 'smooth' })
   })
 
   // Handle scroll requests from the Changes Panel
@@ -177,23 +79,6 @@ function WorkspaceDiffViewerContent({ ownerId, tabId, workspaceId, repositoryPat
     pendingScrollRef.current = null
     scrollToPath(path)
   }, [items, scrollToPath])
-
-  const options: CodeViewOptions<undefined> = ({
-      theme: { dark: 'pierre-dark', light: 'pierre-light' },
-      themeType: 'system',
-      diffStyle,
-      diffIndicators: 'bars',
-      overflow: 'scroll',
-      lineDiffType: 'word',
-      hunkSeparators: 'line-info-basic',
-      enableLineSelection: true,
-      stickyHeaders: true,
-      pointerEventsOnScroll: false,
-      itemMetrics: {
-        hunkLineCount: 1,
-        lineHeight: DIFF_LINE_HEIGHT,
-      },
-    })
 
   if (isLoading) {
     return (
@@ -247,48 +132,22 @@ file
 {items.length !== 1 ? 's' : ''}
         </span>
         <div className="flex-1" />
-        <ToggleGroup
-          type="single"
+        <DiffLayoutToggle
           value={diffStyle}
-          onValueChange={(v) => {
-            if (v === 'split' || v === 'unified') {
-              startDiffStyleTransition(() => {
-                setDiffStyle(v)
-              })
-            }
+          onValueChange={(value) => {
+            startDiffStyleTransition(() => {
+              setDiffStyle(value)
+            })
           }}
-          variant="outline"
-          size="sm"
-          className="h-5 shrink-0 gap-px"
-          aria-label="Diff layout"
           disabled={isDiffStylePending}
-        >
-          <ToggleGroupItem
-            value="split"
-            aria-label="Split"
-            className="h-5 gap-1 px-1.5 text-[10px]"
-          >
-            <Columns2Icon className="size-2.5" />
-            Split
-          </ToggleGroupItem>
-          <ToggleGroupItem
-            value="unified"
-            aria-label="Unified"
-            className="h-5 gap-1 px-1.5 text-[10px]"
-          >
-            <Rows3Icon className="size-2.5" />
-            Unified
-          </ToggleGroupItem>
-        </ToggleGroup>
+        />
       </div>
-      <CodeView
+      <PatchDiffView
         ref={viewerRef}
-        items={items}
-        options={options}
-        className={cn(
-          'min-h-0 flex-1 overflow-auto overscroll-contain [overflow-anchor:none]',
-          '[--diffs-font-size:11px] [--diffs-line-height:18px]',
-        )}
+        data={diffData}
+        diffStyle={diffStyle}
+        enableLineSelection
+        className="flex-1"
       />
     </div>
   )

--- a/apps/web/src/features/chat/rendering/blocks/edit-file-block.tsx
+++ b/apps/web/src/features/chat/rendering/blocks/edit-file-block.tsx
@@ -1,17 +1,15 @@
 import {
-  Columns2Line as Columns2Icon,
   FileLine as FilePenLineIcon,
   RightSmallLine as ChevronRightIcon,
-  Rows3Line as Rows3Icon,
 } from '@mingcute/react'
-import type { FileContents, MultiFileDiffProps } from '@pierre/diffs/react'
-import { MultiFileDiff } from '@pierre/diffs/react'
 import { m } from 'motion/react'
 import { useState } from 'react'
 
+import { DiffLayoutToggle } from '~/components/common/diff/diff-layout-toggle'
+import type { DiffStyle } from '~/components/common/diff/diff-options'
+import { FileContentsDiffView } from '~/components/common/diff/file-contents-diff-view'
 import { Button } from '~/components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '~/components/ui/collapsible'
-import { ToggleGroup, ToggleGroupItem } from '~/components/ui/toggle-group'
 import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip'
 import { cn } from '~/lib/cn'
 
@@ -23,24 +21,6 @@ interface EditFileBlockProps {
   presentation?: 'preview' | 'detail'
   /** Whether the diff viewer is open initially. @default false */
   defaultOpen?: boolean
-}
-
-type DiffLayout = 'split' | 'stacked'
-type DiffsDiffStyle = 'split' | 'unified'
-type DiffOptions = NonNullable<MultiFileDiffProps<undefined>['options']>
-
-const layoutDiffStyles: Record<DiffLayout, DiffsDiffStyle> = {
-  split: 'split',
-  stacked: 'unified',
-}
-
-const DIFF_THEMES = {
-  dark: 'pierre-dark',
-  light: 'pierre-light',
-} as const
-
-function diffCacheKey(prefix: string, filePath: string, content: string): string {
-  return `${prefix}:${filePath}:${content.length}:${content.slice(0, 64)}:${content.slice(-64)}`
 }
 
 /** Line-level change stats, approximate for visual indicator only. */
@@ -57,20 +37,18 @@ function computeChangeStats(oldContent: string, newContent: string) {
 
 function EditFileDiffPane({
   filePath,
-  oldFile,
-  newFile,
-  diffOptions,
-  layout,
+  oldContent,
+  newContent,
+  diffStyle,
   showFilePath,
-  onLayoutChange,
+  onDiffStyleChange,
 }: {
   filePath: string
-  oldFile: FileContents
-  newFile: FileContents
-  diffOptions: DiffOptions
-  layout: DiffLayout
+  oldContent: string
+  newContent: string
+  diffStyle: DiffStyle
   showFilePath: boolean
-  onLayoutChange: (layout: DiffLayout) => void
+  onDiffStyleChange: (diffStyle: DiffStyle) => void
 }) {
   return (
     <>
@@ -85,35 +63,14 @@ function EditFileDiffPane({
             {filePath}
           </span>
         )}
-        <ToggleGroup
-          type="single"
-          value={layout}
-          onValueChange={(v) => {
-            if (v === 'split' || v === 'stacked') {
-              onLayoutChange(v)
-            }
-          }}
-          variant="outline"
-          size="sm"
-          className="h-5 shrink-0 gap-px"
-          aria-label="Diff layout"
-        >
-          <ToggleGroupItem value="split" aria-label="Split" className="h-5 gap-1 px-1.5 text-[10px]">
-            <Columns2Icon className="size-2.5" />
-            Split
-          </ToggleGroupItem>
-          <ToggleGroupItem value="stacked" aria-label="Stacked" className="h-5 gap-1 px-1.5 text-[10px]">
-            <Rows3Icon className="size-2.5" />
-            Stacked
-          </ToggleGroupItem>
-        </ToggleGroup>
+        <DiffLayoutToggle value={diffStyle} onValueChange={onDiffStyleChange} />
       </div>
 
-      <MultiFileDiff
-        oldFile={oldFile}
-        newFile={newFile}
-        options={diffOptions}
-        className="max-h-128 overflow-auto [--diffs-font-size:11px] [--diffs-line-height:18px]"
+      <FileContentsDiffView
+        filePath={filePath}
+        oldContent={oldContent}
+        newContent={newContent}
+        diffStyle={diffStyle}
       />
     </>
   )
@@ -127,38 +84,13 @@ export function EditFileBlock({
   defaultOpen = false,
 }: EditFileBlockProps) {
   const [open, setOpen] = useState(defaultOpen)
-  const [layout, setLayout] = useState<DiffLayout>('split')
+  const [diffStyle, setDiffStyle] = useState<DiffStyle>('split')
 
   const stats = computeChangeStats(oldContent, newContent)
 
   const segments = filePath.split('/')
   const fileName = segments.at(-1) ?? filePath
   const dirPath = segments.length > 1 ? `${segments.slice(0, -1).join('/')}/` : ''
-
-  const oldFile: FileContents = {
-    name: filePath,
-    contents: oldContent,
-    cacheKey: diffCacheKey('old', filePath, oldContent),
-  }
-
-  const newFile: FileContents = {
-    name: filePath,
-    contents: newContent,
-    cacheKey: diffCacheKey('new', filePath, newContent),
-  }
-
-  const diffOptions: DiffOptions = {
-    theme: DIFF_THEMES,
-    themeType: 'system',
-    diffStyle: layoutDiffStyles[layout],
-    disableFileHeader: true,
-    disableBackground: false,
-    diffIndicators: 'bars',
-    hunkSeparators: 'line-info-basic',
-    lineDiffType: 'word' as const,
-    overflow: 'scroll' as const,
-    parseDiffOptions: { context: 3 },
-  }
 
   if (presentation === 'detail') {
     return (
@@ -171,12 +103,11 @@ export function EditFileBlock({
       >
         <EditFileDiffPane
           filePath={filePath}
-          oldFile={oldFile}
-          newFile={newFile}
-          diffOptions={diffOptions}
-          layout={layout}
+          oldContent={oldContent}
+          newContent={newContent}
+          diffStyle={diffStyle}
           showFilePath
-          onLayoutChange={setLayout}
+          onDiffStyleChange={setDiffStyle}
         />
       </m.div>
     )
@@ -251,12 +182,11 @@ export function EditFileBlock({
           <CollapsibleContent className="overflow-hidden rounded-b-md">
             <EditFileDiffPane
               filePath={filePath}
-              oldFile={oldFile}
-              newFile={newFile}
-              diffOptions={diffOptions}
-              layout={layout}
+              oldContent={oldContent}
+              newContent={newContent}
+              diffStyle={diffStyle}
               showFilePath={false}
-              onLayoutChange={setLayout}
+              onDiffStyleChange={setDiffStyle}
             />
           </CollapsibleContent>
         )}

--- a/apps/web/src/features/diff-review/review-detail/diff-stage.tsx
+++ b/apps/web/src/features/diff-review/review-detail/diff-stage.tsx
@@ -3,10 +3,12 @@ import type { CodeViewHandle } from '@pierre/diffs/react'
 import { CodeView, useStableCallback } from '@pierre/diffs/react'
 import { useEffect, useMemo, useRef } from 'react'
 
-import type { CodeViewLineSelection, DiffData, ThreadAnnotation } from '../shared/diff-items'
+import type { DiffData } from '~/components/common/diff/diff-data'
+import { buildDiffOptions } from '~/components/common/diff/diff-options'
+
+import type { CodeViewLineSelection, ThreadAnnotation } from '../shared/diff-items'
 import {
   anchorSideToSelectionSide,
-  buildCodeViewOptions,
   buildThreadAnnotations,
   getSelectedReviewRange,
 } from '../shared/diff-items'
@@ -22,7 +24,7 @@ export interface DiffStageHandle {
 
 interface DiffStageProps {
   review: CradleDiffReview
-  diffData: DiffData
+  diffData: DiffData<ThreadAnnotation>
   visibleItems: CodeViewItem<ThreadAnnotation>[]
   visiblePathToItemId: Map<string, string>
   diffStyle: DiffStyle
@@ -106,7 +108,12 @@ export function DiffStage({
   })
 
   const options = useMemo(
-    () => buildCodeViewOptions(diffStyle, handleGutterUtilityClick),
+    () => buildDiffOptions<ThreadAnnotation>(diffStyle, {
+      controlledSelection: true,
+      enableGutterUtility: true,
+      enableLineSelection: true,
+      onGutterUtilityClick: handleGutterUtilityClick,
+    }),
     [diffStyle, handleGutterUtilityClick],
   )
 

--- a/apps/web/src/features/diff-review/review-detail/guide-view.tsx
+++ b/apps/web/src/features/diff-review/review-detail/guide-view.tsx
@@ -14,17 +14,17 @@ import { CodeView } from '@pierre/diffs/react'
 import type { CSSProperties } from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
+import type { DiffData } from '~/components/common/diff/diff-data'
+import { buildDiffData, emptyDiffData } from '~/components/common/diff/diff-data'
+import { buildDiffOptions } from '~/components/common/diff/diff-options'
 import { Button } from '~/components/ui/button'
 import { Spinner } from '~/components/ui/spinner'
 import { cn } from '~/lib/cn'
 import { STREAMDOWN_RENDER_OPTIONS } from '~/store/streamdown'
 
-import type { CodeViewLineSelection, DiffData, ThreadAnnotation } from '../shared/diff-items'
+import type { CodeViewLineSelection, ThreadAnnotation } from '../shared/diff-items'
 import {
   anchorToLineSelection,
-  buildCodeViewOptions,
-  buildItemsFromPatch,
-  EMPTY_DIFF_DATA,
   formatAnchorRange,
   guideAnchorsForPath,
 } from '../shared/diff-items'
@@ -169,8 +169,10 @@ function GuideReading({
   const pathToFile = useMemo(() => new Map(files.map(file => [file.path, file])), [files])
   const threadById = useMemo(() => new Map(review.threads.map(thread => [thread.id, thread])), [review.threads])
 
-  const diffData: DiffData = useMemo(
-    () => (review.currentRevision?.patch?.trim() ? buildItemsFromPatch(review.currentRevision.patch) : EMPTY_DIFF_DATA),
+  const diffData: DiffData<ThreadAnnotation> = useMemo(
+    () => (review.currentRevision?.patch?.trim()
+      ? buildDiffData<ThreadAnnotation>(review.currentRevision.patch)
+      : emptyDiffData<ThreadAnnotation>()),
     [review.currentRevision?.patch],
   )
 
@@ -397,7 +399,7 @@ function GuideSection({
   index: number
   fileById: Map<string, ReviewFile>
   pathToFile: Map<string, ReviewFile>
-  diffData: DiffData
+  diffData: DiffData<ThreadAnnotation>
   preferences: NonNullable<ReturnType<typeof useReview>['review']>['preferences']
   threadById: Map<string, ReviewThread>
   onOpenInReview: (path?: string, line?: number, side?: 'base' | 'head') => void
@@ -442,7 +444,11 @@ function GuideSection({
   })
 
   const options = useMemo(
-    () => buildCodeViewOptions('unified'),
+    () => buildDiffOptions<ThreadAnnotation>('unified', {
+      controlledSelection: true,
+      enableGutterUtility: true,
+      enableLineSelection: true,
+    }),
     [],
   )
 
@@ -603,7 +609,7 @@ function GuideFileCodeView({
 }: {
   item: Extract<CodeViewItem<ThreadAnnotation>, { type: 'diff' }>
   anchors: ReviewGuideAnchor[]
-  options: ReturnType<typeof buildCodeViewOptions>
+  options: ReturnType<typeof buildDiffOptions<ThreadAnnotation>>
   diffStyleVars: CSSProperties
   onOpenInReview: (path?: string, line?: number, side?: 'base' | 'head') => void
 }) {

--- a/apps/web/src/features/diff-review/review-detail/review-detail-page.tsx
+++ b/apps/web/src/features/diff-review/review-detail/review-detail-page.tsx
@@ -2,13 +2,13 @@ import { GitCompareLine as FileDiffIcon } from '@mingcute/react'
 import type { CodeViewItem } from '@pierre/diffs'
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 
+import type { DiffData } from '~/components/common/diff/diff-data'
+import { buildDiffData, emptyDiffData } from '~/components/common/diff/diff-data'
 import { ResizeHandle } from '~/components/layout/resize-handle'
 import { Spinner } from '~/components/ui/spinner'
 
-import type { CodeViewLineSelection, DiffData, ThreadAnnotation } from '../shared/diff-items'
+import type { CodeViewLineSelection, ThreadAnnotation } from '../shared/diff-items'
 import {
-  buildItemsFromPatch,
-  EMPTY_DIFF_DATA,
   formatSelectedReviewRange,
   getSelectedReviewRange,
 } from '../shared/diff-items'
@@ -83,8 +83,10 @@ export function ReviewDetailPage({
   const patch = review?.currentRevision?.patch ?? ''
   const deferredPatch = useDeferredValue(patch)
 
-  const diffData: DiffData = useMemo(
-    () => (deferredPatch.trim().length === 0 ? EMPTY_DIFF_DATA : buildItemsFromPatch(deferredPatch)),
+  const diffData: DiffData<ThreadAnnotation> = useMemo(
+    () => (deferredPatch.trim().length === 0
+      ? emptyDiffData<ThreadAnnotation>()
+      : buildDiffData<ThreadAnnotation>(deferredPatch)),
     [deferredPatch],
   )
 

--- a/apps/web/src/features/diff-review/review-detail/review-top-bar.tsx
+++ b/apps/web/src/features/diff-review/review-detail/review-top-bar.tsx
@@ -2,11 +2,9 @@ import {
   CheckLine as CheckIcon,
   CloseLine as CloseIcon,
   GitCommitLine as GitCommitHorizontalIcon,
-  GitCommitLine as GitCommitVerticalIcon,
   Message1Line as MessageSquareIcon,
   Refresh1Line as RefreshCwIcon,
   RobotLine as BotIcon,
-  Rows3Line as Rows3Icon,
   SelectorHorizontalLine as SlidersHorizontalIcon,
   SendLine as SendIcon,
   TreeLine as ListTreeIcon,
@@ -14,6 +12,7 @@ import {
 import { useState, useTransition } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { DiffLayoutToggle } from '~/components/common/diff/diff-layout-toggle'
 import { Button } from '~/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover'
 import { Textarea } from '~/components/ui/textarea'
@@ -100,24 +99,11 @@ export function ReviewTopBar({
       <div className="flex-1" />
 
       {/* Layout — primary view control, stays visible. */}
-      <div className="flex items-center rounded-md border border-border/60 p-px">
-        <LayoutPill
-          active={diffStyle === 'unified'}
-          onClick={() => startDiffStyleTransition(() => onDiffStyleChange('unified'))}
-          disabled={isDiffStylePending}
-        >
-          <Rows3Icon className="size-3.5" />
-          Unified
-        </LayoutPill>
-        <LayoutPill
-          active={diffStyle === 'split'}
-          onClick={() => startDiffStyleTransition(() => onDiffStyleChange('split'))}
-          disabled={isDiffStylePending}
-        >
-          <GitCommitVerticalIcon className="size-3.5" />
-          Split
-        </LayoutPill>
-      </div>
+      <DiffLayoutToggle
+        value={diffStyle}
+        onValueChange={value => startDiffStyleTransition(() => onDiffStyleChange(value))}
+        disabled={isDiffStylePending}
+      />
 
       {/* Display filters — secondary, icon popover. */}
       <DisplayPopover
@@ -215,34 +201,6 @@ export function ReviewTopBar({
         <RefreshCwIcon className={cn('size-3.5', refreshing && 'animate-spin')} />
       </Button>
     </header>
-  )
-}
-
-function LayoutPill({
-  active,
-  onClick,
-  disabled,
-  children,
-}: {
-  active: boolean
-  onClick: () => void
-  disabled: boolean
-  children: React.ReactNode
-}) {
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        'h-6 gap-1.5 rounded-[5px] px-2 text-[12px]',
-        active ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground',
-      )}
-    >
-      {children}
-    </Button>
   )
 }
 

--- a/apps/web/src/features/diff-review/shared/diff-items.ts
+++ b/apps/web/src/features/diff-review/shared/diff-items.ts
@@ -1,29 +1,16 @@
 import type {
-  CodeViewItem,
-  CodeViewOptions,
   DiffLineAnnotation,
   SelectedLineRange,
   SelectionSide,
 } from '@pierre/diffs'
-import { parsePatchFiles } from '@pierre/diffs'
-import type { WorkerInitializationRenderOptions, WorkerPoolOptions } from '@pierre/diffs/react'
-import WorkerUrl from '@pierre/diffs/worker/worker.js?worker&url'
 
 import type {
   CradleDiffReview,
-  DiffStyle,
   ReviewFile,
   ReviewGuideAnchor,
   ReviewSourceKind,
   ReviewThread,
 } from './types'
-
-export interface DiffData {
-  items: CodeViewItem<ThreadAnnotation>[]
-  itemIdToPath: Map<string, string>
-  pathToItemId: Map<string, string>
-  whitespaceOnlyPaths: Set<string>
-}
 
 /** Per-thread annotation metadata carried on a CodeView line. */
 export type ThreadAnnotation
@@ -40,98 +27,6 @@ export interface SelectedReviewRange {
   side: 'base' | 'head'
   startLine: number
   endLine: number
-}
-
-export const WORKER_POOL_OPTIONS = {
-  workerFactory: () => new Worker(WorkerUrl, { type: 'module' }),
-  poolSize: 3,
-} satisfies WorkerPoolOptions
-
-export const WORKER_HIGHLIGHTER_OPTIONS = {
-  lineDiffType: 'word',
-  theme: { dark: 'pierre-dark', light: 'pierre-light' },
-  useTokenTransformer: false,
-} satisfies WorkerInitializationRenderOptions
-
-function hashPatchVersion(patch: string): number {
-  let hash = 2166136261
-  for (let index = 0; index < patch.length; index++) {
-    hash ^= patch.charCodeAt(index)
-    hash = Math.imul(hash, 16777619)
-  }
-  return hash >>> 0
-}
-
-function createItemId(
-  path: string,
-  itemIds: Set<string>,
-  nextCollisionSuffixByBase: Map<string, number>,
-): string {
-  if (!itemIds.has(path)) {
-    return path
-  }
-
-  let suffix = nextCollisionSuffixByBase.get(path) ?? 2
-  let itemId = `${path}?${suffix}`
-  while (itemIds.has(itemId)) {
-    suffix++
-    itemId = `${path}?${suffix}`
-  }
-  nextCollisionSuffixByBase.set(path, suffix + 1)
-  return itemId
-}
-
-function normalizeWhitespaceForStructuralDiff(line: string): string {
-  return line.replace(/\s+/g, '')
-}
-
-function isWhitespaceOnlyFileDiff(fileDiff: Extract<CodeViewItem, { type: 'diff' }>['fileDiff']): boolean {
-  if (fileDiff.type === 'rename-pure') {
-    return false
-  }
-  const oldContent = fileDiff.deletionLines.map(normalizeWhitespaceForStructuralDiff).join('\n')
-  const newContent = fileDiff.additionLines.map(normalizeWhitespaceForStructuralDiff).join('\n')
-  return oldContent === newContent
-}
-
-export function buildItemsFromPatch(patch: string): DiffData {
-  const patchVersion = hashPatchVersion(patch)
-  const parsed = parsePatchFiles(
-    patch,
-    `cradle-diffs-${patch.length.toString(36)}-${patchVersion.toString(36)}`,
-  )
-  const items: CodeViewItem<ThreadAnnotation>[] = []
-  const itemIdToPath = new Map<string, string>()
-  const pathToItemId = new Map<string, string>()
-  const whitespaceOnlyPaths = new Set<string>()
-  const itemIds = new Set<string>()
-  const nextCollisionSuffixByBase = new Map<string, number>()
-  for (const p of parsed) {
-    for (const fileDiff of p.files) {
-      const itemId = createItemId(fileDiff.name, itemIds, nextCollisionSuffixByBase)
-      itemIds.add(itemId)
-      items.push({ id: itemId, type: 'diff', fileDiff, version: patchVersion })
-      itemIdToPath.set(itemId, fileDiff.name)
-      pathToItemId.set(fileDiff.name, itemId)
-      if (isWhitespaceOnlyFileDiff(fileDiff)) {
-        whitespaceOnlyPaths.add(fileDiff.name)
-      }
-      if (fileDiff.prevName) {
-        pathToItemId.set(fileDiff.prevName, itemId)
-        if (isWhitespaceOnlyFileDiff(fileDiff)) {
-          whitespaceOnlyPaths.add(fileDiff.prevName)
-        }
-      }
-    }
-  }
-  return { items, itemIdToPath, pathToItemId, whitespaceOnlyPaths }
-}
-
-export const EMPTY_DIFF_DATA: DiffData = {
-  items: [],
-  itemIdToPath: new Map(),
-  pathToItemId: new Map(),
-  whitespaceOnlyPaths: new Set(),
 }
 
 /**
@@ -320,32 +215,6 @@ export function reviewParticipatedByLocalUser(review: CradleDiffReview): boolean
 /** Linear-style "For me" (involved/responsible) vs "Created" (authored). */
 export function reviewForMe(review: CradleDiffReview): boolean {
   return reviewNeedsAttention(review) || reviewParticipatedByLocalUser(review)
-}
-
-export function buildCodeViewOptions(
-  diffStyle: DiffStyle,
-  onGutterUtilityClick?: CodeViewOptions<ThreadAnnotation>['onGutterUtilityClick'],
-): CodeViewOptions<ThreadAnnotation> {
-  return {
-    theme: { dark: 'pierre-dark', light: 'pierre-light' },
-    themeType: 'system',
-    diffStyle,
-    diffIndicators: 'bars',
-    overflow: 'scroll',
-    lineDiffType: 'word',
-    hunkSeparators: 'line-info-basic',
-    enableLineSelection: true,
-    controlledSelection: true,
-    // Hover any line → a "+" appears in the gutter → click opens the composer.
-    enableGutterUtility: true,
-    onGutterUtilityClick,
-    stickyHeaders: true,
-    pointerEventsOnScroll: false,
-    itemMetrics: {
-      hunkLineCount: 1,
-      lineHeight: 18,
-    },
-  }
 }
 
 export { WORKING_TREE_REVIEW_ID } from './types'

--- a/apps/web/src/features/diff-review/workspace-diffs-view.tsx
+++ b/apps/web/src/features/diff-review/workspace-diffs-view.tsx
@@ -1,14 +1,13 @@
-import { WorkerPoolContextProvider } from '@pierre/diffs/react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { BetaNotice } from '~/components/common/beta-notice'
+import { DiffWorkerProvider } from '~/components/common/diff/diff-runtime'
 import { useRegisterLayoutSlots } from '~/components/layout/use-layout-slots'
 import { CommitPlanPage } from '~/features/diff-review/commit-plan-page'
 import { GuideView } from '~/features/diff-review/review-detail/guide-view'
 import { ReviewDetailPage } from '~/features/diff-review/review-detail/review-detail-page'
 import { ReviewsListPage } from '~/features/diff-review/reviews-list-page'
-import { WORKER_HIGHLIGHTER_OPTIONS, WORKER_POOL_OPTIONS } from '~/features/diff-review/shared/diff-items'
 import { navigateToReview, WORKING_TREE_REVIEW_ID } from '~/features/diff-review/shared/navigation'
 
 export interface WorkspaceDiffsViewProps {
@@ -52,7 +51,7 @@ export function WorkspaceDiffsView({
   }), [workspaceId]))
 
   return (
-    <WorkerPoolContextProvider poolOptions={WORKER_POOL_OPTIONS} highlighterOptions={WORKER_HIGHLIGHTER_OPTIONS}>
+    <DiffWorkerProvider>
       <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background">
         <BetaNotice title={t('beta.title')} description={t('beta.description')} />
         <div className="min-h-0 flex-1 overflow-hidden">
@@ -67,7 +66,7 @@ export function WorkspaceDiffsView({
           />
         </div>
       </div>
-    </WorkerPoolContextProvider>
+    </DiffWorkerProvider>
   )
 }
 

--- a/apps/web/src/features/pull-requests/pull-request-detail-panel.tsx
+++ b/apps/web/src/features/pull-requests/pull-request-detail-panel.tsx
@@ -16,6 +16,11 @@ import { m } from 'motion/react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { buildDiffData } from '~/components/common/diff/diff-data'
+import { DiffLayoutToggle } from '~/components/common/diff/diff-layout-toggle'
+import type { DiffStyle } from '~/components/common/diff/diff-options'
+import { DiffWorkerProvider } from '~/components/common/diff/diff-runtime'
+import { PatchDiffView } from '~/components/common/diff/patch-diff-view'
 import { Button } from '~/components/ui/button'
 import { Skeleton } from '~/components/ui/skeleton'
 import { AssetMarkdown } from '~/features/assets/asset-markdown'
@@ -409,64 +414,95 @@ function reviewLabel(state: string | null, t: TFunction<'pull-requests'>): strin
 
 function CodeTab({ files }: { files: PullRequestFile[] }) {
   const { t } = useTranslation('pull-requests')
+  const [diffStyle, setDiffStyle] = useState<DiffStyle>('unified')
   if (files.length === 0) {
     return <p className="pt-6 text-[13px] text-muted-foreground/70">{t('code.noFiles')}</p>
   }
 
   return (
-    <div className="space-y-2 pt-6">
-      {files.map(file => (
-        <details
-          key={file.filename}
-          className="group overflow-hidden rounded-lg border border-border/60 [content-visibility:auto]"
-        >
-          <summary className="flex min-h-9 cursor-default list-none items-center gap-2.5 px-3 py-1.5 text-[11.5px] hover:bg-muted/40">
-            <span className="min-w-0 flex-1 truncate font-mono text-foreground/80">{file.filename}</span>
-            <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
-              {file.status}
-            </span>
-            <span className="shrink-0 font-mono tabular-nums text-success">
-              +
-              {file.additions}
-            </span>
-            <span className="shrink-0 font-mono tabular-nums text-destructive">
-              −
-              {file.deletions}
-            </span>
-          </summary>
-          {file.patch
-            ? <Patch patch={file.patch} />
-            : (
-                <div className="border-t border-border/60 px-3 py-3 text-[11px] text-muted-foreground">
-                  {t('code.patchUnavailable')}
-                </div>
-              )}
-        </details>
-      ))}
-    </div>
+    <DiffWorkerProvider>
+      <div className="space-y-2 pt-6">
+        <div className="flex justify-end pb-1">
+          <DiffLayoutToggle value={diffStyle} onValueChange={setDiffStyle} />
+        </div>
+        {files.map(file => (
+          <PullRequestFileSection
+            key={file.filename}
+            file={file}
+            diffStyle={diffStyle}
+            patchUnavailableLabel={t('code.patchUnavailable')}
+          />
+        ))}
+      </div>
+    </DiffWorkerProvider>
   )
 }
 
-function Patch({ patch }: { patch: string }) {
+function PullRequestFileSection({
+  file,
+  diffStyle,
+  patchUnavailableLabel,
+}: {
+  file: PullRequestFile
+  diffStyle: DiffStyle
+  patchUnavailableLabel: string
+}) {
+  const [hasOpened, setHasOpened] = useState(false)
   return (
-    <pre className="overflow-x-auto border-t border-border/60 bg-muted/30 py-2 font-mono text-[10px] leading-5">
-      {patch.split('\n').map((line, index) => (
-        <code
-          // The immutable GitHub patch line number is the stable identity, even when text repeats.
-          // eslint-disable-next-line react/no-array-index-key
-          key={`${index}:${line}`}
-          className={cn(
-            'block min-w-max px-3 text-foreground/70',
-            line.startsWith('+') && !line.startsWith('+++') && 'bg-success/10 text-success',
-            line.startsWith('-') && !line.startsWith('---') && 'bg-destructive/10 text-destructive',
-            line.startsWith('@@') && 'bg-info/10 text-info',
+    <details
+      className="group overflow-hidden rounded-lg border border-border/60 [content-visibility:auto]"
+      onToggle={(event) => {
+        if (event.currentTarget.open) {
+          setHasOpened(true)
+        }
+      }}
+    >
+      <summary className="flex min-h-9 cursor-default list-none items-center gap-2.5 px-3 py-1.5 text-[11.5px] hover:bg-muted/40">
+        <span className="min-w-0 flex-1 truncate font-mono text-foreground/80">{file.filename}</span>
+        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-muted-foreground">
+          {file.status}
+        </span>
+        <span className="shrink-0 font-mono tabular-nums text-success">
+          +
+          {file.additions}
+        </span>
+        <span className="shrink-0 font-mono tabular-nums text-destructive">
+          −
+          {file.deletions}
+        </span>
+      </summary>
+      {file.patch
+        ? (hasOpened ? <PullRequestFileDiff file={file} diffStyle={diffStyle} /> : null)
+        : (
+            <div className="border-t border-border/60 px-3 py-3 text-[11px] text-muted-foreground">
+              {patchUnavailableLabel}
+            </div>
           )}
-        >
-          {line || ' '}
-        </code>
-      ))}
-    </pre>
+    </details>
   )
+}
+
+function PullRequestFileDiff({ file, diffStyle }: { file: PullRequestFile, diffStyle: DiffStyle }) {
+  const data = useMemo(() => buildDiffData(buildPullRequestFilePatch(file)), [file])
+  return (
+    <PatchDiffView
+      data={data}
+      diffStyle={diffStyle}
+      className="max-h-128 border-t border-border/60"
+    />
+  )
+}
+
+function buildPullRequestFilePatch(file: PullRequestFile): string {
+  const oldPath = file.previousFilename ?? file.filename
+  const oldMarker = file.status === 'added' ? '/dev/null' : `a/${oldPath}`
+  const newMarker = file.status === 'removed' ? '/dev/null' : `b/${file.filename}`
+  return [
+    `diff --git a/${oldPath} b/${file.filename}`,
+    `--- ${oldMarker}`,
+    `+++ ${newMarker}`,
+    file.patch ?? '',
+  ].join('\n')
 }
 
 function ChecksValue({ state, count }: { state: string, count: number }) {


### PR DESCRIPTION
## Summary
Introduces a shared app-specific diff module for parsing, display options, layout controls, worker runtime, and Pierre rendering. Migrates workspace browser, chat EditFile blocks, Diff Review, and pull request Code views to the common rendering path while preserving each surface's domain behavior. Updates common-component documentation and adds focused diff data tests.

## Test plan
pnpm --filter @cradle/web typecheck; pnpm --filter @cradle/web test (111 files, 495 tests); pnpm --filter @cradle/web build; targeted ESLint for changed files; git diff --check

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)