### PR TITLE
feat(usage): add Claude provider-event ledger

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -23,6 +23,7 @@ import {
 } from './modules/chat-runtime/http/events.routes'
 import { linkedChatSessionProxyPlugin } from './modules/chat-runtime/http/linked-session-proxy'
 import { registerTurnCheckpointHooks } from './modules/chat-runtime/turn-checkpoint-hooks'
+import { ClaudeUsageReconciliationScheduler } from './modules/chat-runtime-providers/claude-agent/usage-reconciliation-scheduler'
 import { createOpencodeManagedResourceAdapter } from './modules/chat-runtime-providers/opencode/managed-resource-adapter'
 import { OpencodeRuntimeInstallationService } from './modules/chat-runtime-providers/opencode/runtime-installation'
 import { createChronicleModule } from './modules/chronicle'
@@ -342,6 +343,7 @@ export async function createServerApp(options: CreateServerAppOptions = {}) {
   reconcileExternalIssueSourceRegistrations()
 
   const runtimeResources = new RuntimeResourceRegistry()
+  const claudeUsageReconciliation = new ClaudeUsageReconciliationScheduler()
   const codexUsageReconciliation = new CodexUsageReconciliationScheduler()
   const runSnapshotMaintenance = new RunSnapshotMaintenanceScheduler()
   runtimeResources.register({
@@ -364,6 +366,11 @@ export async function createServerApp(options: CreateServerAppOptions = {}) {
     name: 'opencode-runtime-installation',
     phase: 'drain',
     stop: () => opencodeRuntimeInstallationService.shutdown(),
+  })
+  runtimeResources.register({
+    name: 'claude-usage-reconciliation',
+    phase: 'cancel',
+    stop: () => claudeUsageReconciliation.stop(),
   })
   runtimeResources.register({
     name: 'codex-usage-reconciliation',
@@ -430,6 +437,7 @@ export async function createServerApp(options: CreateServerAppOptions = {}) {
 
   // Start chronicle daemon if enabled
   if (startBackgroundTasks) {
+    claudeUsageReconciliation.start()
     codexUsageReconciliation.start()
     runSnapshotMaintenance.start()
     BackgroundJobPoller.start()

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.test.ts
@@ -5093,7 +5093,7 @@ describe.sequential('claudeAgentProvider MCP integration', () => {
     expect(activeQuery.getContextUsage).toHaveBeenCalledOnce()
   })
 
-  it('accumulates usage across multiple streaming messages', async () => {
+  it('emits only final assistant usage events', async () => {
     const provider = new ClaudeAgentProvider({
       readSecret: () => 'sk-ant-test',
     })
@@ -5101,70 +5101,49 @@ describe.sequential('claudeAgentProvider MCP integration', () => {
     const activeQuery = createAsyncQuery([
       {
         type: 'stream_event',
-        event: {
-          type: 'message_delta',
+        event: { type: 'message_delta', usage: { input_tokens: 100, output_tokens: 50 } },
+        session_id: 'claude-session-1',
+      },
+      {
+        type: 'assistant',
+        session_id: 'claude-session-1',
+        message: {
+          id: 'msg-final',
+          model: 'claude-opus-4-8',
+          content: [{ type: 'text', text: 'Hello' }],
           usage: { input_tokens: 100, output_tokens: 50 },
         },
-        session_id: 'claude-session-1',
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'content_block_delta',
-          index: 0,
-          delta: { type: 'text_delta', text: 'Hello' },
-        },
-        session_id: 'claude-session-1',
-      },
-      {
-        type: 'stream_event',
-        event: {
-          type: 'message_delta',
-          usage: { input_tokens: 0, output_tokens: 25 },
-        },
-        session_id: 'claude-session-1',
       },
       {
         type: 'result',
-        usage: { input_tokens: 0, output_tokens: 10 },
+        usage: { input_tokens: 100, output_tokens: 50 },
         session_id: 'claude-session-1',
       },
     ])
-
     sdkMocks.query.mockReturnValue(activeQuery)
+    const usageEvents: unknown[] = []
 
     const chunks: UIMessageChunk[] = []
     for await (const chunk of provider.streamTurn({
       runId: 'run-test',
       runtimeSession: createRuntimeSession(),
       profile: createProfile(),
-      message: {
-        id: 'user-1',
-        role: 'user',
-        parts: [{ type: 'text', text: 'Test' }],
-      },
+      message: { id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Test' }] },
       workspaceId: 'workspace-1',
+      onUsageEvent: (event) => { usageEvents.push(event) },
     })) {
       chunks.push(chunk)
     }
 
-    // lastUsage should be the most recent usage
-    expect(provider.lastUsage).toEqual({
-      promptTokens: 0,
-      completionTokens: 10,
-      totalTokens: 10,
-      cachedInputTokens: 0,
-      cacheWriteInputTokens: 0,
-    })
+    expect(chunks).toContainEqual(expect.objectContaining({ type: 'finish' }))
 
-    // totalUsage should be the sum of all usage
-    expect(provider.totalUsage).toEqual({
-      promptTokens: 100,
-      completionTokens: 85, // 50 + 25 + 10
-      totalTokens: 185,
-      cachedInputTokens: 0,
-      cacheWriteInputTokens: 0,
-      reasoningOutputTokens: 0,
-    })
+    expect(usageEvents).toEqual([
+      expect.objectContaining({
+        providerThreadId: 'claude-session-1',
+        providerTurnId: 'msg-final',
+        modelId: 'claude-opus-4-8',
+        usage: expect.objectContaining({ totalTokens: 150 }),
+      }),
+    ])
   })
 })

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.ts
@@ -71,8 +71,8 @@ import {
   mergeRuntimeSettings,
 } from '../../chat-runtime/runtime-settings'
 import { isChatStreamTraceEnabled, recordChatStreamTrace } from '../../chat-runtime/stream-trace'
-import type { TokenUsage } from '../../chat-runtime-engine/ai-sdk-engine'
 import { readTrustedClaudeAgentConfig } from '../../provider-contracts/provider-base'
+import { recordRuntimeUsageEvent } from '../../usage/ingest'
 import { AsyncEventQueue } from '../async-event-queue'
 import { createBoundedTextCollector } from '../bounded-text-collector'
 import { providerChunk } from '../kit/chunk-mapper'
@@ -159,6 +159,7 @@ import type {
   ClaudeAgentSessionInfo,
   ClaudeTitleGenerationThinkingEffort,
 } from './types'
+import { projectClaudeAssistantUsageEvent } from './usage-event-projector'
 
 type ActiveClaudeNativeFollowUp = {
   queueItemId: string
@@ -199,6 +200,7 @@ type ActiveClaudeQuery = {
   providerThreadTurns: Map<string, ActiveClaudeProviderThreadTurn>
   completedProviderThreadParentOutputIds: Set<string>
   onProviderSyntheticTurnEvent: StreamTurnInput['onProviderSyntheticTurnEvent'] | null
+  onUsageEvent: StreamTurnInput['onUsageEvent'] | null
   /** Follow-ups already pushed into the SDK input stream, waiting for a Cradle run to adopt. */
   nativeFollowUps: Map<string, ActiveClaudeNativeFollowUp>
   /** SDK messages received after a turn `result` while a native follow-up is waiting to be adopted. */
@@ -303,6 +305,7 @@ export function createClaudeAgentProvider(ctx: ProviderContext): ChatRuntime {
 
 export class ClaudeAgentProvider implements ChatRuntime {
   readonly runtimeKind = CLAUDE_AGENT_RUNTIME_KIND
+  readonly usageAccounting = 'provider-events' as const
   readonly metadata = CLAUDE_AGENT_RUNTIME_METADATA
   readonly capabilities = CLAUDE_AGENT_RUNTIME_CAPABILITIES
 
@@ -311,17 +314,6 @@ export class ClaudeAgentProvider implements ChatRuntime {
   private readonly lastContextUsageBySession = new Map<string, RuntimeContextUsage>()
   private readonly lastContextUsageSampledAtBySession = new Map<string, number>()
   private readonly activePermissionModesBySession = new Map<string, Options['permissionMode']>()
-  private _lastUsage: TokenUsage | null = null
-  private _totalUsage: TokenUsage | null = null
-
-  get lastUsage(): TokenUsage | null {
-    return this._lastUsage
-  }
-
-  get totalUsage(): TokenUsage | null {
-    return this._totalUsage
-  }
-
   constructor(private readonly deps: ClaudeAgentProviderDeps) {}
 
   private releaseQuery(sessionId: string, entry: ActiveClaudeQuery): void {
@@ -610,6 +602,7 @@ export class ClaudeAgentProvider implements ChatRuntime {
         providerThreadTurns: new Map(),
         completedProviderThreadParentOutputIds: new Set(),
         onProviderSyntheticTurnEvent: null,
+        onUsageEvent: null,
         nativeFollowUps: new Map(),
         preAdoptBuffer: [],
         closed: false,
@@ -668,11 +661,10 @@ export class ClaudeAgentProvider implements ChatRuntime {
       activeEntry.runtimeSession = input.runtimeSession
       resetClaudeAgentChunkMapperForTurn(activeEntry.mapperState)
     }
-    this._lastUsage = null
-    this._totalUsage = null
     const traceMessageId = input.responseMessageId ?? input.message.id
 
     activeEntry.onProviderSyntheticTurnEvent = input.onProviderSyntheticTurnEvent ?? null
+    activeEntry.onUsageEvent = input.onUsageEvent ?? null
     clearClaudeAgentCapturedPlan(input.runtimeSession)
 
     // Langfuse tracing via @langfuse/tracing SDK
@@ -711,13 +703,6 @@ export class ClaudeAgentProvider implements ChatRuntime {
  else {
         generation.update({
           output: outputTextCollector.read(),
-          ...(this._lastUsage && {
-            usageDetails: {
-              input: this._lastUsage.promptTokens,
-              output: this._lastUsage.completionTokens,
-              total: this._lastUsage.totalTokens,
-            },
-          }),
         })
       }
       generation.end()
@@ -905,6 +890,10 @@ export class ClaudeAgentProvider implements ChatRuntime {
     }
 
     const result = await mapClaudeAgentMessageToChunks(message, entry.mapperState)
+    if (turn) {
+      await this.updateClaudeTurnProviderSession(entry, turn, result.sessionId)
+    }
+    await this.emitClaudeAssistantUsageEvent(entry, message, turn?.effectiveModel)
     for (const plan of result.capturedPlans) {
       writeClaudeAgentCapturedPlan(entry.runtimeSession, plan)
     }
@@ -954,8 +943,6 @@ export class ClaudeAgentProvider implements ChatRuntime {
     }
 
     if (turn) {
-      await this.updateClaudeTurnProviderSession(entry, turn, result.sessionId)
-      this.updateClaudeTurnUsage(result.usage)
       for (const chunk of result.chunks) {
         if (chunk.type === 'text-delta' && 'delta' in chunk) {
           turn.outputTextCollector.append((chunk as { delta: string }).delta)
@@ -1001,6 +988,8 @@ export class ClaudeAgentProvider implements ChatRuntime {
       message,
       providerThreadTurn.mapperState,
     )
+    await this.updateClaudeTurnProviderSession(entry, turn, result.sessionId)
+    await this.emitClaudeAssistantUsageEvent(entry, message, turn.effectiveModel)
     for (const crewCall of result.capturedCrewCalls) {
       writeClaudeAgentCrewCall(entry.runtimeSession, mapCrewCallToSnapshot(crewCall))
       if (crewCall.workflow) {
@@ -1010,7 +999,6 @@ export class ClaudeAgentProvider implements ChatRuntime {
     for (const taskActivity of result.capturedTaskActivity) {
       writeClaudeAgentTaskActivity(entry.runtimeSession, taskActivity)
     }
-    this.updateClaudeTurnUsage(result.usage)
     this.publishClaudeProviderThreadEvent(turn, providerThreadTurn, result.chunks)
     if (hasTerminalProviderThreadChunk(result.chunks)) {
       this.emitClaudeProviderThreadParentOutput(entry, turn, providerThreadId, result.chunks)
@@ -1385,26 +1373,64 @@ export class ClaudeAgentProvider implements ChatRuntime {
     })
   }
 
-  private updateClaudeTurnUsage(usage: TokenUsage | null): void {
-    if (!usage) {
-      return
+  private async emitClaudeAssistantUsageEvent(
+    entry: ActiveClaudeQuery,
+    message: SDKMessage,
+    fallbackModelId: string | null | undefined,
+  ): Promise<void> {
+    let event: ReturnType<typeof projectClaudeAssistantUsageEvent>
+    try {
+      event = projectClaudeAssistantUsageEvent({
+        message,
+        fallbackModelId,
+      })
     }
-    this._lastUsage = usage
-    if (this._totalUsage) {
-      this._totalUsage = {
-        promptTokens: this._totalUsage.promptTokens + usage.promptTokens,
-        completionTokens: this._totalUsage.completionTokens + usage.completionTokens,
-        totalTokens: this._totalUsage.totalTokens + usage.totalTokens,
-        cachedInputTokens:
-          (this._totalUsage.cachedInputTokens ?? 0) + (usage.cachedInputTokens ?? 0),
-        cacheWriteInputTokens:
-          (this._totalUsage.cacheWriteInputTokens ?? 0) + (usage.cacheWriteInputTokens ?? 0),
-        reasoningOutputTokens:
-          (this._totalUsage.reasoningOutputTokens ?? 0) + (usage.reasoningOutputTokens ?? 0),
+    catch (error) {
+      if (entry.currentTurn) {
+        throw error
       }
+      this.deps.logger?.warn?.('Claude Agent ignored malformed late assistant usage event', {
+        error,
+        chatSessionId: entry.runtimeSession.chatSessionId,
+      })
       return
     }
-    this._totalUsage = { ...usage }
+    if (!event) {
+      return
+    }
+    if (entry.currentTurn && entry.onUsageEvent) {
+      await entry.onUsageEvent(event)
+      return
+    }
+
+    const providerSessionId = entry.runtimeSession.providerSessionId
+    if (!providerSessionId) {
+      this.deps.logger?.warn?.('Claude Agent late assistant usage event arrived before provider session binding', {
+        chatSessionId: entry.runtimeSession.chatSessionId,
+        providerThreadId: event.providerThreadId,
+        providerTurnId: event.providerTurnId,
+      })
+      return
+    }
+    try {
+      recordRuntimeUsageEvent({
+        event,
+        sessionId: entry.runtimeSession.chatSessionId,
+        runId: null,
+        messageId: null,
+        providerTargetId: entry.providerTargetId,
+        providerSessionId,
+      })
+    }
+    catch (error) {
+      this.deps.logger?.warn?.('Claude Agent failed to persist late assistant usage event', {
+        error,
+        chatSessionId: entry.runtimeSession.chatSessionId,
+        providerSessionId,
+        providerThreadId: event.providerThreadId,
+        providerTurnId: event.providerTurnId,
+      })
+    }
   }
 
   private closeSessionQuery(sessionId: string, entry: ActiveClaudeQuery): void {

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.ts
@@ -988,7 +988,6 @@ export class ClaudeAgentProvider implements ChatRuntime {
       message,
       providerThreadTurn.mapperState,
     )
-    await this.updateClaudeTurnProviderSession(entry, turn, result.sessionId)
     await this.emitClaudeAssistantUsageEvent(entry, message, turn.effectiveModel)
     for (const crewCall of result.capturedCrewCalls) {
       writeClaudeAgentCrewCall(entry.runtimeSession, mapCrewCallToSnapshot(crewCall))

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/usage-event-projector.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/usage-event-projector.test.ts
@@ -1,0 +1,109 @@
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk'
+import { describe, expect, it } from 'vitest'
+
+import {
+  ClaudeUsageEventProjectionError,
+  createClaudeUsageEventId,
+  projectClaudeAssistantUsageEvent,
+} from './usage-event-projector'
+
+describe('projectClaudeAssistantUsageEvent', () => {
+  it('projects a root assistant message with complete cache usage', () => {
+    const message = {
+      type: 'assistant',
+      session_id: 'session-root',
+      message: {
+        id: 'msg-root',
+        model: 'claude-opus-4-8',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_input_tokens: 40,
+          cache_creation_input_tokens: 20,
+        },
+      },
+    } as unknown as SDKMessage
+
+    expect(projectClaudeAssistantUsageEvent({
+      message,
+      fallbackModelId: null,
+      occurredAt: 123,
+    })).toEqual({
+      id: createClaudeUsageEventId('session-root', 'session-root', 'msg-root'),
+      providerThreadId: 'session-root',
+      providerTurnId: 'msg-root',
+      modelId: 'claude-opus-4-8',
+      occurredAt: 123,
+      usage: {
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+        cachedInputTokens: 40,
+        cacheWriteInputTokens: 20,
+      },
+      providerTotal: {
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+        cachedInputTokens: 40,
+        cacheWriteInputTokens: 20,
+      },
+    })
+  })
+
+  it('attributes child assistant usage to its parent tool call', () => {
+    const message = {
+      type: 'assistant',
+      session_id: 'session-root',
+      parent_tool_use_id: 'toolu_parent',
+      message: {
+        id: 'msg-child',
+        usage: { input_tokens: 4, output_tokens: 6 },
+      },
+    } as unknown as SDKMessage
+
+    const event = projectClaudeAssistantUsageEvent({
+      message,
+      fallbackModelId: 'claude-sonnet-5',
+      occurredAt: 456,
+    })
+
+    expect(event).toEqual(expect.objectContaining({
+      id: createClaudeUsageEventId('session-root', 'toolu_parent', 'msg-child'),
+      providerThreadId: 'toolu_parent',
+      providerTurnId: 'msg-child',
+      modelId: 'claude-sonnet-5',
+    }))
+  })
+
+  it('ignores non-final assistant SDK messages', () => {
+    expect(projectClaudeAssistantUsageEvent({
+      message: {
+        type: 'result',
+        session_id: 'session-root',
+        usage: { input_tokens: 4, output_tokens: 6 },
+      } as unknown as SDKMessage,
+      fallbackModelId: 'claude-sonnet-5',
+    })).toBeNull()
+  })
+
+  it('rejects missing immutable identity and nonpositive totals', () => {
+    expect(() => projectClaudeAssistantUsageEvent({
+      message: {
+        type: 'assistant',
+        session_id: 'session-root',
+        message: { usage: { input_tokens: 4, output_tokens: 6 } },
+      } as unknown as SDKMessage,
+      fallbackModelId: 'claude-sonnet-5',
+    })).toThrow(ClaudeUsageEventProjectionError)
+
+    expect(() => projectClaudeAssistantUsageEvent({
+      message: {
+        type: 'assistant',
+        session_id: 'session-root',
+        message: { id: 'msg-empty', usage: { input_tokens: 0, output_tokens: 0 } },
+      } as unknown as SDKMessage,
+      fallbackModelId: 'claude-sonnet-5',
+    })).toThrow('positive model-call total')
+  })
+})

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/usage-event-projector.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/usage-event-projector.ts
@@ -1,0 +1,89 @@
+import { createHash } from 'node:crypto'
+
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk'
+
+import type { RuntimeUsageEvent, TokenUsage } from '../../chat-runtime/runtime-provider-types'
+
+export class ClaudeUsageEventProjectionError extends Error {}
+
+type ClaudeAssistantUsage = {
+  input_tokens?: number
+  output_tokens?: number
+  cache_read_input_tokens?: number
+  cache_creation_input_tokens?: number
+}
+
+type ClaudeAssistantMessage = {
+  id?: string
+  model?: string
+  usage?: ClaudeAssistantUsage
+}
+
+type ClaudeAssistantSdkMessage = {
+  type: 'assistant'
+  session_id?: string
+  parent_tool_use_id?: string
+  message?: ClaudeAssistantMessage
+}
+
+export function projectClaudeAssistantUsageEvent(input: {
+  message: SDKMessage
+  fallbackModelId: string | null | undefined
+  occurredAt?: number
+}): RuntimeUsageEvent | null {
+  if (input.message.type !== 'assistant') {
+    return null
+  }
+
+  const message = input.message as ClaudeAssistantSdkMessage
+  const providerSessionId = message.session_id?.trim()
+  const providerTurnId = message.message?.id?.trim()
+  const modelId = message.message?.model?.trim() || input.fallbackModelId?.trim()
+  const usage = message.message?.usage
+  if (!usage) {
+    return null
+  }
+  if (!providerSessionId || !providerTurnId || !modelId) {
+    throw new ClaudeUsageEventProjectionError(
+      'Claude assistant usage is missing provider session, message, or model identity.',
+    )
+  }
+
+  const tokenUsage = toTokenUsage(usage)
+  if (tokenUsage.totalTokens <= 0) {
+    throw new ClaudeUsageEventProjectionError('Claude assistant usage does not contain a positive model-call total.')
+  }
+
+  const providerThreadId = message.parent_tool_use_id?.trim() || providerSessionId
+  return {
+    id: createClaudeUsageEventId(providerSessionId, providerThreadId, providerTurnId),
+    providerThreadId,
+    providerTurnId,
+    modelId,
+    occurredAt: input.occurredAt ?? Math.floor(Date.now() / 1000),
+    usage: tokenUsage,
+    providerTotal: tokenUsage,
+  }
+}
+
+export function createClaudeUsageEventId(
+  providerSessionId: string,
+  providerThreadId: string,
+  providerTurnId: string,
+): string {
+  return createHash('sha256')
+    .update(['claude-agent', providerSessionId, providerThreadId, providerTurnId].join(':'))
+    .digest('hex')
+}
+
+function toTokenUsage(usage: ClaudeAssistantUsage): TokenUsage {
+  const promptTokens = usage.input_tokens ?? 0
+  const completionTokens = usage.output_tokens ?? 0
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+    cachedInputTokens: usage.cache_read_input_tokens ?? 0,
+    cacheWriteInputTokens: usage.cache_creation_input_tokens ?? 0,
+  }
+}

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/usage-reconciliation-scheduler.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/usage-reconciliation-scheduler.ts
@@ -1,0 +1,58 @@
+import type { ClaudeUsageReconciliationSummary } from './usage-reconciliation'
+import { reconcileCradleClaudeUsage } from './usage-reconciliation'
+
+const PRIORITY_BINDING_LIMIT = 200
+const BACKGROUND_BINDING_LIMIT = 5
+const BACKGROUND_DELAY_MS = 5_000
+
+type ReconcileClaudeUsage = (input: { maxBindings: number }) => Promise<ClaudeUsageReconciliationSummary>
+
+export class ClaudeUsageReconciliationScheduler {
+  private activeTask: Promise<void> | null = null
+  private scheduledTask: ReturnType<typeof setTimeout> | null = null
+  private stopped = false
+
+  constructor(
+    private readonly reconcile: ReconcileClaudeUsage = reconcileCradleClaudeUsage,
+  ) {}
+
+  start(): void {
+    if (this.activeTask || this.scheduledTask || this.stopped) { return }
+    this.run(() => this.runPriorityPass())
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true
+    if (this.scheduledTask) {
+      clearTimeout(this.scheduledTask)
+      this.scheduledTask = null
+    }
+    await this.activeTask
+  }
+
+  private async runPriorityPass(): Promise<void> {
+    await this.reconcile({ maxBindings: PRIORITY_BINDING_LIMIT })
+    this.scheduleBackgroundPass()
+  }
+
+  private scheduleBackgroundPass(): void {
+    if (this.stopped || this.scheduledTask) { return }
+    this.scheduledTask = setTimeout(() => {
+      this.scheduledTask = null
+      this.run(() => this.runBackgroundPass())
+    }, BACKGROUND_DELAY_MS)
+  }
+
+  private async runBackgroundPass(): Promise<void> {
+    const summary = await this.reconcile({ maxBindings: BACKGROUND_BINDING_LIMIT })
+    if (summary.bindings > 0) { this.scheduleBackgroundPass() }
+  }
+
+  private run(task: () => Promise<void>): void {
+    this.activeTask = task().catch((error) => {
+      console.error('[claude-usage-reconciliation] Background reconciliation failed:', error)
+    }).finally(() => {
+      this.activeTask = null
+    })
+  }
+}

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/usage-reconciliation.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/usage-reconciliation.ts
@@ -1,0 +1,302 @@
+import { createReadStream, existsSync, readdirSync, realpathSync, statSync } from 'node:fs'
+import { isAbsolute, join, relative } from 'node:path'
+import { createInterface } from 'node:readline'
+
+import { backendSessionBindings, providerTargets, usageLogs } from '@cradle/db'
+import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm'
+import { z } from 'zod'
+
+import { db } from '../../../infra'
+import { createDedupeKey, OBSERVABILITY_CODES } from '../../observability/contract'
+import * as Observability from '../../observability/service'
+import { readTrustedClaudeAgentConfig } from '../../provider-contracts/provider-base'
+import type { RuntimeUsageEventContext } from '../../usage/ingest'
+import { recordRuntimeUsageEvent, replaceLegacyRuntimeUsage } from '../../usage/ingest'
+import { resolveClaudeAgentSdkConfigDir } from './runtime-context'
+import { projectClaudeAssistantUsageEvent } from './usage-event-projector'
+
+const DEFAULT_MAX_BINDINGS = 200
+
+const TranscriptRecordSchema = z.object({
+  type: z.string(),
+  sessionId: z.string().min(1).optional(),
+  parent_tool_use_id: z.string().min(1).optional(),
+  timestamp: z.string().min(1).optional(),
+  message: z.object({
+    id: z.string().min(1).optional(),
+    model: z.string().min(1).optional(),
+    usage: z.object({
+      input_tokens: z.number().int().nonnegative().optional(),
+      output_tokens: z.number().int().nonnegative().optional(),
+      cache_read_input_tokens: z.number().int().nonnegative().optional(),
+      cache_creation_input_tokens: z.number().int().nonnegative().optional(),
+    }).optional(),
+  }).passthrough().optional(),
+}).passthrough()
+
+export interface ClaudeUsageReconciliationIncident {
+  reason: string
+  path?: string
+  lineNumber?: number
+}
+
+export interface ClaudeUsageReconciliationSummary {
+  bindings: number
+  transcripts: number
+  inserted: number
+  duplicates: number
+  incidents: number
+  completed?: boolean
+}
+
+export async function reconcileClaudeSessionUsage(input: {
+  sessionId: string
+  providerSessionId: string
+  providerTargetId: string | null
+  bindingId?: string
+  runtimeHome?: string
+  replaceLegacyUsage?: boolean
+  recordIncident?: (incident: ClaudeUsageReconciliationIncident) => void
+}): Promise<ClaudeUsageReconciliationSummary> {
+  const summary = emptySummary()
+  summary.bindings = 1
+  const recordIncident = input.recordIncident ?? (incident => recordReconciliationIncident(input.sessionId, incident))
+  const runtimeHome = input.runtimeHome ?? resolveClaudeAgentSdkConfigDir()
+  const transcriptPaths = findClaudeTranscriptPaths(runtimeHome, input.providerSessionId)
+  if (transcriptPaths.length === 0) {
+    summary.incidents += 1
+    recordIncident({ reason: 'Claude usage reconciliation could not locate a Cradle-owned transcript.' })
+    markBindingReconciliation(input.bindingId, 'blocked')
+    return { ...summary, completed: false }
+  }
+
+  const events: RuntimeUsageEventContext[] = []
+  for (const path of transcriptPaths) {
+    summary.transcripts += 1
+    const result = await readClaudeTranscript({
+      path,
+      runtimeHome,
+      providerSessionId: input.providerSessionId,
+      sessionId: input.sessionId,
+      providerTargetId: input.providerTargetId,
+      recordIncident,
+    })
+    events.push(...result.events)
+    summary.incidents += result.incidents
+  }
+  if (summary.incidents > 0) {
+    markBindingReconciliation(input.bindingId, 'blocked')
+    return { ...summary, completed: false }
+  }
+  if (events.length === 0 && hasLegacyUsage(input.sessionId)) {
+    summary.incidents += 1
+    recordIncident({ reason: 'Claude usage reconciliation found no authoritative events to replace legacy usage.' })
+    markBindingReconciliation(input.bindingId, 'blocked')
+    return { ...summary, completed: false }
+  }
+
+  const persisted = input.replaceLegacyUsage
+    ? replaceLegacyRuntimeUsage({ sessionId: input.sessionId, runtimeKind: 'claude-agent', events })
+    : persistUsageEvents(events)
+  summary.inserted += persisted.inserted
+  summary.duplicates += persisted.duplicates
+  markBindingReconciliation(input.bindingId, 'completed')
+  return { ...summary, completed: true }
+}
+
+export async function reconcileCradleClaudeUsage(input: {
+  maxBindings?: number
+  runtimeHome?: string
+} = {}): Promise<ClaudeUsageReconciliationSummary> {
+  const bindings = db().select().from(backendSessionBindings).where(and(
+      eq(backendSessionBindings.runtimeKind, 'claude-agent'),
+      isNotNull(backendSessionBindings.backendSessionId),
+      eq(backendSessionBindings.usageReconciliationStatus, 'pending'),
+    )).orderBy(desc(backendSessionBindings.updatedAt)).limit(input.maxBindings ?? DEFAULT_MAX_BINDINGS).all()
+  const summary = emptySummary()
+  for (const binding of bindings) {
+    if (!binding.backendSessionId || !isApiKeyClaudeBinding(binding.providerTargetId)) {
+      markBindingReconciliation(binding.id, 'unavailable')
+      continue
+    }
+    addSummary(summary, await reconcileClaudeSessionUsage({
+      sessionId: binding.chatSessionId,
+      providerSessionId: binding.backendSessionId,
+      providerTargetId: binding.providerTargetId,
+      bindingId: binding.id,
+      runtimeHome: input.runtimeHome,
+      replaceLegacyUsage: true,
+    }))
+  }
+  return summary
+}
+
+function isApiKeyClaudeBinding(providerTargetId: string | null): boolean {
+  if (!providerTargetId) {
+    return false
+  }
+  const target = db().select({ configJson: providerTargets.connectionConfigJson }).from(providerTargets).where(eq(providerTargets.id, providerTargetId)).get()
+  if (!target) {
+    return false
+  }
+  try {
+    return readTrustedClaudeAgentConfig(target.configJson).authMode === 'apiKey'
+  }
+  catch {
+    return false
+  }
+}
+
+async function readClaudeTranscript(input: {
+  path: string
+  runtimeHome: string
+  providerSessionId: string
+  sessionId: string
+  providerTargetId: string | null
+  recordIncident: (incident: ClaudeUsageReconciliationIncident) => void
+}): Promise<{ events: RuntimeUsageEventContext[], incidents: number }> {
+  const path = readContainedTranscriptPath(input.runtimeHome, input.path)
+  const events: RuntimeUsageEventContext[] = []
+  let incidents = 0
+  let lineNumber = 0
+  const lines = createInterface({ input: createReadStream(path), crlfDelay: Infinity })
+  for await (const line of lines) {
+    lineNumber += 1
+    let record: z.infer<typeof TranscriptRecordSchema>
+    try {
+      record = TranscriptRecordSchema.parse(JSON.parse(line))
+    }
+    catch (error) {
+      incidents += 1
+      input.recordIncident({ reason: `Claude transcript contains invalid JSONL: ${errorMessage(error)}`, path, lineNumber })
+      continue
+    }
+    if (record.type !== 'assistant') {
+      continue
+    }
+    if (record.sessionId !== input.providerSessionId) {
+      incidents += 1
+      input.recordIncident({ reason: 'Claude transcript assistant record has a mismatched provider session.', path, lineNumber })
+      continue
+    }
+    const occurredAt = record.timestamp ? Date.parse(record.timestamp) : Number.NaN
+    if (!Number.isFinite(occurredAt)) {
+      incidents += 1
+      input.recordIncident({ reason: 'Claude transcript assistant record has an invalid timestamp.', path, lineNumber })
+      continue
+    }
+    try {
+      const event = projectClaudeAssistantUsageEvent({
+        message: {
+          type: 'assistant',
+          session_id: record.sessionId,
+          ...(record.parent_tool_use_id ? { parent_tool_use_id: record.parent_tool_use_id } : {}),
+          message: record.message,
+        } as never,
+        fallbackModelId: null,
+        occurredAt: Math.floor(occurredAt / 1000),
+      })
+      if (event) {
+        events.push({
+          event,
+          sessionId: input.sessionId,
+          runId: null,
+          messageId: null,
+          providerTargetId: input.providerTargetId,
+          providerSessionId: input.providerSessionId,
+        })
+      }
+    }
+    catch (error) {
+      incidents += 1
+      input.recordIncident({ reason: `Claude transcript usage event was rejected: ${errorMessage(error)}`, path, lineNumber })
+    }
+  }
+  return { events, incidents }
+}
+
+function findClaudeTranscriptPaths(runtimeHome: string, providerSessionId: string): string[] {
+  const root = readContainedTranscriptPath(runtimeHome, findClaudeSessionPath(runtimeHome, providerSessionId))
+  const paths = [root]
+  const subagents = join(root, '..', 'subagents')
+  if (!existsSync(subagents)) {
+    return paths
+  }
+  for (const entry of readdirSync(subagents, { recursive: true })) {
+    if (typeof entry === 'string' && /^agent-[^/]+\.jsonl$/.test(entry)) {
+      paths.push(readContainedTranscriptPath(runtimeHome, join(subagents, entry)))
+    }
+  }
+  return paths
+}
+
+function findClaudeSessionPath(runtimeHome: string, providerSessionId: string): string {
+  const projects = join(runtimeHome, 'projects')
+  for (const project of readdirSync(projects)) {
+    const candidate = join(projects, project, `${providerSessionId}.jsonl`)
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  throw new Error('Claude transcript does not exist.')
+}
+
+function readContainedTranscriptPath(runtimeHome: string, path: string): string {
+  const canonicalHome = realpathSync(runtimeHome)
+  const canonicalPath = realpathSync(path)
+  const relativePath = relative(canonicalHome, canonicalPath)
+  if (!relativePath || relativePath.startsWith('..') || isAbsolute(relativePath) || !statSync(canonicalPath).isFile()) {
+    throw new Error('Claude transcript path is outside the Cradle-owned runtime home.')
+  }
+  return canonicalPath
+}
+
+function persistUsageEvents(events: RuntimeUsageEventContext[]): { inserted: number, duplicates: number } {
+  let inserted = 0
+  let duplicates = 0
+  for (const event of events) {
+    if (recordRuntimeUsageEvent(event) === 'inserted') { inserted += 1 }
+    else { duplicates += 1 }
+  }
+  return { inserted, duplicates }
+}
+
+function hasLegacyUsage(sessionId: string): boolean {
+  return Boolean(db().select({ id: usageLogs.id }).from(usageLogs)
+    .where(and(eq(usageLogs.sessionId, sessionId), isNull(usageLogs.providerThreadId))).limit(1).get())
+}
+
+function markBindingReconciliation(bindingId: string | undefined, status: 'completed' | 'blocked' | 'unavailable'): void {
+  if (!bindingId) { return }
+  const now = Math.floor(Date.now() / 1000)
+  db().update(backendSessionBindings).set({ usageReconciliationStatus: status, usageReconciliationAttemptedAt: now, updatedAt: now }).where(eq(backendSessionBindings.id, bindingId)).run()
+}
+
+function recordReconciliationIncident(sessionId: string, incident: ClaudeUsageReconciliationIncident): void {
+  Observability.record({
+    source: 'provider',
+    code: OBSERVABILITY_CODES.chatUsageIngestionFailed,
+    severity: 'error',
+    category: 'chat',
+    message: incident.reason,
+    chatSessionId: sessionId,
+    dedupeKey: createDedupeKey({ code: OBSERVABILITY_CODES.chatUsageIngestionFailed, chatSessionId: sessionId, runId: null }),
+    attrs: { runtimeKind: 'claude-agent', phase: 'reconciliation', path: incident.path, lineNumber: incident.lineNumber },
+  })
+}
+
+function emptySummary(): ClaudeUsageReconciliationSummary {
+  return { bindings: 0, transcripts: 0, inserted: 0, duplicates: 0, incidents: 0 }
+}
+
+function addSummary(target: ClaudeUsageReconciliationSummary, source: ClaudeUsageReconciliationSummary): void {
+  target.bindings += source.bindings
+  target.transcripts += source.transcripts
+  target.inserted += source.inserted
+  target.duplicates += source.duplicates
+  target.incidents += source.incidents
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/usage-reconciliation.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/usage-reconciliation.ts
@@ -62,7 +62,18 @@ export async function reconcileClaudeSessionUsage(input: {
   summary.bindings = 1
   const recordIncident = input.recordIncident ?? (incident => recordReconciliationIncident(input.sessionId, incident))
   const runtimeHome = input.runtimeHome ?? resolveClaudeAgentSdkConfigDir()
-  const transcriptPaths = findClaudeTranscriptPaths(runtimeHome, input.providerSessionId)
+  let transcriptPaths: string[]
+  try {
+    transcriptPaths = findClaudeTranscriptPaths(runtimeHome, input.providerSessionId)
+  }
+  catch (error) {
+    summary.incidents += 1
+    recordIncident({
+      reason: `Claude usage reconciliation could not locate a Cradle-owned transcript: ${errorMessage(error)}`,
+    })
+    markBindingReconciliation(input.bindingId, 'blocked')
+    return { ...summary, completed: false }
+  }
   if (transcriptPaths.length === 0) {
     summary.incidents += 1
     recordIncident({ reason: 'Claude usage reconciliation could not locate a Cradle-owned transcript.' })
@@ -73,16 +84,22 @@ export async function reconcileClaudeSessionUsage(input: {
   const events: RuntimeUsageEventContext[] = []
   for (const path of transcriptPaths) {
     summary.transcripts += 1
-    const result = await readClaudeTranscript({
-      path,
-      runtimeHome,
-      providerSessionId: input.providerSessionId,
-      sessionId: input.sessionId,
-      providerTargetId: input.providerTargetId,
-      recordIncident,
-    })
-    events.push(...result.events)
-    summary.incidents += result.incidents
+    try {
+      const result = await readClaudeTranscript({
+        path,
+        runtimeHome,
+        providerSessionId: input.providerSessionId,
+        sessionId: input.sessionId,
+        providerTargetId: input.providerTargetId,
+        recordIncident,
+      })
+      events.push(...result.events)
+      summary.incidents += result.incidents
+    }
+    catch (error) {
+      summary.incidents += 1
+      recordIncident({ reason: `Claude transcript could not be replayed: ${errorMessage(error)}`, path })
+    }
   }
   if (summary.incidents > 0) {
     markBindingReconciliation(input.bindingId, 'blocked')

--- a/apps/server/src/modules/chat-runtime-providers/codex/usage-reconciliation.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/usage-reconciliation.ts
@@ -10,7 +10,7 @@ import { db } from '../../../infra'
 import { createDedupeKey, OBSERVABILITY_CODES } from '../../observability/contract'
 import * as Observability from '../../observability/service'
 import type { RuntimeUsageEventContext } from '../../usage/ingest'
-import { recordRuntimeUsageEvent, replaceLegacyCodexUsage } from '../../usage/ingest'
+import { recordRuntimeUsageEvent, replaceLegacyRuntimeUsage } from '../../usage/ingest'
 import { CodexAppServerClient, resolveCodexAppServerHome } from './app-server/client'
 import type { Thread } from './app-server-protocol/v2/Thread'
 import type { ThreadListParams } from './app-server-protocol/v2/ThreadListParams'
@@ -155,7 +155,7 @@ export async function reconcileCodexSessionUsage(
   }
 
   const persisted = input.replaceLegacyUsage
-    ? replaceLegacyCodexUsage({ sessionId: input.sessionId, events })
+    ? replaceLegacyRuntimeUsage({ sessionId: input.sessionId, runtimeKind: 'codex', events })
     : persistUsageEvents(events)
   summary.inserted += persisted.inserted
   summary.duplicates += persisted.duplicates

--- a/apps/server/src/modules/usage/ingest.test.ts
+++ b/apps/server/src/modules/usage/ingest.test.ts
@@ -2,12 +2,12 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { sessions, usageLogs } from '@cradle/db'
+import { backendSessionBindings, sessions, usageLogs } from '@cradle/db'
 import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { db, shutdownInfra } from '../../infra'
-import { recordRuntimeUsageEvent, replaceLegacyCodexUsage } from './ingest'
+import { recordRuntimeUsageEvent, replaceLegacyRuntimeUsage } from './ingest'
 
 const previousDataDir = process.env.CRADLE_DATA_DIR
 let dataDir = ''
@@ -101,6 +101,11 @@ describe('recordRuntimeUsageEvent', () => {
 
   it('atomically replaces only legacy Codex summary rows after a verified session replay', () => {
     db().insert(sessions).values({ id: 'session-1', title: 'Session', runtimeKind: 'codex' }).run()
+    db().insert(backendSessionBindings).values({
+      id: 'binding-1',
+      chatSessionId: 'session-1',
+      runtimeKind: 'codex',
+    }).run()
     db().insert(usageLogs).values({
       id: 'legacy-summary',
       sessionId: 'session-1',
@@ -111,8 +116,9 @@ describe('recordRuntimeUsageEvent', () => {
       createdAt: 1_700_000_000,
     }).run()
 
-    const result = replaceLegacyCodexUsage({
+    const result = replaceLegacyRuntimeUsage({
       sessionId: 'session-1',
+      runtimeKind: 'codex',
       events: [{
         event: {
           id: 'event-1',

--- a/apps/server/src/modules/usage/ingest.ts
+++ b/apps/server/src/modules/usage/ingest.ts
@@ -1,4 +1,4 @@
-import { usageLogs } from '@cradle/db'
+import { backendSessionBindings, usageLogs } from '@cradle/db'
 import { and, eq, isNull } from 'drizzle-orm'
 
 import { db } from '../../infra'
@@ -19,15 +19,24 @@ export function recordRuntimeUsageEvent(input: RuntimeUsageEventContext): 'inser
   return result.changes > 0 ? 'inserted' : 'duplicate'
 }
 
-export function replaceLegacyCodexUsage(input: {
+export function replaceLegacyRuntimeUsage(input: {
   sessionId: string
+  runtimeKind: string
   events: RuntimeUsageEventContext[]
 }): { inserted: number, duplicates: number } {
   for (const event of input.events) {
     validateRuntimeUsageEventContext(event)
     if (event.sessionId !== input.sessionId) {
-      throw new Error('Codex usage reconciliation events must belong to one Cradle session.')
+      throw new Error('Runtime usage reconciliation events must belong to one Cradle session.')
     }
+  }
+
+  const binding = db().select({ id: backendSessionBindings.id }).from(backendSessionBindings).where(and(
+      eq(backendSessionBindings.chatSessionId, input.sessionId),
+      eq(backendSessionBindings.runtimeKind, input.runtimeKind),
+    )).get()
+  if (!binding) {
+    throw new Error('Runtime usage reconciliation can only replace a matching session binding.')
   }
 
   return db().transaction((tx) => {

--- a/apps/server/tests/sdk-providers.test.ts
+++ b/apps/server/tests/sdk-providers.test.ts
@@ -203,7 +203,10 @@ describe('sdk-backed providers in unified chat runtime', () => {
         type: 'assistant',
         session_id: 'claude-session-1',
         message: {
+          id: 'msg_1',
+          model: 'claude-sonnet-4-20250514',
           content: [{ type: 'text', text: 'Claude says hi' }],
+          usage: { input_tokens: 9, output_tokens: 4 },
         },
       },
       {
@@ -300,7 +303,10 @@ describe('sdk-backed providers in unified chat runtime', () => {
         type: 'assistant',
         session_id: 'claude-agent-settings-session',
         message: {
+          id: 'msg_2',
+          model: 'claude-sonnet-4-20250514',
           content: [{ type: 'text', text: 'Agent configured' }],
+          usage: { input_tokens: 3, output_tokens: 2 },
         },
       },
       {
@@ -432,7 +438,10 @@ describe('sdk-backed providers in unified chat runtime', () => {
         type: 'assistant',
         session_id: 'claude-session-matrix-session',
         message: {
+          id: 'msg_3',
+          model: 'claude-sonnet-main',
           content: [{ type: 'text', text: 'Session configured' }],
+          usage: { input_tokens: 4, output_tokens: 2 },
         },
       },
       {
@@ -550,9 +559,12 @@ describe('sdk-backed providers in unified chat runtime', () => {
         type: 'assistant',
         session_id: 'claude-tool-session',
         message: {
+          id: 'msg_4a',
+          model: 'claude-sonnet-4-20250514',
           content: [
             { type: 'tool_use', id: 'toolu_abc123', name: 'bash', input: { command: 'echo hello' } },
           ],
+          usage: { input_tokens: 10, output_tokens: 3 },
         },
       },
       {
@@ -568,7 +580,10 @@ describe('sdk-backed providers in unified chat runtime', () => {
         type: 'assistant',
         session_id: 'claude-tool-session',
         message: {
+          id: 'msg_4b',
+          model: 'claude-sonnet-4-20250514',
           content: [{ type: 'text', text: 'Done running bash' }],
+          usage: { input_tokens: 15, output_tokens: 5 },
         },
       },
       {
@@ -676,10 +691,13 @@ describe('sdk-backed providers in unified chat runtime', () => {
         type: 'assistant',
         session_id: 'claude-subagent-session',
         message: {
+          id: 'msg_5a',
+          model: 'claude-sonnet-4-20250514',
           content: [
             { type: 'text', text: 'Main task dispatch' },
             { type: 'tool_use', id: 'toolu_parent_1', name: 'task', input: { description: 'Investigate runtime' } },
           ],
+          usage: { input_tokens: 10, output_tokens: 4 },
         },
       },
       {
@@ -696,14 +714,20 @@ describe('sdk-backed providers in unified chat runtime', () => {
         session_id: 'claude-subagent-session',
         parent_tool_use_id: 'toolu_parent_1',
         message: {
+          id: 'msg_5b',
+          model: 'claude-sonnet-4-20250514',
           content: [{ type: 'text', text: 'Subagent investigating' }],
+          usage: { input_tokens: 5, output_tokens: 2 },
         },
       },
       {
         type: 'assistant',
         session_id: 'claude-subagent-session',
         message: {
+          id: 'msg_5c',
+          model: 'claude-sonnet-4-20250514',
           content: [{ type: 'text', text: 'Main task finished' }],
+          usage: { input_tokens: 15, output_tokens: 5 },
         },
       },
       {
@@ -802,10 +826,13 @@ describe('sdk-backed providers in unified chat runtime', () => {
         type: 'assistant',
         session_id: 'claude-subagent-late-task-session',
         message: {
+          id: 'msg_6a',
+          model: 'claude-sonnet-4-20250514',
           content: [
             { type: 'text', text: 'Dispatch late-task subagent' },
             { type: 'tool_use', id: 'toolu_parent_late', name: 'task', input: { description: 'Investigate late task metadata' } },
           ],
+          usage: { input_tokens: 10, output_tokens: 4 },
         },
       },
       {
@@ -813,7 +840,10 @@ describe('sdk-backed providers in unified chat runtime', () => {
         session_id: 'claude-subagent-late-task-session',
         parent_tool_use_id: 'toolu_parent_late',
         message: {
+          id: 'msg_6b',
+          model: 'claude-sonnet-4-20250514',
           content: [{ type: 'text', text: 'Working before task metadata arrives' }],
+          usage: { input_tokens: 5, output_tokens: 2 },
         },
       },
       {
@@ -918,18 +948,24 @@ describe('sdk-backed providers in unified chat runtime', () => {
         type: 'assistant',
         session_id: 'claude-subagent-split-session',
         message: {
+          id: 'msg_7a',
+          model: 'claude-sonnet-4-20250514',
           content: [
             { type: 'tool_use', id: 'call_parent_a', name: 'Agent', input: { description: 'Explore preferences', subagent_type: 'Explore' } },
           ],
+          usage: { input_tokens: 10, output_tokens: 3 },
         },
       },
       {
         type: 'assistant',
         session_id: 'claude-subagent-split-session',
         message: {
+          id: 'msg_7b',
+          model: 'claude-sonnet-4-20250514',
           content: [
             { type: 'tool_use', id: 'call_parent_b', name: 'Agent', input: { description: 'Explore diff-review', subagent_type: 'Explore' } },
           ],
+          usage: { input_tokens: 10, output_tokens: 3 },
         },
       },
       {
@@ -1103,9 +1139,12 @@ describe('sdk-backed providers in unified chat runtime', () => {
         type: 'assistant',
         session_id: 'claude-err-session',
         message: {
+          id: 'msg_8a',
+          model: 'claude-sonnet-4-20250514',
           content: [
             { type: 'tool_use', id: 'toolu_err456', name: 'bash', input: { command: 'false' } },
           ],
+          usage: { input_tokens: 8, output_tokens: 2 },
         },
       },
       {
@@ -1121,7 +1160,10 @@ describe('sdk-backed providers in unified chat runtime', () => {
         type: 'assistant',
         session_id: 'claude-err-session',
         message: {
+          id: 'msg_8b',
+          model: 'claude-sonnet-4-20250514',
           content: [{ type: 'text', text: 'Command failed' }],
+          usage: { input_tokens: 12, output_tokens: 4 },
         },
       },
       {

--- a/packages/db/src/schema/backend-control-plane.ts
+++ b/packages/db/src/schema/backend-control-plane.ts
@@ -22,7 +22,7 @@ export const backendSessionBindings = sqliteTable(
     backendStateSnapshot: text('backend_state_snapshot'),
     requestedModelId: text('requested_model_id'),
     usageReconciliationStatus: text('usage_reconciliation_status', {
-      enum: ['pending', 'completed', 'blocked'],
+      enum: ['pending', 'completed', 'blocked', 'unavailable'],
     }).notNull().default('pending'),
     usageReconciliationAttemptedAt: int('usage_reconciliation_attempted_at'),
     ...timestamps(),


### PR DESCRIPTION
## Summary
Replace Claude Agent’s overlapping run-level usage summary with final-assistant provider events, durable late-event ingestion, and initial transcript reconciliation/scheduler support. Preserve provider-thread routing while projecting child usage independently, and fail closed on malformed transcript replay.

## Test plan
pnpm --filter @cradle/server typecheck
pnpm --filter @cradle/server exec vitest run src/modules/chat-runtime-providers/claude-agent/provider.test.ts --reporter=dot
pnpm --filter @cradle/server exec vitest run src/modules/chat-runtime-providers/claude-agent/usage-event-projector.test.ts src/modules/usage/ingest.test.ts --reporter=dot

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)