### PR TITLE
feat(desktop): slim Electron package size path toward &lt;100MB

### DIFF
--- a/apps/desktop/docs/package-size.md
+++ b/apps/desktop/docs/package-size.md
@@ -1,0 +1,100 @@
+# Desktop package size (target: DMG & ZIP &lt; 100MB)
+
+## Current baseline (dev-20260718.1)
+
+| Artifact | Size |
+| --- | ---: |
+| `Cradle.dmg` | ~393 MB |
+| `Cradle-mac-arm64.zip` | ~360 MB |
+| `Cradle-setup.exe` | ~337 MB |
+
+Unpacked Electron 42 shell alone is ~273 MB on macOS arm64 before any Cradle code. The installer is therefore dominated by **vendor binaries**, not `Contents/Resources/*.lproj`.
+
+## Where the megabytes go
+
+Measured on a local desktop-runtime + packaged Windows dir / mac resources tree:
+
+| Component | Raw size | Notes |
+| --- | ---: | --- |
+| `@anthropic-ai/claude-agent-sdk-*-` native `claude` CLI | **~230 MB** | optionalDependency platform package |
+| Codex `codex-app-server` (packaged) / full `codex` CLI | **~207–248 MB** | copied in `afterPack` today |
+| Electron Framework (mac) | **~273 MB** | Chromium + V8; ~47 MB is `*.lproj` |
+| Windows `locales/*.pak` (55 files) | **~44 MB** | not pruned before this work |
+| `@arcships/light-ocr` + ONNX + model | **~68 MB** | image OCR feature |
+| `better-sqlite3` build/deps leftovers | **~25 MB** | prune was broken on hoisted layout |
+| `app.asar` (renderer + main) | **~49 MB** | already asar'd |
+| Server JS bundle | **~16 MB** | vite `dist` |
+| Plugins (esp. slack-conversation-bridge deps) | **~28 MB** | production deploy of plugin deps |
+| `ffmpeg` / swiftshader | **~3–20 MB** | optional for Cradle UI |
+
+Compression (zlib-9 sample) only halves the big agent binaries (~0.4–0.5 ratio). So **even with maximum DMG/ZIP compression, embedding Claude + Codex makes &lt;100 MB impossible**.
+
+### Math for &lt;100 MB
+
+Approximate compressed contribution:
+
+- Bare Electron after locale/ffmpeg strip: **~70–85 MB**
+- Cradle app.asar + slim server natives (no agent CLIs, OCR optional): **~25–45 MB**
+- Claude CLI alone: **~110 MB compressed**
+- Codex app-server alone: **~100+ MB compressed**
+
+⇒ **Required for &lt;100 MB:** do not ship Claude/Codex (and ideally OCR) inside the base installer. Deliver them via Download Center / first-use install, same pattern as ACP binary agents.
+
+## What this branch implements
+
+### Packaging hygiene (safe, always on)
+
+1. **`electronLanguages`** + `afterPack` hard prune of unused mac `*.lproj` and Windows/Linux `locales/*.pak`.
+2. **Optional Chromium libs removed** in afterPack: `libffmpeg` / `ffmpeg.dll`, swiftshader (no HTML5 media/Vulkan software path in core UI).
+3. **`rebuild-electron-runtime.mjs` prune fixed for hoisted `node_modules`** (previously only looked under `.pnpm/.../node_modules/...` and left `better-sqlite3` build trees intact).
+4. **Claude platform optionalDependencies stripped** from desktop-runtime by default; Anthropic SDK `src/` trees dropped.
+5. **DMG compression**: installer `build-dmg.mjs` / `build-dmg.sh` prefer **ULMO (LZMA)**, fallback **UDZO zlib-level=9**. electron-builder `compression: 'maximum'` + zip maximum retained.
+
+### Slim agent bundles (default)
+
+- Env **`CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES`**:
+  - unset / false → **slim** (default): skip Codex `afterPack` copy; strip Claude `claude-agent-sdk-*` packages from runtime + packaged app.
+  - `1` / `true` → full offline Claude+Codex bundle (old behavior; ~350–400 MB installers).
+
+Until Download Center wiring lands for Claude/Codex first-run install, slim packages **will not run Claude Agent / Codex sessions offline**. Product follow-up is required (see below).
+
+## Expected size after this PR (order of magnitude)
+
+| Scenario | Expected DMG/ZIP |
+| --- | ---: |
+| Hygiene only (still bundle agents) | ~300–340 MB |
+| Slim (no Claude/Codex) + hygiene + ULMO | **~90–160 MB** (depends on OCR/sharp/jieba still embedded) |
+| Slim + OCR on-demand + aggressive asar | **toward &lt;100 MB** (realistic goal) |
+
+Hitting a reliable **&lt;100 MB on both DMG and ZIP** needs the OCR/model optional path and a measured CI size gate, not more locale trimming.
+
+## Product follow-ups (not in this PR)
+
+1. **On-demand Claude CLI** – resolve binary via Download Center into app data; keep only `@anthropic-ai/claude-agent-sdk` JS loaders in the base package.
+2. **On-demand Codex app-server** – same; `sync-codex-runtime` already knows how to download releases; gate install on first Codex session.
+3. **Optional OCR** – ship `@arcships/light-ocr` + model as a managed resource (~68 MB raw).
+4. **CI size budget** – fail release if `Cradle.dmg` / `Cradle-mac-arm64.zip` exceed 100 MB when `CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES` is unset.
+5. **Plugin dep audit** – `slack-conversation-bridge` alone is ~26 MB of `node_modules`; consider shared runtime deps or thinner deploys.
+
+## Commands
+
+```bash
+# Slim package (default) — measure dir then zip/dmg
+pnpm --filter @cradle/desktop pack
+du -sh apps/desktop/release/mac-arm64/Cradle.app
+ditto -c -k --sequesterRsrc --keepParent \
+  apps/desktop/release/mac-arm64/Cradle.app /tmp/Cradle-slim.zip
+ls -lh /tmp/Cradle-slim.zip
+
+# Full offline agents (old size)
+CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES=1 pnpm --filter @cradle/desktop dist:mac
+
+# Installer DMG with max compression
+node installer/build-dmg.mjs --app apps/desktop/release/mac-arm64/Cradle.app
+```
+
+## References
+
+- electron-builder `compression`, `electronLanguages`, `afterPack`
+- hdiutil formats: ULMO (LZMA) &gt; UDZO zlib-9 for download size
+- Industry empty Electron shell ≈ 80 MB compressed after locale strip

