### PR TITLE
fix(remote-control): send provider/model for remote sessions and sync

### DIFF
--- a/apps/server/src/modules/session/index.ts
+++ b/apps/server/src/modules/session/index.ts
@@ -6,13 +6,23 @@ import { WorktreeModel } from '../worktree/model'
 import * as Worktree from '../worktree/service'
 import { sessionArchiveChunks } from './export-archive'
 import { SessionModel } from './model'
+import { isRemoteProjectedSession, syncRemoteSessionTitle } from './remote-projection'
 import * as Session from './service'
 
 export const session = new Elysia({
   prefix: '/sessions',
   detail: { tags: ['session'] },
 })
-  .get('/', ({ query }) => Session.list(query), {
+  .get('/', ({ query }) => {
+    const sessions = Session.list(query)
+    // Best-effort: sync titles from remote host for any remote-projected sessions.
+    for (const s of sessions) {
+      if (s.execution.kind === 'remote-host') {
+        void syncRemoteSessionTitle(s.id)
+      }
+    }
+    return sessions
+  }, {
     detail: {
       'summary': 'List sessions',
       'x-cradle-cli': {
@@ -28,6 +38,10 @@ export const session = new Elysia({
       const s = Session.get(params.id)
       if (!s) {
         throw new AppError({ code: 'session_not_found', status: 404, message: 'Session not found' })
+      }
+      // Best-effort: sync title from remote host so the local projection stays fresh.
+      if (isRemoteProjectedSession(params.id)) {
+        void syncRemoteSessionTitle(params.id)
       }
       return s
     },

--- a/apps/server/src/modules/session/remote-projection.ts
+++ b/apps/server/src/modules/session/remote-projection.ts
@@ -4,6 +4,7 @@ import { remoteSessionLinks, sessions } from '@cradle/db'
 import { eq } from 'drizzle-orm'
 
 import { AppError } from '../../errors/app-error'
+import { currentUnixSeconds } from '../../helpers/time'
 import { db } from '../../infra'
 import type { ChatThinkingEffort } from '../chat-runtime/runtime-provider-types'
 import type { ChatRuntimeSettingsUpdatePatch } from '../chat-runtime/runtime-settings-api'
@@ -179,6 +180,12 @@ export async function createRemoteProjectedSession(input: {
         })
   }
 
+  const localConfigJson = JSON.stringify({
+    ...(input.modelId ? { requestedModelId: input.modelId } : {}),
+    ...(input.providerTargetId ? { requestedProviderTargetId: input.providerTargetId } : {}),
+    ...(input.thinkingEffort ? { requestedThinkingEffort: input.thinkingEffort } : {}),
+  })
+
   try {
     db().transaction((tx) => {
       tx.insert(sessions)
@@ -190,7 +197,7 @@ export async function createRemoteProjectedSession(input: {
           providerTargetId: null,
           runtimeKind: input.runtimeKind ?? 'standard',
           agentId: null,
-          configJson: '{}',
+          configJson: localConfigJson,
           linkedIssueId: input.linkedIssueId ?? null,
           sessionGroupId: input.sessionGroupId ?? null,
         })
@@ -294,4 +301,46 @@ export function buildProxiedJsonRequest(
     body: JSON.stringify(body),
     signal: request.signal,
   })
+}
+
+/**
+ * Fetch the remote session title and update the local projection if it changed.
+ * Returns `true` if the title was updated.
+ */
+export async function syncRemoteSessionTitle(localSessionId: string): Promise<boolean> {
+  const link = getRemoteSessionLink(localSessionId)
+  if (!link) {
+    return false
+  }
+
+  try {
+    const { baseUrl } = await ensureRemoteHostConnected(link.hostId)
+    const remote = await upstreamJsonByBaseUrl<{ id: string, title: string | null }>(
+      baseUrl,
+      `/sessions/${encodeURIComponent(link.remoteSessionId)}`,
+    )
+    if (!remote?.title) {
+      return false
+    }
+
+    const local = db()
+      .select({ title: sessions.title })
+      .from(sessions)
+      .where(eq(sessions.id, localSessionId))
+      .get()
+    if (!local || local.title === remote.title) {
+      return false
+    }
+
+    db()
+      .update(sessions)
+      .set({ title: remote.title, updatedAt: currentUnixSeconds() })
+      .where(eq(sessions.id, localSessionId))
+      .run()
+    return true
+  }
+  catch {
+    // Best-effort: do not fail the request if title sync fails.
+    return false
+  }
 }

--- a/apps/server/src/modules/session/service.ts
+++ b/apps/server/src/modules/session/service.ts
@@ -163,6 +163,13 @@ export function readSessionModelPreference(configJson: string | null | undefined
     : null
 }
 
+export function readSessionProviderPreference(configJson: string | null | undefined): string | null {
+  const config = parseTrustedConfigJson(configJson)
+  return typeof config.requestedProviderTargetId === 'string' && config.requestedProviderTargetId.trim().length > 0
+    ? config.requestedProviderTargetId.trim()
+    : null
+}
+
 export function readSessionThinkingEffortPreference(
   configJson: string | null | undefined,
 ): ChatThinkingEffort | null {
@@ -350,7 +357,7 @@ function toSessionView(
   return {
     ...session,
     execution: readSessionExecutionTarget(session.id),
-    providerTargetId: session.providerTargetId,
+    providerTargetId: session.providerTargetId ?? readSessionProviderPreference(session.configJson),
     modelId,
     thinkingEffort: readSessionThinkingEffortPreference(session.configJson),
     status,

--- a/apps/web/src/features/workspace-detail/workspace-detail-page.tsx
+++ b/apps/web/src/features/workspace-detail/workspace-detail-page.tsx
@@ -512,6 +512,9 @@ function useWorkspaceDetailOwner(workspaceId: string) {
           ? {
               workspaceId,
               title: sessionTitle,
+              providerTargetId: opts.providerTargetId,
+              modelId: opts.modelId ?? null,
+              thinkingEffort: opts.thinkingEffort,
               runtimeKind: opts.runtimeKind,
               runtimeSettings: opts.runtimeSettings,
             }
@@ -548,6 +551,9 @@ function useWorkspaceDetailOwner(workspaceId: string) {
             workspaceId,
             runtimeKind: opts.runtimeKind,
             title: sessionTitle,
+            providerTargetId: opts.providerTargetId,
+            modelId: opts.modelId ?? null,
+            thinkingEffort: opts.thinkingEffort,
             runtimeSettings: opts.runtimeSettings,
           }
         : {
@@ -566,8 +572,8 @@ function useWorkspaceDetailOwner(workspaceId: string) {
       id: session.id,
       title: sessionTitle,
       workspaceId,
-      providerTargetId: isRemoteWorkspace ? null : (opts.providerTargetId ?? null),
-      modelId: isRemoteWorkspace ? null : (opts.modelId ?? null),
+      providerTargetId: opts.providerTargetId ?? null,
+      modelId: opts.modelId ?? null,
       runtimeKind: opts.runtimeKind,
     }, { promote: true })
     await openCreatedWorkspaceSession(session.id, target)
@@ -579,7 +585,8 @@ function useWorkspaceDetailOwner(workspaceId: string) {
         text,
         files,
         contextParts,
-        modelId: isRemoteWorkspace ? undefined : opts.modelId,
+        providerTargetId: opts.providerTargetId,
+        modelId: opts.modelId,
         thinkingEffort: opts.thinkingEffort,
         runtimeSettings: readRunRuntimeSettingsPatch(opts.runtimeSettings),
       },


### PR DESCRIPTION
- Include providerTargetId, modelId, thinkingEffort in session creation and first response body for remote workspaces (workspace-detail-page)
- Persist provider/model in local projection configJson so existing remote sessions restore the correct composer selection
- Add readSessionProviderPreference() fallback in toSessionView()
- Add syncRemoteSessionTitle() to fetch remote title and update local projection; fire-and-forget from GET /sessions and GET /sessions/:id

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
