### PR TITLE
feat(desktop): wire PostHog into release builds

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -187,3 +187,6 @@ Report success with the release URL. If the workflow failed, report the run URL 
 - Dev builds publish both their own `dev-*` release and the rolling `feed-dev` update feed.
 - The dev feed URL is `https://github.com/wibus-wee/cradle-app/releases/download/feed-dev/`.
 - The dev feed uses `latest-mac.yml`; app-side updater logic does not switch to `dev-mac.yml`.
+- Desktop releases require the repository Actions secret `POSTHOG_PROJECT_TOKEN` so product
+  analytics (`VITE_POSTHOG_*`) is baked into the renderer. Internal channels also bake
+  PostHog AI Observability; the `release` channel keeps AI capture off.

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ CRADLE_OTEL_RUNTIME_SAMPLE_INTERVAL_MS=10000
 # ─── Anonymous Product Analytics (PostHog) ──────────────────
 # The renderer only sends manually defined semantic events. DOM autocapture,
 # session replay, exception capture, prompts, code, paths, and resource IDs are disabled.
+# Desktop releases inject these from the repository secret POSTHOG_PROJECT_TOKEN
+# (see .github/workflows/release-desktop.yml). Local `pnpm dev` reads this file.
 VITE_POSTHOG_PROJECT_TOKEN=
 VITE_POSTHOG_HOST=https://us.i.posthog.com
 VITE_POSTHOG_BUILD_CHANNEL=
@@ -37,6 +39,8 @@ VITE_POSTHOG_INTERNAL_ACTOR=
 # sends model, latency, token/cache counts, and cost without conversation content.
 # `full` also sends prompts, outputs, and tool names/inputs/outputs.
 # Keep full capture disabled in end-user builds until explicit server-side consent exists.
+# Packaged `dev` / `bleeding-edge` builds bake these when POSTHOG_AI is enabled in CI;
+# `release` channel keeps AI observability off and only ships product analytics.
 CRADLE_POSTHOG_AI_OBSERVABILITY_ENABLED=0
 CRADLE_POSTHOG_AI_CAPTURE_MODE=metadata
 CRADLE_POSTHOG_PROJECT_TOKEN=

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -49,6 +49,10 @@ jobs:
       source_ref: ${{ steps.params.outputs.source_ref }}
       update_url: ${{ steps.params.outputs.update_url }}
       release_download_url: ${{ steps.params.outputs.release_download_url }}
+      analytics_build_channel: ${{ steps.params.outputs.analytics_build_channel }}
+      analytics_audience: ${{ steps.params.outputs.analytics_audience }}
+      posthog_ai_enabled: ${{ steps.params.outputs.posthog_ai_enabled }}
+      posthog_ai_capture_mode: ${{ steps.params.outputs.posthog_ai_capture_mode }}
     steps:
       - name: Resolve parameters
         id: params
@@ -107,10 +111,24 @@ jobs:
 
           if [ "$CHANNEL" = "release" ]; then
             UPDATE_URL="https://github.com/${{ github.repository }}/releases/latest/download/manifest.json"
+            ANALYTICS_BUILD_CHANNEL="release"
+            ANALYTICS_AUDIENCE="external"
+            # End-user builds: product analytics only. AI full/metadata capture stays off
+            # until explicit server-side consent exists.
+            POSTHOG_AI_ENABLED="0"
+            POSTHOG_AI_CAPTURE_MODE="metadata"
           elif [ "$CHANNEL" = "bleeding-edge" ]; then
             UPDATE_URL="https://github.com/${{ github.repository }}/releases/download/${BLEEDING_EDGE_FEED_TAG}/manifest.json"
+            ANALYTICS_BUILD_CHANNEL="bleeding-edge"
+            ANALYTICS_AUDIENCE="internal"
+            POSTHOG_AI_ENABLED="1"
+            POSTHOG_AI_CAPTURE_MODE="full"
           else
             UPDATE_URL="https://github.com/${{ github.repository }}/releases/download/${DEV_FEED_TAG}/manifest.json"
+            ANALYTICS_BUILD_CHANNEL="development"
+            ANALYTICS_AUDIENCE="internal"
+            POSTHOG_AI_ENABLED="1"
+            POSTHOG_AI_CAPTURE_MODE="full"
           fi
           RELEASE_DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${RELEASE_TAG}"
 
@@ -128,6 +146,10 @@ jobs:
           echo "source_ref=$SOURCE_REF" >> "$GITHUB_OUTPUT"
           echo "update_url=$UPDATE_URL" >> "$GITHUB_OUTPUT"
           echo "release_download_url=$RELEASE_DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
