### PR TITLE
fix(server): force-kill stale managed relayd

### DIFF
--- a/apps/server/src/modules/relay-servers/local-relayd-supervisor.ts
+++ b/apps/server/src/modules/relay-servers/local-relayd-supervisor.ts
@@ -18,6 +18,7 @@ const localRelayDisplayName = 'Built-in local relay'
 const defaultRelayHost = '127.0.0.1'
 const networkRelayHost = '0.0.0.0'
 const relaydExecutableName = process.platform === 'win32' ? 'relayd.exe' : 'relayd'
+const managedRelaydForceKillAfterMs = 1_000
 const localModuleDir = dirname(fileURLToPath(import.meta.url))
 const logger = createChildLogger({ module: 'local-relayd-supervisor' })
 
@@ -293,7 +294,54 @@ async function terminateChild(child: ManagedChildProcess): Promise<void> {
     return
   }
   closeChildOwnerPipe(child)
-  await child.stop('SIGTERM')
+
+  let gracefulStopFailed = false
+  const gracefulStop = child.stop('SIGTERM').catch(() => {
+    gracefulStopFailed = true
+  })
+  await Promise.race([gracefulStop, waitForDuration(managedRelaydForceKillAfterMs)])
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return
+  }
+
+  logger.warn('managed local relayd did not stop after SIGTERM; forcing process-group shutdown', {
+    pid: readManagedProcessPid(child),
+    gracefulStopFailed,
+  })
+  signalManagedRelaydTarget(child, 'SIGKILL')
+  try {
+    child.kill('SIGKILL')
+  }
+  catch {
+    // The runner may have exited while the target process group was being killed.
+  }
+  await Promise.race([gracefulStop, waitForDuration(managedRelaydForceKillAfterMs)])
+}
+
+function signalManagedRelaydTarget(child: ManagedChildProcess, signal: NodeJS.Signals): void {
+  const targetPid = child.targetPid
+  if (!targetPid) {
+    return
+  }
+  try {
+    if (process.platform !== 'win32') {
+      process.kill(-targetPid, signal)
+    }
+    else {
+      process.kill(targetPid, signal)
+    }
+  }
+  catch (error) {
+    const processError = error as NodeJS.ErrnoException
+    if (processError.code === 'ESRCH') {
+      return
+    }
+    logger.warn('failed to signal managed local relayd target', { pid: targetPid, signal, err: error })
+  }
+}
+
+async function waitForDuration(durationMs: number): Promise<void> {
+  await new Promise<void>(resolveWait => setTimeout(resolveWait, durationMs))
 }
 
 function closeChildOwnerPipe(child: ManagedChildProcess): void {

--- a/apps/server/tests/relay-servers.test.ts
+++ b/apps/server/tests/relay-servers.test.ts
@@ -46,7 +46,11 @@ function shutdown() {
   server.close(() => process.exit(0))
   setTimeout(() => process.exit(0), 1000).unref()
 }
-process.on('SIGTERM', shutdown)
+if (process.env.CRADLE_TEST_RELAYD_IGNORE_SIGTERM === '1') {
+  process.on('SIGTERM', () => {})
+} else {
+  process.on('SIGTERM', shutdown)
+}
 process.on('SIGINT', shutdown)
 `)
   chmodSync(executablePath, 0o755)
@@ -328,6 +332,42 @@ describe('relay servers', () => {
       restoreEnv('CRADLE_RELAYD_PATH', previousRelaydPath)
       restoreEnv('CRADLE_RELAYD_LISTEN', previousRelaydListen)
       restoreEnv('CRADLE_RELAYD_PUBLIC_URL', previousRelaydPublicUrl)
+    }
+  })
+
+  it('force-kills a managed relayd that ignores SIGTERM before reusing its port', async () => {
+    const dataDir = makeTempDir('cradle-managed-local-relayd-force-kill-')
+    const binDir = makeTempDir('cradle-managed-local-relayd-force-kill-bin-')
+    const relayPort = await reserveTcpPort()
+    const previousDataDir = process.env.CRADLE_DATA_DIR
+    const previousAutostart = process.env.CRADLE_RELAYD_AUTOSTART
+    const previousRelaydPath = process.env.CRADLE_RELAYD_PATH
+    const previousRelaydListen = process.env.CRADLE_RELAYD_LISTEN
+    const previousIgnoreSigterm = process.env.CRADLE_TEST_RELAYD_IGNORE_SIGTERM
+
+    try {
+      process.env.CRADLE_RELAYD_AUTOSTART = '1'
+      process.env.CRADLE_RELAYD_PATH = writeFakeRelaydExecutable(binDir)
+      process.env.CRADLE_RELAYD_LISTEN = `127.0.0.1:${relayPort}`
+      process.env.CRADLE_TEST_RELAYD_IGNORE_SIGTERM = '1'
+      await createAppWithDataDir(dataDir)
+
+      await startManagedLocalRelayd()
+      await stopManagedLocalRelayd()
+      await startManagedLocalRelayd()
+
+      const readyRes = await fetch(`http://127.0.0.1:${relayPort}/readyz`)
+      expect(readyRes.status).toBe(200)
+    }
+    finally {
+      await stopManagedLocalRelayd()
+      rmSync(dataDir, { recursive: true, force: true })
+      rmSync(binDir, { recursive: true, force: true })
+      restoreEnv('CRADLE_DATA_DIR', previousDataDir)
+      restoreEnv('CRADLE_RELAYD_AUTOSTART', previousAutostart)
+      restoreEnv('CRADLE_RELAYD_PATH', previousRelaydPath)
+      restoreEnv('CRADLE_RELAYD_LISTEN', previousRelaydListen)
+      restoreEnv('CRADLE_TEST_RELAYD_IGNORE_SIGTERM', previousIgnoreSigterm)
     }
   })
 


### PR DESCRIPTION
## Summary
Make stopManagedLocalRelayd escalate to SIGKILL after a 1-second SIGTERM grace period. The fallback signals the managed relayd target process group directly on Unix (or target PID on Windows), then kills the runner so stale listeners cannot keep the configured port occupied. Add a regression test with a relayd that ignores SIGTERM and verifies the same port can be reused.

## Test plan
pnpm --filter @cradle/plugin-sdk build; pnpm --filter @cradle/server exec vitest run tests/relay-servers.test.ts (7 passed); pnpm --filter @cradle/server exec tsc --noEmit; pnpm exec eslint apps/server/src/modules/relay-servers/local-relayd-supervisor.ts apps/server/tests/relay-servers.test.ts

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)