### PR TITLE
fix(chat): open GitHub pull request links in panel

### DIFF
--- a/apps/web/src/features/chat/rendering/github-pull-request-link.ts
+++ b/apps/web/src/features/chat/rendering/github-pull-request-link.ts
@@ -1,0 +1,52 @@
+export interface ParsedGitHubPullRequestLink {
+  owner: string
+  repo: string
+  number: number
+}
+
+/**
+ * Parse a GitHub pull request URL into the identity used by the Pull Request
+ * detail API and Browser Panel tab.
+ *
+ * GitHub keeps the repository identity in the first two path segments, so
+ * links to a PR's files, commits, or checks can all reuse the same detail tab.
+ */
+export function parseGitHubPullRequestFromHref(
+  href: string | undefined,
+): ParsedGitHubPullRequestLink | null {
+  if (!href) {
+    return null
+  }
+
+  let url: URL
+  try {
+    url = new URL(href)
+  }
+ catch {
+    return null
+  }
+
+  if (
+    (url.protocol !== 'http:' && url.protocol !== 'https:')
+    || (url.hostname !== 'github.com' && url.hostname !== 'www.github.com')
+  ) {
+    return null
+  }
+
+  const segments = url.pathname.split('/').filter(Boolean)
+  if (segments.length < 4 || segments[2] !== 'pull') {
+    return null
+  }
+
+  const number = Number(segments[3])
+  if (!Number.isSafeInteger(number) || number <= 0 || !/^\d+$/.test(segments[3])) {
+    return null
+  }
+
+  const [owner, repo] = segments
+  if (!/^[\w.-]+$/.test(owner) || !/^[\w.-]+$/.test(repo)) {
+    return null
+  }
+
+  return { owner, repo, number }
+}

--- a/apps/web/src/features/chat/rendering/markdown-file-link.test.ts
+++ b/apps/web/src/features/chat/rendering/markdown-file-link.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseGitHubPullRequestFromHref } from './github-pull-request-link'
+
+describe('parseGitHubPullRequestFromHref', () => {
+  it('parses a GitHub pull request URL', () => {
+    expect(parseGitHubPullRequestFromHref('https://github.com/cradle/app/pull/42')).toEqual({
+      owner: 'cradle',
+      repo: 'app',
+      number: 42,
+    })
+  })
+
+  it('parses links to pull request sub-pages', () => {
+    expect(
+      parseGitHubPullRequestFromHref(
+        'https://www.github.com/cradle/app/pull/42/files?short_path=abc',
+      ),
+    ).toEqual({
+      owner: 'cradle',
+      repo: 'app',
+      number: 42,
+    })
+  })
+
+  it('rejects non-pull-request and non-GitHub URLs', () => {
+    expect(parseGitHubPullRequestFromHref('https://github.com/cradle/app/issues/42')).toBeNull()
+    expect(parseGitHubPullRequestFromHref('https://example.com/cradle/app/pull/42')).toBeNull()
+    expect(
+      parseGitHubPullRequestFromHref('https://github.com/cradle/app/pull/not-a-number'),
+    ).toBeNull()
+  })
+})

--- a/apps/web/src/features/chat/rendering/markdown-file-link.test.tsx
+++ b/apps/web/src/features/chat/rendering/markdown-file-link.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useBrowserPanelStore } from '~/store/browser-panel'
+
+import { MarkdownFileLink } from './markdown-file-link'
+
+vi.mock('../session/use-session-binding', () => ({
+  useSessionBinding: () => ({ workspaceId: 'workspace-1' }),
+}))
+
+describe('markdownFileLink', () => {
+  beforeEach(() => {
+    cleanup()
+    localStorage.clear()
+    useBrowserPanelStore.setState({
+      activeOwnerId: 'chat:session-1',
+      owners: {},
+      open: false,
+      tabs: [],
+      activeTabId: null,
+      requestedTab: null,
+      scrollToFilePath: null,
+    })
+  })
+
+  it('opens a GitHub pull request in the current chat Surface owner', () => {
+    render(
+      <MarkdownFileLink href="https://github.com/cradle/app/pull/42" sessionId="session-1">
+        #42
+      </MarkdownFileLink>,
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: '#42' }))
+
+    const ownerState = useBrowserPanelStore.getState().owners['chat:session-1']
+    expect(ownerState?.activeTabId).toBe('pull-request:cradle/app#42')
+    expect(ownerState?.tabs).toEqual([
+      expect.objectContaining({
+        kind: 'pull-request',
+        owner: 'cradle',
+        repo: 'app',
+        number: 42,
+        title: '#42',
+      }),
+    ])
+  })
+})

--- a/apps/web/src/features/chat/rendering/markdown-file-link.tsx
+++ b/apps/web/src/features/chat/rendering/markdown-file-link.tsx
@@ -4,6 +4,7 @@ import type { AnchorHTMLAttributes } from 'react'
 import { useBrowserPanelStore } from '~/store/browser-panel'
 
 import { useSessionBinding } from '../session/use-session-binding'
+import { parseGitHubPullRequestFromHref } from './github-pull-request-link'
 
 interface MarkdownFileLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   href?: string
@@ -16,6 +17,8 @@ interface MarkdownFileLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> 
  */
 export function MarkdownFileLink({ href, sessionId, children, ...props }: MarkdownFileLinkProps) {
   const openWorkspaceFileTab = useBrowserPanelStore(state => state.openWorkspaceFileTab)
+  const openPullRequestTab = useBrowserPanelStore(state => state.openPullRequestTab)
+  const browserPanelOwnerId = useBrowserPanelStore(state => state.activeOwnerId)
   const sessionBinding = useSessionBinding(sessionId ?? null, Boolean(sessionId))
   const workspaceId = sessionBinding?.workspaceId ?? null
 
@@ -27,6 +30,17 @@ export function MarkdownFileLink({ href, sessionId, children, ...props }: Markdo
 
     if (!href || !workspaceId) {
       handleExternalMarkdownLinkClick(event, href)
+      return
+    }
+
+    const pullRequest = parseGitHubPullRequestFromHref(href)
+    if (pullRequest) {
+      event.preventDefault()
+      openPullRequestTab({
+        ...pullRequest,
+        title: `#${pullRequest.number}`,
+        ownerId: browserPanelOwnerId,
+      })
       return
     }
 


### PR DESCRIPTION
## Summary
Parse GitHub pull request Markdown links and open the existing Pull Request detail tab in the current chat's right-side Browser Panel owner. Preserve external-link behavior for other URLs and file-link handling for workspace paths.

## Test plan
Passed the focused Markdown PR parser and click interaction tests (4 tests), Browser Panel and store tests (45 tests), Web typecheck including API boundary validation, and staged ESLint checks.

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)