+          echo "analytics_build_channel=$ANALYTICS_BUILD_CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "analytics_audience=$ANALYTICS_AUDIENCE" >> "$GITHUB_OUTPUT"
+          echo "posthog_ai_enabled=$POSTHOG_AI_ENABLED" >> "$GITHUB_OUTPUT"
+          echo "posthog_ai_capture_mode=$POSTHOG_AI_CAPTURE_MODE" >> "$GITHUB_OUTPUT"
 
           echo "Channel: $CHANNEL"
           echo "Desktop version: $DESKTOP_VERSION"
@@ -138,6 +160,9 @@ jobs:
           echo "Source ref: $SOURCE_REF"
           echo "Update URL: $UPDATE_URL"
           echo "Release download URL: $RELEASE_DOWNLOAD_URL"
+          echo "Analytics build channel: $ANALYTICS_BUILD_CHANNEL"
+          echo "Analytics audience: $ANALYTICS_AUDIENCE"
+          echo "PostHog AI observability: $POSTHOG_AI_ENABLED ($POSTHOG_AI_CAPTURE_MODE)"
 
   build-macos:
     name: Build Desktop (mac arm64)
@@ -177,6 +202,38 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
+
+      - name: Configure PostHog build env
+        env:
+          POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
+          ANALYTICS_BUILD_CHANNEL: ${{ needs.resolve.outputs.analytics_build_channel }}
+          ANALYTICS_AUDIENCE: ${{ needs.resolve.outputs.analytics_audience }}
+          POSTHOG_AI_ENABLED: ${{ needs.resolve.outputs.posthog_ai_enabled }}
+          POSTHOG_AI_CAPTURE_MODE: ${{ needs.resolve.outputs.posthog_ai_capture_mode }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${POSTHOG_PROJECT_TOKEN:-}" ]; then
+            echo "POSTHOG_PROJECT_TOKEN repository secret is required for desktop releases." >&2
+            echo "Add it under Settings → Secrets and variables → Actions." >&2
+            exit 1
+          fi
+          {
+            echo "VITE_POSTHOG_PROJECT_TOKEN=$POSTHOG_PROJECT_TOKEN"
+            echo "VITE_POSTHOG_HOST=https://us.i.posthog.com"
+            echo "VITE_POSTHOG_BUILD_CHANNEL=$ANALYTICS_BUILD_CHANNEL"
+            echo "VITE_POSTHOG_AUDIENCE=$ANALYTICS_AUDIENCE"
+            if [ "$POSTHOG_AI_ENABLED" = "1" ]; then
+              echo "CRADLE_OTEL_ENABLED=1"
+              echo "CRADLE_OTEL_TRACES_ENABLED=1"
+              echo "CRADLE_POSTHOG_AI_OBSERVABILITY_ENABLED=1"
+              echo "CRADLE_POSTHOG_AI_CAPTURE_MODE=$POSTHOG_AI_CAPTURE_MODE"
+              echo "CRADLE_POSTHOG_PROJECT_TOKEN=$POSTHOG_PROJECT_TOKEN"
+              echo "CRADLE_POSTHOG_HOST=https://us.i.posthog.com"
+            fi
+          } >> "$GITHUB_ENV"
+          echo "Product analytics: channel=$ANALYTICS_BUILD_CHANNEL audience=$ANALYTICS_AUDIENCE"
+          echo "PostHog AI observability: enabled=$POSTHOG_AI_ENABLED capture=$POSTHOG_AI_CAPTURE_MODE"
 
       - name: Build relayd (darwin-arm64)
         run: pnpm --filter @cradle/relayd build:desktop-resource -- --target=darwin-arm64
@@ -270,6 +327,38 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
+
+      - name: Configure PostHog build env
+        env:
+          POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
+          ANALYTICS_BUILD_CHANNEL: ${{ needs.resolve.outputs.analytics_build_channel }}
+          ANALYTICS_AUDIENCE: ${{ needs.resolve.outputs.analytics_audience }}
+          POSTHOG_AI_ENABLED: ${{ needs.resolve.outputs.posthog_ai_enabled }}
+          POSTHOG_AI_CAPTURE_MODE: ${{ needs.resolve.outputs.posthog_ai_capture_mode }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${POSTHOG_PROJECT_TOKEN:-}" ]; then
+            echo "POSTHOG_PROJECT_TOKEN repository secret is required for desktop releases." >&2
+            echo "Add it under Settings → Secrets and variables → Actions." >&2
+            exit 1
+          fi
+          {
+            echo "VITE_POSTHOG_PROJECT_TOKEN=$POSTHOG_PROJECT_TOKEN"
+            echo "VITE_POSTHOG_HOST=https://us.i.posthog.com"
+            echo "VITE_POSTHOG_BUILD_CHANNEL=$ANALYTICS_BUILD_CHANNEL"
+            echo "VITE_POSTHOG_AUDIENCE=$ANALYTICS_AUDIENCE"
+            if [ "$POSTHOG_AI_ENABLED" = "1" ]; then
+              echo "CRADLE_OTEL_ENABLED=1"
+              echo "CRADLE_OTEL_TRACES_ENABLED=1"
+              echo "CRADLE_POSTHOG_AI_OBSERVABILITY_ENABLED=1"
+              echo "CRADLE_POSTHOG_AI_CAPTURE_MODE=$POSTHOG_AI_CAPTURE_MODE"
+              echo "CRADLE_POSTHOG_PROJECT_TOKEN=$POSTHOG_PROJECT_TOKEN"
+              echo "CRADLE_POSTHOG_HOST=https://us.i.posthog.com"
+            fi
+          } >> "$GITHUB_ENV"
+          echo "Product analytics: channel=$ANALYTICS_BUILD_CHANNEL audience=$ANALYTICS_AUDIENCE"
+          echo "PostHog AI observability: enabled=$POSTHOG_AI_ENABLED capture=$POSTHOG_AI_CAPTURE_MODE"
 
       - name: Build relayd (win32-x64)
         run: pnpm --filter @cradle/relayd build:desktop-resource -- --target=win32-x64

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -20,6 +20,33 @@ const nodeRuntimeExternals = [
   'electron',
 ]
 
+/** Observability keys that may be baked into packaged main-process defaults. */
+const PACKAGED_OBSERVABILITY_ENV_KEYS = [
+  'CRADLE_OTEL_ENABLED',
+  'CRADLE_OTEL_TRACES_ENABLED',
+  'CRADLE_POSTHOG_AI_OBSERVABILITY_ENABLED',
+  'CRADLE_POSTHOG_AI_CAPTURE_MODE',
+  'CRADLE_POSTHOG_PROJECT_TOKEN',
+  'CRADLE_POSTHOG_HOST',
+] as const
+
+function readPackagedObservabilityEnv(): Record<string, string> {
+  const baked: Record<string, string> = {}
+  for (const key of PACKAGED_OBSERVABILITY_ENV_KEYS) {
+    const value = process.env[key]?.trim()
+    if (value) {
+      baked[key] = value
+    }
+  }
+
+  // Only bake AI Observability when explicitly enabled for this build.
+  if (baked.CRADLE_POSTHOG_AI_OBSERVABILITY_ENABLED !== '1') {
+    return {}
+  }
+
+  return baked
+}
+
 export default defineConfig({
   main: {
     ssr: {
@@ -27,6 +54,7 @@ export default defineConfig({
     },
     define: {
       __CRADLE_DESKTOP_UPDATE_URL__: JSON.stringify(desktopUpdateUrl),
+      __CRADLE_DESKTOP_PACKAGED_OBSERVABILITY_ENV__: JSON.stringify(readPackagedObservabilityEnv()),
     },
     build: {
       externalizeDeps: false,

--- a/apps/desktop/src/main/dev-env.ts
+++ b/apps/desktop/src/main/dev-env.ts
@@ -18,7 +18,8 @@ const DEFAULT_DEV_CHROMIUM_ARGS = ['--remote-debugging-port=9222']
  * fields automatically.
  *
  * Shell-provided variables win: existing `process.env` entries are never
- * overridden. No-op in production builds, which receive env from the launcher.
+ * overridden. No-op in production builds — packaged builds apply compile-time
+ * defaults via `applyDesktopPackagedObservabilityEnv` instead.
  */
 export function loadDesktopDevEnv(): void {
   const isDev = !!process.env.ELECTRON_RENDERER_URL

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,7 +1,9 @@
 import { applyDesktopDevChromiumArgs, loadDesktopDevEnv } from './dev-env'
 import { installDesktopMainErrorCapture } from './observability-reporter'
+import { applyDesktopPackagedObservabilityEnv } from './packaged-observability-env'
 
 loadDesktopDevEnv()
+applyDesktopPackagedObservabilityEnv()
 applyDesktopDevChromiumArgs()
 installDesktopMainErrorCapture()
 

--- a/apps/desktop/src/main/packaged-observability-env.ts
+++ b/apps/desktop/src/main/packaged-observability-env.ts
@@ -1,0 +1,46 @@
+import { app } from 'electron'
+
+/**
+ * Build-time defaults for packaged desktop observability.
+ *
+ * Release CI bakes these through `electron.vite.config.ts` so the main process
+ * (and the forked server via `pickDesktopServerObservabilityEnv`) can enable
+ * PostHog AI Observability without a local `.env`. Shell-provided values win.
+ *
+ * Product analytics uses `VITE_POSTHOG_*` in the renderer and is independent.
+ */
+declare const __CRADLE_DESKTOP_PACKAGED_OBSERVABILITY_ENV__: Record<string, string>
+
+function readPackagedDefaults(): Record<string, string> {
+  try {
+    const baked = __CRADLE_DESKTOP_PACKAGED_OBSERVABILITY_ENV__
+    if (!baked || typeof baked !== 'object') {
+      return {}
+    }
+    return baked
+  }
+  catch {
+    return {}
+  }
+}
+
+/**
+ * Apply compile-time observability defaults in packaged builds.
+ * No-op while developing (`electron-vite dev`) or when the launcher already
+ * set the same keys.
+ */
+export function applyDesktopPackagedObservabilityEnv(): void {
+  if (!app.isPackaged) {
+    return
+  }
+
+  for (const [key, value] of Object.entries(readPackagedDefaults())) {
+    const trimmed = value?.trim()
+    if (!trimmed) {
+      continue
+    }
+    if (process.env[key] === undefined) {
+      process.env[key] = trimmed
+    }
+  }
+}

--- a/apps/web/src/features/product-analytics/README.md
+++ b/apps/web/src/features/product-analytics/README.md
@@ -19,6 +19,15 @@ resource IDs to product analytics properties.
 - `VITE_POSTHOG_AUDIENCE`: set to `internal` for internal packaged builds.
 - `VITE_POSTHOG_INTERNAL_ACTOR`: optional internal-only actor label.
 
+Desktop release builds inject these from the repository Actions secret
+`POSTHOG_PROJECT_TOKEN` in `release-desktop.yml`:
+
+| Channel | `build_channel` | `audience` | Product analytics | AI Observability |
+| --- | --- | --- | --- | --- |
+| `dev` | `development` | `internal` | on | on (`full`) |
+| `bleeding-edge` | `bleeding-edge` | `internal` | on | on (`full`) |
+| `release` | `release` | `external` | on | off |
+
 The user-facing setting is enabled by default and persisted under the
 Cradle-owned `cradle:product-analytics:v1` local-storage namespace. App-open
 lifecycle state uses `cradle:product-analytics:lifecycle:v1` and represents the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Desktop release builds previously never injected `VITE_POSTHOG_*`, so packaged Cradle never actually sent product analytics. This wires PostHog into `release-desktop.yml` and bakes optional AI Observability for internal channels.

## Channel policy

| Channel | Product analytics | `build_channel` | `audience` | AI Observability |
| --- | --- | --- | --- | --- |
| `dev` | on | `development` | `internal` | on (`full`) |
| `bleeding-edge` | on | `bleeding-edge` | `internal` | on (`full`) |
| `release` | on | `release` | `external` | **off** |

`release` keeps AI capture off on purpose (no server-side consent yet). Product analytics still ships.

## Implementation

- Inject `VITE_POSTHOG_*` during mac/win packaging from Actions secret `POSTHOG_PROJECT_TOKEN`
- Bake `CRADLE_POSTHOG_*` / OTEL flags into packaged main via `electron.vite` define (internal channels only)
- Apply baked defaults at startup with `applyDesktopPackagedObservabilityEnv()`

## Required before next release

Add repository secret:

```text
POSTHOG_PROJECT_TOKEN=<your phc_... token>
```

Settings → Secrets and variables → Actions → New repository secret

Without this secret, the release workflow will fail fast instead of shipping a silent no-analytics build.

## Test plan

- [ ] Add `POSTHOG_PROJECT_TOKEN` secret
- [ ] Merge and cut a `dev-*` release; confirm renderer has analytics (`build_channel=development`, `audience=internal`) and AI Observability is enabled
- [ ] Cut a `release` build; confirm product analytics works with `audience=external` and AI Observability stays off

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-536d7707-cf02-4d59-84e8-fa6863fd0364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-536d7707-cf02-4d59-84e8-fa6863fd0364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