--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -1,8 +1,11 @@
-import fs from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import { fixMacOSFrameworkSymlinks } from './scripts/fix-macos-framework-symlinks.mjs'
+import {
+  prunePackagedApp,
+  shouldBundleAgentBinaries,
+} from './scripts/prune-packaged-app.mjs'
 import { copyCodexRuntimeToPackagedResources } from './scripts/sync-codex-runtime.mjs'
 
 const require = createRequire(import.meta.url)
@@ -17,17 +20,6 @@ const hasAppleSigningIdentity = Boolean(process.env.CSC_LINK || process.env.CSC_
 if (!hasAppleSigningIdentity) {
   process.env.CSC_IDENTITY_AUTO_DISCOVERY = 'false'
 }
-
-const keepElectronFrameworkLocales = new Set([
-  'en',
-  'en_GB',
-  'en-US',
-  'en_US',
-  'es',
-  'ja',
-  'zh_CN',
-  'zh_TW',
-])
 
 function getPublishConfig() {
   if (!updateServerUrl) {
@@ -103,55 +95,6 @@ function loadSparkleBuilderFragments() {
 
 const sparkle = loadSparkleBuilderFragments()
 
-async function removeUnusedMacFrameworkLocales(context) {
-  if (!['darwin', 'mas'].includes(context.electronPlatformName)) {
-    return
-  }
-
-  const frameworkResources = path.join(
-    context.appOutDir,
-    `${context.packager.appInfo.productFilename}.app`,
-    'Contents',
-    'Frameworks',
-    'Electron Framework.framework',
-    'Versions',
-    'A',
-    'Resources',
-  )
-
-  let entries
-  try {
-    entries = await fs.readdir(frameworkResources)
-  }
-  catch {
-    return
-  }
-
-  let removed = false
-  await Promise.all(
-    entries.map(async (entry) => {
-      if (!entry.endsWith('.lproj')) {
-        return
-      }
-
-      const locale = entry.slice(0, -'.lproj'.length)
-      if (keepElectronFrameworkLocales.has(locale)) {
-        return
-      }
-
-      await fs.rm(path.join(frameworkResources, entry), { recursive: true, force: true })
-      removed = true
-    }),
-  )
-
-  if (removed) {
-    // Remove stale code signature so electron-builder regenerates it during re-signing.
-    // _CodeSignature lives at Electron Framework.framework/_CodeSignature (3 levels above Resources).
-    const frameworkRoot = path.resolve(frameworkResources, '..', '..', '..')
-    await fs.rm(path.join(frameworkRoot, '_CodeSignature'), { recursive: true, force: true }).catch(() => {})
-  }
-}
-
 async function adHocSignAfterPack(context) {
   try {
     const builder = await import('electron-sparkle-updater/builder')
@@ -165,8 +108,20 @@ async function adHocSignAfterPack(context) {
 }
 
 async function afterPack(context) {
-  await copyCodexRuntimeToPackagedResources(context)
-  await removeUnusedMacFrameworkLocales(context)
+  // Codex app-server alone is ~200MB; only embed when offline agent bundles are requested.
+  if (shouldBundleAgentBinaries()) {
+    await copyCodexRuntimeToPackagedResources(context)
+  }
+  else {
+    console.warn(
+      '[desktop] Skipping bundled Codex runtime (slim package). '
+      + 'Set CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES=1 to embed it.',
+    )
+  }
+
+  // Locale/pak/ffmpeg/agent-binary strip before any re-sign.
+  await prunePackagedApp(context)
+
   if (['darwin', 'mas'].includes(context.electronPlatformName)) {
     const appPath = path.join(
       context.appOutDir,
@@ -208,6 +163,9 @@ const config = {
   ],
 
   compression: 'maximum',
+  // Keep only Chromium chrome locales that match product languages. electron-builder
+  // strips locales/*.pak on supported targets; afterPack also hard-prunes leftovers.
+  electronLanguages: ['en-US', 'en-GB', 'es', 'ja', 'zh-CN', 'zh-TW'],
   detectUpdateChannel: true,
   generateUpdatesFilesForAllChannels: true,
   npmRebuild: false,
@@ -227,6 +185,8 @@ const config = {
     // loader can require native/build/Release/sparkle_bridge.node from asar.unpacked.
     'node_modules/electron-sparkle-updater/**/*',
     '!node_modules/electron-sparkle-updater/node_modules',
+    '!node_modules/electron-sparkle-updater/**/*.{md,ts,map}',
+    '!node_modules/electron-sparkle-updater/**/{test,tests,__tests__,docs}/**',
     ...(Array.isArray(sparkle.files) ? sparkle.files : []),
   ],
 
@@ -307,7 +267,13 @@ const config = {
 
   dmg: {
     ...(sparkle.dmg ?? {}),
+    // UDZO is the strongest widely-compatible hdiutil format electron-builder
+    // supports natively. Installer build-dmg.mjs further converts to ULMO (LZMA).
+    format: 'UDZO',
   },
+
+  // Note: electron-builder 26.x has no top-level `zip` schema key (validation fails).
+  // ZIP compression follows global `compression: 'maximum'`. Installer DMG uses ULMO.
 
   win: {
     target: [

--- a/apps/desktop/scripts/README.md
+++ b/apps/desktop/scripts/README.md
@@ -5,7 +5,8 @@
 - **set-version.mjs**: Writes the desktop package version before release packaging.
 - **build-mac-bridge.mjs**: Builds the Swift Mac Bridge binary for packaging.
 - **fix-macos-framework-symlinks.mjs**: Rewrites absolute Electron framework symlinks after pack.
-- **sync-codex-runtime.mjs**: Copies Codex runtime assets into packaged resources.
+- **sync-codex-runtime.mjs**: Copies Codex runtime assets into packaged resources (skipped unless `CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES=1`).
+- **prune-packaged-app.mjs**: afterPack size prune — Chromium locales/lproj, optional ffmpeg/swiftshader, slim Claude/Codex agent binaries. See `docs/package-size.md`.
 - **verify-macos-distribution-credentials.mjs**: Optional Developer ID credential checks.
 
 ## Sparkle update packaging notes

--- a/apps/desktop/scripts/prune-packaged-app.mjs
+++ b/apps/desktop/scripts/prune-packaged-app.mjs
@@ -1,0 +1,313 @@
+/**
+ * Post-pack size pruning for Cradle desktop.
+ * Removes Chromium locales/lproj bloat and optional heavy vendor binaries so
+ * compressed DMG/ZIP can approach the product size budget.
+ */
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+/** Locales retained inside Electron Framework *.lproj / locales/*.pak */
+export const KEEP_ELECTRON_LOCALES = new Set([
+  'en',
+  'en_GB',
+  'en-GB',
+  'en-US',
+  'en_US',
+  'es',
+  'ja',
+  'zh_CN',
+  'zh-CN',
+  'zh_TW',
+  'zh-TW',
+  'zh-Hans',
+  'zh_Hans',
+  'zh-Hant',
+  'zh_Hant',
+])
+
+/**
+ * When true (default), omit huge first-party agent binaries from the package.
+ * Claude Agent SDK ships a ~230MB native CLI; Codex app-server is ~200MB.
+ * Both compress poorly relative to the <100MB installer goal and should be
+ * delivered on demand (Download Center) rather than baked into every DMG/ZIP.
+ *
+ * Opt back into full offline bundles with CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES=1.
+ */
+export function shouldBundleAgentBinaries() {
+  const raw = process.env.CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES?.trim().toLowerCase()
+  if (!raw) {
+    // Slim by default: base installer must stay downloadable.
+    return false
+  }
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on'
+}
+
+function isKeptLocale(localeName) {
+  if (KEEP_ELECTRON_LOCALES.has(localeName)) {
+    return true
+  }
+  // Gender/case variants (en_FEMININE.lproj) are never needed for Chromium chrome strings.
+  const base = localeName.split('_')[0]?.split('-')[0]
+  return base ? KEEP_ELECTRON_LOCALES.has(base) && !/[_-](FEMININE|MASCULINE|NEUTER)$/i.test(localeName) : false
+}
+
+export async function removeUnusedMacFrameworkLocales(context) {
+  if (!['darwin', 'mas'].includes(context.electronPlatformName)) {
+    return { removed: 0 }
+  }
+
+  const frameworkResources = path.join(
+    context.appOutDir,
+    `${context.packager.appInfo.productFilename}.app`,
+    'Contents',
+    'Frameworks',
+    'Electron Framework.framework',
+    'Versions',
+    'A',
+    'Resources',
+  )
+
+  let entries
+  try {
+    entries = await fs.readdir(frameworkResources)
+  }
+  catch {
+    return { removed: 0 }
+  }
+
+  let removed = 0
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.endsWith('.lproj')) {
+        return
+      }
+      const locale = entry.slice(0, -'.lproj'.length)
+      if (isKeptLocale(locale)) {
+        return
+      }
+      await fs.rm(path.join(frameworkResources, entry), { recursive: true, force: true })
+      removed += 1
+    }),
+  )
+
+  if (removed > 0) {
+    // Stale signature under the framework must be cleared so re-sign can succeed.
+    const frameworkRoot = path.resolve(frameworkResources, '..', '..', '..')
+    await fs.rm(path.join(frameworkRoot, '_CodeSignature'), { recursive: true, force: true }).catch(() => {})
+  }
+
+  return { removed }
+}
+
+/**
+ * Strip Chromium locale packs on Windows/Linux (and macOS app Resources/locales if present).
+ */
+export async function removeUnusedChromiumLocalePaks(context) {
+  const platform = context.electronPlatformName
+  const candidates = []
+
+  if (platform === 'darwin' || platform === 'mas') {
+    const appRoot = path.join(
+      context.appOutDir,
+      `${context.packager.appInfo.productFilename}.app`,
+      'Contents',
+    )
+    candidates.push(path.join(appRoot, 'Frameworks', 'Electron Framework.framework', 'Versions', 'A', 'Resources', 'locales'))
+    candidates.push(path.join(appRoot, 'Resources', 'locales'))
+  }
+  else {
+    candidates.push(path.join(context.appOutDir, 'locales'))
+    candidates.push(path.join(context.appOutDir, 'resources', 'locales'))
+  }
+
+  let removed = 0
+  for (const localesDir of candidates) {
+    let entries
+    try {
+      entries = await fs.readdir(localesDir)
+    }
+    catch {
+      continue
+    }
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (!entry.endsWith('.pak')) {
+          return
+        }
+        const locale = entry.slice(0, -'.pak'.length)
+        if (isKeptLocale(locale)) {
+          return
+        }
+        await fs.rm(path.join(localesDir, entry), { force: true })
+        removed += 1
+      }),
+    )
+  }
+
+  return { removed }
+}
+
+/**
+ * Optional Chromium media/GPU helpers that Cradle does not require for core UI.
+ * ffmpeg is only needed for HTML5 media decode; swiftshader is a software Vulkan fallback.
+ * Removing them saves ~10–20MB uncompressed; re-sign is required on macOS after.
+ */
+export async function removeOptionalChromiumLibraries(context) {
+  const platform = context.electronPlatformName
+  const removed = []
+
+  const targets = []
+  if (platform === 'darwin' || platform === 'mas') {
+    const libraries = path.join(
+      context.appOutDir,
+      `${context.packager.appInfo.productFilename}.app`,
+      'Contents',
+      'Frameworks',
+      'Electron Framework.framework',
+      'Versions',
+      'A',
+      'Libraries',
+    )
+    targets.push(
+      path.join(libraries, 'libffmpeg.dylib'),
+      path.join(libraries, 'libvk_swiftshader.dylib'),
+      path.join(libraries, 'vk_swiftshader_icd.json'),
+    )
+  }
+  else if (platform === 'win32') {
+    targets.push(
+      path.join(context.appOutDir, 'ffmpeg.dll'),
+      path.join(context.appOutDir, 'vk_swiftshader.dll'),
+      path.join(context.appOutDir, 'vk_swiftshader_icd.json'),
+      path.join(context.appOutDir, 'vulkan-1.dll'),
+    )
+  }
+  else if (platform === 'linux') {
+    targets.push(
+      path.join(context.appOutDir, 'libffmpeg.so'),
+      path.join(context.appOutDir, 'libvk_swiftshader.so'),
+      path.join(context.appOutDir, 'vk_swiftshader_icd.json'),
+    )
+  }
+
+  for (const target of targets) {
+    try {
+      await fs.rm(target, { force: true })
+      removed.push(target)
+    }
+    catch {
+      // absent is fine
+    }
+  }
+
+  if (removed.length > 0 && (platform === 'darwin' || platform === 'mas')) {
+    const frameworkRoot = path.join(
+      context.appOutDir,
+      `${context.packager.appInfo.productFilename}.app`,
+      'Contents',
+      'Frameworks',
+      'Electron Framework.framework',
+    )
+    await fs.rm(path.join(frameworkRoot, '_CodeSignature'), { recursive: true, force: true }).catch(() => {})
+  }
+
+  return { removed }
+}
+
+function packagedResourcesDir(context) {
+  if (context.electronPlatformName === 'darwin' || context.electronPlatformName === 'mas') {
+    return path.join(
+      context.appOutDir,
+      `${context.packager.appInfo.productFilename}.app`,
+      'Contents',
+      'Resources',
+    )
+  }
+  return path.join(context.appOutDir, 'resources')
+}
+
+/**
+ * Drop Claude Agent SDK platform packages (~230MB CLI) and any leftover Codex CLI
+ * from the packaged server runtime when slim packaging is active.
+ */
+export async function removeUnbundledAgentBinaries(context) {
+  if (shouldBundleAgentBinaries()) {
+    return { removed: [] }
+  }
+
+  const resourcesDir = packagedResourcesDir(context)
+  const removed = []
+  const candidates = [
+    // Codex app-server (afterPack may skip copy; also scrub any residual full CLI)
+    path.join(resourcesDir, 'codex'),
+    path.join(resourcesDir, 'codex.exe'),
+    path.join(resourcesDir, 'codex-app-server'),
+    path.join(resourcesDir, 'codex-app-server.exe'),
+    // Claude Agent SDK optionalDependencies land under server/node_modules
+    path.join(resourcesDir, 'server', 'node_modules', '@anthropic-ai', 'claude-agent-sdk-darwin-arm64'),
+    path.join(resourcesDir, 'server', 'node_modules', '@anthropic-ai', 'claude-agent-sdk-darwin-x64'),
+    path.join(resourcesDir, 'server', 'node_modules', '@anthropic-ai', 'claude-agent-sdk-win32-x64'),
+    path.join(resourcesDir, 'server', 'node_modules', '@anthropic-ai', 'claude-agent-sdk-win32-arm64'),
+    path.join(resourcesDir, 'server', 'node_modules', '@anthropic-ai', 'claude-agent-sdk-linux-x64'),
+    path.join(resourcesDir, 'server', 'node_modules', '@anthropic-ai', 'claude-agent-sdk-linux-arm64'),
+    path.join(resourcesDir, 'server', 'node_modules', '@anthropic-ai', 'claude-agent-sdk-linux-x64-musl'),
+    path.join(resourcesDir, 'server', 'node_modules', '@anthropic-ai', 'claude-agent-sdk-linux-arm64-musl'),
+  ]
+
+  // Also scrub pnpm virtual store copies if present
+  const serverNodeModules = path.join(resourcesDir, 'server', 'node_modules')
+  try {
+    const top = await fs.readdir(serverNodeModules)
+    for (const entry of top) {
+      if (entry.startsWith('claude-agent-sdk-') || entry.includes('claude-agent-sdk-')) {
+        candidates.push(path.join(serverNodeModules, entry))
+      }
+    }
+    const pnpmDir = path.join(serverNodeModules, '.pnpm')
+    const pnpmEntries = await fs.readdir(pnpmDir).catch(() => [])
+    for (const entry of pnpmEntries) {
+      if (entry.includes('claude-agent-sdk-darwin')
+        || entry.includes('claude-agent-sdk-win32')
+        || entry.includes('claude-agent-sdk-linux')) {
+        candidates.push(path.join(pnpmDir, entry))
+      }
+    }
+  }
+  catch {
+    // server runtime may be missing in partial packs
+  }
+
+  for (const target of candidates) {
+    try {
+      await fs.rm(target, { recursive: true, force: true })
+      removed.push(target)
+    }
+    catch {
+      // ignore
+    }
+  }
+
+  if (removed.length > 0) {
+    console.warn(
+      `[desktop] Slim package: removed ${removed.length} agent binary path(s). `
+      + 'Set CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES=1 for offline Claude/Codex bundles.',
+    )
+  }
+
+  return { removed }
+}
+
+export async function prunePackagedApp(context) {
+  const lproj = await removeUnusedMacFrameworkLocales(context)
+  const paks = await removeUnusedChromiumLocalePaks(context)
+  const libs = await removeOptionalChromiumLibraries(context)
+  const agents = await removeUnbundledAgentBinaries(context)
+
+  console.warn(
+    `[desktop] Size prune: lproj=${lproj.removed} pak=${paks.removed} `
+    + `chromiumLibs=${libs.removed.length} agentPaths=${agents.removed.length}`,
+  )
+
+  return { lproj, paks, libs, agents }
+}

--- a/apps/server/scripts/rebuild-electron-runtime.mjs
+++ b/apps/server/scripts/rebuild-electron-runtime.mjs
@@ -125,6 +125,8 @@ function pruneElectronRuntimeArtifact() {
   pruneGptTokenizer(pruned)
   pruneTypeScriptPeer(pruned)
   pruneCradleDbDuplicateMigrations(pruned)
+  pruneClaudeAgentSdkPlatformBinaries(pruned)
+  pruneAnthropicSdkSources(pruned)
 
   writeElectronRuntimePruneManifest(pruned)
 }
@@ -137,6 +139,11 @@ function removeMatchingFiles(root, patterns, pruned) {
   for (const entry of readdirSync(root, { withFileTypes: true })) {
     const entryPath = join(root, entry.name)
     if (entry.isDirectory()) {
+      // Skip nested node_modules traversal noise; we still walk package trees via
+      // resolvePackageRoots. Nested modules are visited when their own root is listed.
+      if (entry.name === 'node_modules' || entry.name === '.bin') {
+        continue
+      }
       removeMatchingFiles(entryPath, patterns, pruned)
       continue
     }
@@ -147,92 +154,156 @@ function removeMatchingFiles(root, patterns, pruned) {
   }
 }
 
-function pruneNodePty(pruned) {
-  const packageDir = findPnpmPackageDir('node-pty@')
-  if (!packageDir) {
-    return
+/**
+ * Resolve a package directory under either hoisted node_modules or .pnpm virtual store.
+ * prepare-desktop-runtime uses --config.node-linker=hoisted, so most packages live at
+ * node_modules/<name> rather than node_modules/.pnpm/<name@ver>/node_modules/<name>.
+ */
+function resolvePackageRoots(packageName) {
+  const roots = []
+  const topLevel = join(serverRuntimeNodeModules, ...packageName.split('/'))
+  if (existsSync(topLevel)) {
+    roots.push(topLevel)
   }
 
-  const prebuildsDir = join(packageDir, 'node_modules/node-pty/prebuilds')
-  const targetPrebuild = `${process.platform}-${targetArch}`
-  if (existsSync(prebuildsDir)) {
-    for (const entry of readdirSync(prebuildsDir, { withFileTypes: true })) {
-      if (entry.isDirectory() && entry.name !== targetPrebuild) {
-        removePath(join(prebuildsDir, entry.name), pruned)
+  const pnpmDir = join(serverRuntimeNodeModules, '.pnpm')
+  if (existsSync(pnpmDir)) {
+    const escaped = packageName.startsWith('@')
+      ? packageName.replace('/', '+')
+      : packageName
+    for (const entry of readdirSync(pnpmDir)) {
+      if (!entry.startsWith(`${escaped}@`) && !entry.startsWith(`${packageName}@`)) {
+        continue
+      }
+      const nested = join(pnpmDir, entry, 'node_modules', ...packageName.split('/'))
+      if (existsSync(nested)) {
+        roots.push(nested)
+      }
+    }
+  }
+
+  return roots
+}
+
+function pruneNodePty(pruned) {
+  for (const packageDir of resolvePackageRoots('node-pty')) {
+    const prebuildsDir = join(packageDir, 'prebuilds')
+    const targetPrebuild = `${process.platform}-${targetArch}`
+    if (existsSync(prebuildsDir)) {
+      for (const entry of readdirSync(prebuildsDir, { withFileTypes: true })) {
+        if (entry.isDirectory() && entry.name !== targetPrebuild) {
+          removePath(join(prebuildsDir, entry.name), pruned)
+        }
       }
     }
   }
 }
 
 function pruneBetterSqlite3(pruned) {
-  const packageDir = findPnpmPackageDir('better-sqlite3@')
-  if (!packageDir) {
-    return
-  }
-
-  const betterSqliteDir = join(packageDir, 'node_modules/better-sqlite3')
-  for (const relativePath of [
-    'bin',
-    'deps',
-    'src',
-    'build/Makefile',
-    'build/better_sqlite3.target.mk',
-    'build/binding.Makefile',
-    'build/config.gypi',
-    'build/deps',
-    'build/gyp-mac-tool',
-    'build/test_extension.target.mk',
-    'build/Release/.deps',
-    'build/Release/obj',
-    'build/Release/obj.target',
-    'build/Release/sqlite3.a',
-    'build/Release/test_extension.node',
-  ]) {
-    removePath(join(betterSqliteDir, relativePath), pruned)
+  for (const betterSqliteDir of resolvePackageRoots('better-sqlite3')) {
+    // Keep only the runtime .node + JS loader. Build intermediates and SQLite
+    // amalgamation sources routinely add ~25MB and are never loaded at runtime.
+    for (const relativePath of [
+      'bin',
+      'deps',
+      'src',
+      'build/Makefile',
+      'build/better_sqlite3.target.mk',
+      'build/binding.Makefile',
+      'build/config.gypi',
+      'build/deps',
+      'build/gyp-mac-tool',
+      'build/test_extension.target.mk',
+      'build/Release/.deps',
+      'build/Release/obj',
+      'build/Release/obj.target',
+      'build/Release/obj/gen',
+      'build/Release/sqlite3.a',
+      'build/Release/test_extension.node',
+      'binding.gyp',
+    ]) {
+      removePath(join(betterSqliteDir, relativePath), pruned)
+    }
   }
 }
 
 function pruneTypeScriptPeer(pruned) {
-  const packageDir = findPnpmPackageDir('typescript@')
-  if (!packageDir) {
-    return
+  for (const packageDir of resolvePackageRoots('typescript')) {
+    removePath(packageDir, pruned)
   }
-
-  removePath(join(packageDir, 'node_modules/typescript'), pruned)
 }
 
 function pruneCradleDbDuplicateMigrations(pruned) {
-  const packageDir = findPnpmPackageDir('@cradle+db@')
-  if (!packageDir) {
-    return
+  for (const packageDir of resolvePackageRoots('@cradle/db')) {
+    removePath(join(packageDir, 'drizzle'), pruned)
   }
-
-  removePath(join(packageDir, 'node_modules/@cradle/db/drizzle'), pruned)
 }
 
 function pruneGptTokenizer(pruned) {
-  const packageDir = findPnpmPackageDir('gpt-tokenizer@')
-  if (!packageDir) {
-    return
-  }
-
-  const tokenizerDir = join(packageDir, 'node_modules/gpt-tokenizer')
-  for (const relativePath of [
-    'dist',
-    'src',
-  ]) {
-    removePath(join(tokenizerDir, relativePath), pruned)
+  for (const tokenizerDir of resolvePackageRoots('gpt-tokenizer')) {
+    for (const relativePath of [
+      'dist',
+      'src',
+    ]) {
+      removePath(join(tokenizerDir, relativePath), pruned)
+    }
   }
 }
 
-function findPnpmPackageDir(prefix) {
-  const pnpmDir = join(serverRuntimeNodeModules, '.pnpm')
-  if (!existsSync(pnpmDir)) {
-    return null
-  }
+/**
+ * Claude Agent SDK optionalDependencies ship a ~230MB native `claude` CLI per
+ * platform. Slim desktop packages omit them (Download Center later); full offline
+ * bundles keep only the host platform package.
+ */
+function pruneClaudeAgentSdkPlatformBinaries(pruned) {
+  const bundleAgents = ['1', 'true', 'yes', 'on'].includes(
+    (process.env.CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES ?? '').trim().toLowerCase(),
+  )
+  const hostPackage = `@anthropic-ai/claude-agent-sdk-${process.platform}-${targetArch}`
+  const platformPackages = [
+    '@anthropic-ai/claude-agent-sdk-darwin-arm64',
+    '@anthropic-ai/claude-agent-sdk-darwin-x64',
+    '@anthropic-ai/claude-agent-sdk-win32-x64',
+    '@anthropic-ai/claude-agent-sdk-win32-arm64',
+    '@anthropic-ai/claude-agent-sdk-linux-x64',
+    '@anthropic-ai/claude-agent-sdk-linux-arm64',
+    '@anthropic-ai/claude-agent-sdk-linux-x64-musl',
+    '@anthropic-ai/claude-agent-sdk-linux-arm64-musl',
+  ]
 
-  const packageEntry = readdirSync(pnpmDir).find(entry => entry.startsWith(prefix))
-  return packageEntry ? join(pnpmDir, packageEntry) : null
+  for (const packageName of platformPackages) {
+    if (bundleAgents && packageName === hostPackage) {
+      continue
+    }
+    for (const root of resolvePackageRoots(packageName)) {
+      removePath(root, pruned)
+    }
+    // Top-level scoped dir may remain empty after package removal
+    removePath(join(serverRuntimeNodeModules, ...packageName.split('/')), pruned)
+  }
+}
+
+/** Anthropic JS SDK ships src/ + .d.ts trees that are never executed at runtime. */
+function pruneAnthropicSdkSources(pruned) {
+  for (const packageDir of resolvePackageRoots('@anthropic-ai/sdk')) {
+    for (const relativePath of ['src', '.github']) {
+      removePath(join(packageDir, relativePath), pruned)
+    }
+  }
+  for (const packageDir of resolvePackageRoots('@anthropic-ai/claude-agent-sdk')) {
+    // Keep only the JS loaders; type defs / browser bundle are not needed in Electron server.
+    for (const relativePath of [
+      'browser-sdk.js',
+      'browser-sdk.d.ts',
+      'sdk.d.ts',
+      'bridge.d.ts',
+      'agentSdkTypes.d.ts',
+      'sdk-tools.d.ts',
+      'extractFromBunfs.d.ts',
+    ]) {
+      removePath(join(packageDir, relativePath), pruned)
+    }
+  }
 }
 
 function removePath(pathToRemove, pruned) {

--- a/installer/build-dmg.mjs
+++ b/installer/build-dmg.mjs
@@ -243,9 +243,10 @@ async function main() {
       { format: 'ULMO', args: ['-format', 'ULMO'] },
       { format: 'UDZO', args: ['-format', 'UDZO', '-imagekey', 'zlib-level=9'] },
     ]
-    let convertErr
+    let convertErr = null
     let usedFormat = null
-    formatLoop: for (const candidate of preferredFormats) {
+    for (const candidate of preferredFormats) {
+      convertErr = null
       for (let attempt = 1; attempt <= 3; attempt++) {
         try {
           execFileSync(
@@ -255,7 +256,7 @@ async function main() {
           )
           convertErr = null
           usedFormat = candidate.format
-          break formatLoop
+          break
         }
         catch (err) {
           convertErr = err
@@ -268,6 +269,9 @@ async function main() {
             execFileSync('/bin/sleep', ['2'])
           }
         }
+      }
+      if (usedFormat) {
+        break
       }
     }
     if (convertErr) { throw convertErr }

--- a/installer/build-dmg.mjs
+++ b/installer/build-dmg.mjs
@@ -235,28 +235,44 @@ async function main() {
     try { execFileSync('/bin/sync', { stdio: 'ignore' }) }
  catch {}
 
+    // Prefer ULMO (LZMA) for smallest download size on modern macOS; fall back to
+    // UDZO zlib-level=9 when ULMO is unavailable. Both beat default UDZO.
     // hdiutil convert can transiently fail on CI runners when a prior detach
     // hasn't fully released the image.  Retry up to 3 times with a short delay.
+    const preferredFormats = [
+      { format: 'ULMO', args: ['-format', 'ULMO'] },
+      { format: 'UDZO', args: ['-format', 'UDZO', '-imagekey', 'zlib-level=9'] },
+    ]
     let convertErr
-    for (let attempt = 1; attempt <= 3; attempt++) {
-      try {
-        execFileSync('/usr/bin/hdiutil', ['convert', rwDmg, '-format', 'UDZO', '-o', outputAbs], { stdio: 'pipe' })
-        convertErr = null
-        break
-      }
- catch (err) {
-        convertErr = err
-        const stderr = err.stderr?.toString?.() ?? ''
-        console.error(`hdiutil convert attempt ${attempt} failed${stderr ? `: ${stderr.trim()}` : ''}`)
-        if (attempt < 3) {
-          // Wait before retrying — gives APFS time to release the image
-          execFileSync('/bin/sleep', ['2'])
+    let usedFormat = null
+    formatLoop: for (const candidate of preferredFormats) {
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+          execFileSync(
+            '/usr/bin/hdiutil',
+            ['convert', rwDmg, ...candidate.args, '-o', outputAbs],
+            { stdio: 'pipe' },
+          )
+          convertErr = null
+          usedFormat = candidate.format
+          break formatLoop
+        }
+        catch (err) {
+          convertErr = err
+          const stderr = err.stderr?.toString?.() ?? ''
+          console.error(
+            `hdiutil convert ${candidate.format} attempt ${attempt} failed${stderr ? `: ${stderr.trim()}` : ''}`,
+          )
+          if (attempt < 3) {
+            // Wait before retrying — gives APFS time to release the image
+            execFileSync('/bin/sleep', ['2'])
+          }
         }
       }
     }
     if (convertErr) { throw convertErr }
 
-    console.log(`Wrote ${outputAbs}`)
+    console.log(`Wrote ${outputAbs} (format=${usedFormat})`)
   }
  finally {
     if (!args.keepStage) {

--- a/installer/build-dmg.sh
+++ b/installer/build-dmg.sh
@@ -204,19 +204,32 @@ stage_payload() {
 
 create_dmg() {
   local output_abs
+  local format_used="UDZO"
 
   output_abs="$(resolve_path "$OUTPUT_PATH")"
   /bin/mkdir -p "$(dirname "$output_abs")"
   /bin/rm -f "$output_abs"
 
-  /usr/bin/hdiutil create \
+  # Prefer ULMO (LZMA) for smallest download size; fall back to max zlib UDZO.
+  if /usr/bin/hdiutil create \
     -volname "$VOLUME_NAME" \
     -srcfolder "$STAGE_DIR" \
     -ov \
-    -format UDZO \
-    "$output_abs" >/dev/null
+    -format ULMO \
+    "$output_abs" >/dev/null 2>&1; then
+    format_used="ULMO"
+  else
+    /bin/rm -f "$output_abs"
+    /usr/bin/hdiutil create \
+      -volname "$VOLUME_NAME" \
+      -srcfolder "$STAGE_DIR" \
+      -ov \
+      -format UDZO \
+      -imagekey zlib-level=9 \
+      "$output_abs" >/dev/null
+  fi
 
-  printf 'Wrote %s\n' "$output_abs"
+  printf 'Wrote %s (format=%s)\n' "$output_abs" "$format_used"
 }
 
 main() {


### PR DESCRIPTION
## Summary
## Research conclusion

Current release artifacts are ~360–393MB compressed. Locale/lproj cleanup alone cannot hit 100MB.

**Dominant cost (raw):**
- Claude Agent SDK native CLI ~230MB
- Codex app-server ~207MB (full CLI ~248MB)
- Electron Framework ~273MB (of which ~47MB lproj)
- OCR stack ~68MB, better-sqlite3 build leftovers ~25MB, plugin deps ~28MB

Claude+Codex alone compress to ~200MB+ even with max zlib. **&lt;100MB requires not shipping agent binaries in the base installer.**

Measured: afterPack locale+ffmpeg prune saves **~60.6MB** on Electron.app (272→212MB).

## This PR

1. `prune-packaged-app.mjs` + expanded afterPack: lproj/pak, ffmpeg/swiftshader, slim agent scrub
2. `electronLanguages` for builder-level locale strip
3. Fix `rebuild-electron-runtime` prune on **hoisted** node_modules; drop Claude platform packages by default; strip SDK sources
4. Default slim packaging: skip Codex afterPack copy unless `CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES=1`
5. Installer DMG: prefer ULMO (LZMA), fallback UDZO zlib-9 (no labeled breaks — eslint clean)
6. Docs: `apps/desktop/docs/package-size.md`

## Follow-ups for reliable &lt;100MB

On-demand Claude/Codex via Download Center, optional OCR package, CI size gate.

## Test plan
- `node --check` on all edited mjs scripts
- Simulated prune on Electron 42.4.1 Framework: 213 lproj removed, 3 libs, −60.6MB
- Config: no invalid top-level `zip` key; `electronLanguages` + `dmg.format` valid in app-builder-lib 26.15
- Lint fix: installer convert loop uses plain nested loops (no `no-labels`)
- Full pack not run in worktree without node_modules; verify with pack + ditto zip + installer DMG ULMO log
- Slim app: Claude/Codex offline sessions expected to need on-demand install follow-up
- `CRADLE_DESKTOP_BUNDLE_AGENT_BINARIES=1` restores offline agents

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)