### PR TITLE
perf(relay): improve V2 transport latency and efficiency

### DIFF
--- a/apps/relayd/internal/httpapi/server_test.go
+++ b/apps/relayd/internal/httpapi/server_test.go
@@ -125,7 +125,7 @@ func TestWebSocketRoutesEnvelopeBetweenHostAndController(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeEnvelope() error = %v", err)
 	}
-	if err := host.Write(t.Context(), websocket.MessageText, data); err != nil {
+	if err := host.Write(t.Context(), websocket.MessageBinary, data); err != nil {
 		t.Fatalf("host Write() error = %v", err)
 	}
 
@@ -192,7 +192,7 @@ func TestWebSocketHeartbeatKeepsIdleConnectionOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeEnvelope() error = %v", err)
 	}
-	if err := host.Write(t.Context(), websocket.MessageText, data); err != nil {
+	if err := host.Write(t.Context(), websocket.MessageBinary, data); err != nil {
 		t.Fatalf("host Write() error = %v", err)
 	}
 
@@ -239,7 +239,7 @@ func TestWebSocketRejectsRoomMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EncodeEnvelope() error = %v", err)
 	}
-	if err := host.Write(t.Context(), websocket.MessageText, data); err != nil {
+	if err := host.Write(t.Context(), websocket.MessageBinary, data); err != nil {
 		t.Fatalf("host Write() error = %v", err)
 	}
 	readCtx, cancel := context.WithTimeout(t.Context(), time.Second)

--- a/apps/relayd/internal/relay/envelope.go
+++ b/apps/relayd/internal/relay/envelope.go
@@ -1,19 +1,24 @@
 package relay
 
 import (
-	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 )
 
 const (
-	ProtocolVersion = 1
+	ProtocolVersion = 2
 
 	KindRelayDataFrame = "relay_data_frame"
-	KindPeerClosed       = "relay_peer_closed"
-	KindRelayError       = "relay_error"
+	KindPeerClosed     = "relay_peer_closed"
+	KindRelayError     = "relay_error"
+
+	PriorityControl = "control"
+	PriorityData    = "data"
+
+	envelopeHeaderBytes = 16
+	flagHasStreamID     = 1
 )
 
 var (
@@ -21,36 +26,63 @@ var (
 	ErrFrameTooLarge   = errors.New("relay: frame too large")
 )
 
-// Envelope is the outer relayd frame. Dual-written with
-// apps/server/src/modules/relay-transport/protocol.ts — keep shapes in lockstep.
-//
-// Seq is stamped by senders for debug/ordering; relayd does not enforce it yet.
-// Ack and StreamID are reserved/unused: stream multiplexing and credit live in
-// the encrypted inner frames (opaque payload), not on this envelope.
+// Envelope is the v2 outer binary relay frame. relayd can read only the room,
+// stream id, and coarse priority needed for routing and fair scheduling. The
+// payload is opaque endpoint-to-endpoint ciphertext after the initial hello.
 type Envelope struct {
-	Version  int             `json:"version"`
-	RoomID   string          `json:"roomId"`
-	Seq      uint64          `json:"seq"`
-	Ack      *uint64         `json:"ack,omitempty"`
-	Kind     string          `json:"kind"`
-	StreamID string          `json:"streamId,omitempty"`
-	Payload  json.RawMessage `json:"payload"`
+	Version  int
+	RoomID   string
+	Seq      uint32
+	Kind     string
+	Priority string
+	StreamID string
+	Payload  []byte
 }
 
 func ParseEnvelope(data []byte, maxBytes int64) (Envelope, error) {
 	if maxBytes > 0 && int64(len(data)) > maxBytes {
 		return Envelope{}, ErrFrameTooLarge
 	}
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	var env Envelope
-	if err := decoder.Decode(&env); err != nil {
-		return Envelope{}, fmt.Errorf("%w: %v", ErrInvalidEnvelope, err)
+	if len(data) < envelopeHeaderBytes {
+		return Envelope{}, fmt.Errorf("%w: frame too short", ErrInvalidEnvelope)
 	}
-	var extra json.RawMessage
-	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
-		return Envelope{}, ErrInvalidEnvelope
+	if int(data[0]) != ProtocolVersion {
+		return Envelope{}, fmt.Errorf("%w: unsupported protocol version", ErrInvalidEnvelope)
 	}
+	kind, ok := kindFromCode(data[1])
+	if !ok {
+		return Envelope{}, fmt.Errorf("%w: unknown kind", ErrInvalidEnvelope)
+	}
+	priority, ok := priorityFromCode(data[2])
+	if !ok {
+		return Envelope{}, fmt.Errorf("%w: invalid priority", ErrInvalidEnvelope)
+	}
+	flags := data[3]
+	if flags & ^byte(flagHasStreamID) != 0 {
+		return Envelope{}, fmt.Errorf("%w: invalid flags", ErrInvalidEnvelope)
+	}
+	roomLen := int(binary.BigEndian.Uint16(data[4:6]))
+	streamLen := int(binary.BigEndian.Uint16(data[6:8]))
+	seq := binary.BigEndian.Uint32(data[8:12])
+	payloadLen := int(binary.BigEndian.Uint32(data[12:16]))
+	expectedLen := envelopeHeaderBytes + roomLen + streamLen + payloadLen
+	if roomLen == 0 || payloadLen == 0 || expectedLen != len(data) || (flags&flagHasStreamID != 0) != (streamLen > 0) {
+		return Envelope{}, fmt.Errorf("%w: invalid field lengths", ErrInvalidEnvelope)
+	}
+	offset := envelopeHeaderBytes
+	env := Envelope{
+		Version:  ProtocolVersion,
+		RoomID:   string(data[offset : offset+roomLen]),
+		Seq:      seq,
+		Kind:     kind,
+		Priority: priority,
+	}
+	offset += roomLen
+	if streamLen > 0 {
+		env.StreamID = string(data[offset : offset+streamLen])
+		offset += streamLen
+	}
+	env.Payload = append([]byte(nil), data[offset:]...)
 	if err := env.Validate(maxBytes); err != nil {
 		return Envelope{}, err
 	}
@@ -58,44 +90,51 @@ func ParseEnvelope(data []byte, maxBytes int64) (Envelope, error) {
 }
 
 func (e Envelope) Validate(maxBytes int64) error {
-	if e.Version != ProtocolVersion {
-		return fmt.Errorf("%w: unsupported protocol version", ErrInvalidEnvelope)
+	if e.Version != ProtocolVersion || e.RoomID == "" || e.Kind == "" || e.Priority == "" || len(e.Payload) == 0 {
+		return fmt.Errorf("%w: required envelope field is missing", ErrInvalidEnvelope)
 	}
-	if e.RoomID == "" {
-		return fmt.Errorf("%w: room id is required", ErrInvalidEnvelope)
-	}
-	if e.Kind == "" {
-		return fmt.Errorf("%w: kind is required", ErrInvalidEnvelope)
-	}
-	switch e.Kind {
-	case KindRelayDataFrame, KindPeerClosed, KindRelayError:
-	default:
+	if _, ok := kindCode(e.Kind); !ok {
 		return fmt.Errorf("%w: unknown kind", ErrInvalidEnvelope)
 	}
-	if len(e.Payload) == 0 {
-		return fmt.Errorf("%w: payload is required", ErrInvalidEnvelope)
+	if _, ok := priorityCode(e.Priority); !ok {
+		return fmt.Errorf("%w: invalid priority", ErrInvalidEnvelope)
 	}
-	if maxBytes > 0 {
-		encoded, err := json.Marshal(e)
-		if err != nil {
-			return fmt.Errorf("marshaling envelope: %w", err)
-		}
-		if int64(len(encoded)) > maxBytes {
-			return ErrFrameTooLarge
-		}
+	if len(e.RoomID) > 0xffff || len(e.StreamID) > 0xffff {
+		return fmt.Errorf("%w: identifier too long", ErrInvalidEnvelope)
+	}
+	if maxBytes > 0 && int64(envelopeHeaderBytes+len(e.RoomID)+len(e.StreamID)+len(e.Payload)) > maxBytes {
+		return ErrFrameTooLarge
 	}
 	return nil
 }
 
 func EncodeEnvelope(e Envelope, maxBytes int64) ([]byte, error) {
+	if e.Priority == "" {
+		e.Priority = PriorityControl
+	}
 	if err := e.Validate(maxBytes); err != nil {
 		return nil, err
 	}
-	encoded, err := json.Marshal(e)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling envelope: %w", err)
+	kind, _ := kindCode(e.Kind)
+	priority, _ := priorityCode(e.Priority)
+	out := make([]byte, envelopeHeaderBytes+len(e.RoomID)+len(e.StreamID)+len(e.Payload))
+	out[0] = ProtocolVersion
+	out[1] = kind
+	out[2] = priority
+	if e.StreamID != "" {
+		out[3] = flagHasStreamID
 	}
-	return encoded, nil
+	binary.BigEndian.PutUint16(out[4:6], uint16(len(e.RoomID)))
+	binary.BigEndian.PutUint16(out[6:8], uint16(len(e.StreamID)))
+	binary.BigEndian.PutUint32(out[8:12], e.Seq)
+	binary.BigEndian.PutUint32(out[12:16], uint32(len(e.Payload)))
+	offset := envelopeHeaderBytes
+	copy(out[offset:], e.RoomID)
+	offset += len(e.RoomID)
+	copy(out[offset:], e.StreamID)
+	offset += len(e.StreamID)
+	copy(out[offset:], e.Payload)
+	return out, nil
 }
 
 func RelayControlEnvelope(roomID string, kind string, payload any) (Envelope, error) {
@@ -104,10 +143,58 @@ func RelayControlEnvelope(roomID string, kind string, payload any) (Envelope, er
 		return Envelope{}, fmt.Errorf("marshaling relay control payload: %w", err)
 	}
 	return Envelope{
-		Version: ProtocolVersion,
-		RoomID:  roomID,
-		Seq:     0,
-		Kind:    kind,
-		Payload: raw,
+		Version:  ProtocolVersion,
+		RoomID:   roomID,
+		Kind:     kind,
+		Priority: PriorityControl,
+		Payload:  raw,
 	}, nil
+}
+
+func kindCode(kind string) (byte, bool) {
+	switch kind {
+	case KindRelayDataFrame:
+		return 1, true
+	case KindPeerClosed:
+		return 2, true
+	case KindRelayError:
+		return 3, true
+	default:
+		return 0, false
+	}
+}
+
+func kindFromCode(code byte) (string, bool) {
+	switch code {
+	case 1:
+		return KindRelayDataFrame, true
+	case 2:
+		return KindPeerClosed, true
+	case 3:
+		return KindRelayError, true
+	default:
+		return "", false
+	}
+}
+
+func priorityCode(priority string) (byte, bool) {
+	switch priority {
+	case PriorityControl:
+		return 1, true
+	case PriorityData:
+		return 2, true
+	default:
+		return 0, false
+	}
+}
+
+func priorityFromCode(code byte) (string, bool) {
+	switch code {
+	case 1:
+		return PriorityControl, true
+	case 2:
+		return PriorityData, true
+	default:
+		return "", false
+	}
 }

--- a/apps/relayd/internal/relay/envelope.go
+++ b/apps/relayd/internal/relay/envelope.go
@@ -39,7 +39,23 @@ type Envelope struct {
 	Payload  []byte
 }
 
+// ParseEnvelope decodes a v2 envelope and returns an owned payload copy. Use
+// ParseEnvelopeView when the caller owns data for the returned envelope's full
+// lifetime and only needs to inspect its routing metadata.
 func ParseEnvelope(data []byte, maxBytes int64) (Envelope, error) {
+	env, err := ParseEnvelopeView(data, maxBytes)
+	if err != nil {
+		return Envelope{}, err
+	}
+	env.Payload = append([]byte(nil), env.Payload...)
+	return env, nil
+}
+
+// ParseEnvelopeView decodes and validates a v2 envelope without copying its
+// opaque payload. The returned payload aliases data, so callers must retain
+// data unchanged for as long as they retain the Envelope. relayd uses this to
+// validate one WebSocket message and forward that exact message to the peer.
+func ParseEnvelopeView(data []byte, maxBytes int64) (Envelope, error) {
 	if maxBytes > 0 && int64(len(data)) > maxBytes {
 		return Envelope{}, ErrFrameTooLarge
 	}
@@ -82,7 +98,7 @@ func ParseEnvelope(data []byte, maxBytes int64) (Envelope, error) {
 		env.StreamID = string(data[offset : offset+streamLen])
 		offset += streamLen
 	}
-	env.Payload = append([]byte(nil), data[offset:]...)
+	env.Payload = data[offset:]
 	if err := env.Validate(maxBytes); err != nil {
 		return Envelope{}, err
 	}

--- a/apps/relayd/internal/relay/envelope_test.go
+++ b/apps/relayd/internal/relay/envelope_test.go
@@ -27,6 +27,37 @@ func TestParseEnvelope(t *testing.T) {
 	}
 }
 
+func TestParseEnvelopeViewAliasesPayloadWhileParseEnvelopeOwnsCopy(t *testing.T) {
+	data, err := EncodeEnvelope(Envelope{
+		Version:  ProtocolVersion,
+		RoomID:   "room_1",
+		Seq:      1,
+		Kind:     KindRelayDataFrame,
+		Priority: PriorityControl,
+		Payload:  []byte("hello"),
+	}, 1024)
+	if err != nil {
+		t.Fatalf("EncodeEnvelope() error = %v", err)
+	}
+
+	view, err := ParseEnvelopeView(data, 1024)
+	if err != nil {
+		t.Fatalf("ParseEnvelopeView() error = %v", err)
+	}
+	owned, err := ParseEnvelope(data, 1024)
+	if err != nil {
+		t.Fatalf("ParseEnvelope() error = %v", err)
+	}
+
+	data[len(data)-1] = 'X'
+	if got := string(view.Payload); got != "hellX" {
+		t.Fatalf("view payload = %q, expected alias to mutated input", got)
+	}
+	if got := string(owned.Payload); got != "hello" {
+		t.Fatalf("owned payload = %q, expected detached copy", got)
+	}
+}
+
 func TestParseEnvelopeRejectsInvalidVersion(t *testing.T) {
 	data, err := EncodeEnvelope(Envelope{
 		Version:  99,

--- a/apps/relayd/internal/relay/envelope_test.go
+++ b/apps/relayd/internal/relay/envelope_test.go
@@ -1,25 +1,21 @@
 package relay
 
 import (
-	"encoding/json"
 	"errors"
 	"testing"
 )
 
 func TestParseEnvelope(t *testing.T) {
-	payload, err := json.Marshal(map[string]string{"kind": "host/hello"})
+	data, err := EncodeEnvelope(Envelope{
+		Version:  ProtocolVersion,
+		RoomID:   "room_1",
+		Seq:      1,
+		Kind:     KindRelayDataFrame,
+		Priority: PriorityControl,
+		Payload:  []byte("hello"),
+	}, 1024)
 	if err != nil {
-		t.Fatalf("Marshal() error = %v", err)
-	}
-	data, err := json.Marshal(Envelope{
-		Version: ProtocolVersion,
-		RoomID:  "room_1",
-		Seq:     1,
-		Kind:    KindRelayDataFrame,
-		Payload: payload,
-	})
-	if err != nil {
-		t.Fatalf("Marshal() error = %v", err)
+		t.Fatalf("EncodeEnvelope() error = %v", err)
 	}
 
 	env, err := ParseEnvelope(data, 1024)
@@ -32,20 +28,18 @@ func TestParseEnvelope(t *testing.T) {
 }
 
 func TestParseEnvelopeRejectsInvalidVersion(t *testing.T) {
-	payload, err := json.Marshal(map[string]string{"kind": "host/hello"})
-	if err != nil {
-		t.Fatalf("Marshal() error = %v", err)
+	data, err := EncodeEnvelope(Envelope{
+		Version:  99,
+		RoomID:   "room_1",
+		Seq:      1,
+		Kind:     KindRelayDataFrame,
+		Priority: PriorityControl,
+		Payload:  []byte("hello"),
+	}, 1024)
+	if err == nil {
+		t.Fatal("EncodeEnvelope() unexpectedly accepted an invalid version")
 	}
-	data, err := json.Marshal(Envelope{
-		Version: 99,
-		RoomID:  "room_1",
-		Seq:     1,
-		Kind:    KindRelayDataFrame,
-		Payload: payload,
-	})
-	if err != nil {
-		t.Fatalf("Marshal() error = %v", err)
-	}
+	data = append([]byte{99}, make([]byte, envelopeHeaderBytes-1)...)
 
 	_, err = ParseEnvelope(data, 1024)
 	if !errors.Is(err, ErrInvalidEnvelope) {

--- a/apps/relayd/internal/relay/fixture_test.go
+++ b/apps/relayd/internal/relay/fixture_test.go
@@ -2,43 +2,20 @@ package relay
 
 import (
 	"errors"
-	"os"
-	"path/filepath"
 	"testing"
 )
 
 func TestEnvelopeFixtures(t *testing.T) {
-	fixtures := filepath.Join("..", "..", "testdata")
-	validNames := []string{
-		"valid-host-envelope.json",
-		"valid-controller-envelope.json",
+	valid, err := EncodeEnvelope(Envelope{Version: ProtocolVersion, RoomID: "fixture", Kind: KindRelayDataFrame, Priority: PriorityData, StreamID: "c1", Payload: []byte("opaque")}, 4096)
+	if err != nil {
+		t.Fatalf("EncodeEnvelope() error = %v", err)
 	}
-	for _, name := range validNames {
-		t.Run(name, func(t *testing.T) {
-			data, err := os.ReadFile(filepath.Join(fixtures, name))
-			if err != nil {
-				t.Fatalf("ReadFile() error = %v", err)
-			}
-			if _, err := ParseEnvelope(data, 4096); err != nil {
-				t.Fatalf("ParseEnvelope() error = %v", err)
-			}
-		})
+	if _, err := ParseEnvelope(valid, 4096); err != nil {
+		t.Fatalf("ParseEnvelope() error = %v", err)
 	}
-
-	invalidNames := []string{
-		"invalid-version-envelope.json",
-		"missing-room-envelope.json",
-	}
-	for _, name := range invalidNames {
-		t.Run(name, func(t *testing.T) {
-			data, err := os.ReadFile(filepath.Join(fixtures, name))
-			if err != nil {
-				t.Fatalf("ReadFile() error = %v", err)
-			}
-			_, err = ParseEnvelope(data, 4096)
-			if !errors.Is(err, ErrInvalidEnvelope) {
-				t.Fatalf("ParseEnvelope() error = %v, expected ErrInvalidEnvelope", err)
-			}
-		})
+	invalid := append([]byte(nil), valid...)
+	invalid[3] = 0x80
+	if _, err := ParseEnvelope(invalid, 4096); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("ParseEnvelope() error = %v, expected ErrInvalidEnvelope", err)
 	}
 }

--- a/apps/relayd/internal/relay/forward_benchmark_test.go
+++ b/apps/relayd/internal/relay/forward_benchmark_test.go
@@ -1,0 +1,72 @@
+package relay
+
+import (
+	"fmt"
+	"testing"
+)
+
+var (
+	benchmarkForwardEnvelope Envelope
+	benchmarkForwardBytes    []byte
+)
+
+// BenchmarkRelayForwardPath compares the exact V2 Relay work before and after
+// pass-through forwarding. It intentionally measures only Relay-process work,
+// not Internet throughput: legacy copies the opaque payload and recreates a
+// frame; the V2 path validates metadata and queues the received frame itself.
+func BenchmarkRelayForwardPath(b *testing.B) {
+	for _, payloadBytes := range []int{1 << 10, 64 << 10, 256 << 10} {
+		b.Run(fmt.Sprintf("%dKiB", payloadBytes>>10), func(b *testing.B) {
+			frame := benchmarkV2Frame(b, payloadBytes)
+			b.Run("legacy-parse-reencode", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(frame)))
+				for b.Loop() {
+					env, err := ParseEnvelope(frame, 1<<20)
+					if err != nil {
+						b.Fatal(err)
+					}
+					forwarded, err := EncodeEnvelope(env, 1<<20)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkForwardEnvelope = env
+					benchmarkForwardBytes = forwarded
+				}
+			})
+			b.Run("v2-validated-passthrough", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(frame)))
+				for b.Loop() {
+					env, err := ParseEnvelopeView(frame, 1<<20)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkForwardEnvelope = env
+					benchmarkForwardBytes = frame
+				}
+			})
+		})
+	}
+}
+
+func benchmarkV2Frame(b *testing.B, payloadBytes int) []byte {
+	b.Helper()
+	payload := make([]byte, payloadBytes)
+	for index := range payload {
+		payload[index] = byte(index)
+	}
+	frame, err := EncodeEnvelope(Envelope{
+		Version:  ProtocolVersion,
+		RoomID:   "room_benchmark",
+		Seq:      1,
+		Kind:     KindRelayDataFrame,
+		Priority: PriorityData,
+		StreamID: "stream_benchmark",
+		Payload:  payload,
+	}, 1<<20)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return frame
+}

--- a/apps/relayd/internal/relay/forward_benchmark_test.go
+++ b/apps/relayd/internal/relay/forward_benchmark_test.go
@@ -1,7 +1,12 @@
 package relay
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"testing"
 )
 
@@ -17,12 +22,29 @@ var (
 func BenchmarkRelayForwardPath(b *testing.B) {
 	for _, payloadBytes := range []int{1 << 10, 64 << 10, 256 << 10} {
 		b.Run(fmt.Sprintf("%dKiB", payloadBytes>>10), func(b *testing.B) {
-			frame := benchmarkV2Frame(b, payloadBytes)
-			b.Run("legacy-parse-reencode", func(b *testing.B) {
+			v1Frame := benchmarkV1Frame(b, payloadBytes)
+			v2Frame := benchmarkV2Frame(b, payloadBytes)
+			b.Run("v1-json-parse-reencode", func(b *testing.B) {
 				b.ReportAllocs()
-				b.SetBytes(int64(len(frame)))
+				b.SetBytes(int64(len(v1Frame)))
 				for b.Loop() {
-					env, err := ParseEnvelope(frame, 1<<20)
+					env, err := parseBenchmarkV1Envelope(v1Frame, 1<<20)
+					if err != nil {
+						b.Fatal(err)
+					}
+					forwarded, err := encodeBenchmarkV1Envelope(env, 1<<20)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchmarkForwardEnvelope = Envelope{Payload: env.Payload}
+					benchmarkForwardBytes = forwarded
+				}
+			})
+			b.Run("v2-before-parse-reencode", func(b *testing.B) {
+				b.ReportAllocs()
+				b.SetBytes(int64(len(v2Frame)))
+				for b.Loop() {
+					env, err := ParseEnvelope(v2Frame, 1<<20)
 					if err != nil {
 						b.Fatal(err)
 					}
@@ -34,16 +56,16 @@ func BenchmarkRelayForwardPath(b *testing.B) {
 					benchmarkForwardBytes = forwarded
 				}
 			})
-			b.Run("v2-validated-passthrough", func(b *testing.B) {
+			b.Run("v2-current-validated-passthrough", func(b *testing.B) {
 				b.ReportAllocs()
-				b.SetBytes(int64(len(frame)))
+				b.SetBytes(int64(len(v2Frame)))
 				for b.Loop() {
-					env, err := ParseEnvelopeView(frame, 1<<20)
+					env, err := ParseEnvelopeView(v2Frame, 1<<20)
 					if err != nil {
 						b.Fatal(err)
 					}
 					benchmarkForwardEnvelope = env
-					benchmarkForwardBytes = frame
+					benchmarkForwardBytes = v2Frame
 				}
 			})
 		})
@@ -52,7 +74,12 @@ func BenchmarkRelayForwardPath(b *testing.B) {
 
 func benchmarkV2Frame(b *testing.B, payloadBytes int) []byte {
 	b.Helper()
-	payload := make([]byte, payloadBytes)
+	// V2 stream_data plaintext is one byte kind, two bytes stream-id length,
+	// four bytes sequence, the stream id, and payload. XChaCha20-Poly1305 adds
+	// a 24-byte nonce plus a 16-byte authentication tag. relayd only sees the
+	// resulting opaque payload, so a deterministic byte slice has the exact
+	// relevant length without doing endpoint cryptography in this Go benchmark.
+	payload := make([]byte, payloadBytes+7+len("benchmark")+24+16)
 	for index := range payload {
 		payload[index] = byte(index)
 	}
@@ -62,11 +89,117 @@ func benchmarkV2Frame(b *testing.B, payloadBytes int) []byte {
 		Seq:      1,
 		Kind:     KindRelayDataFrame,
 		Priority: PriorityData,
-		StreamID: "stream_benchmark",
+		StreamID: "benchmark",
 		Payload:  payload,
 	}, 1<<20)
 	if err != nil {
 		b.Fatal(err)
 	}
 	return frame
+}
+
+// benchmarkV1Envelope mirrors the historical JSON envelope from the parent of
+// commit 9c437fde. It exists only in this benchmark so production supports one
+// protocol: V2.
+type benchmarkV1Envelope struct {
+	Version  int             `json:"version"`
+	RoomID   string          `json:"roomId"`
+	Seq      uint64          `json:"seq"`
+	Ack      *uint64         `json:"ack,omitempty"`
+	Kind     string          `json:"kind"`
+	StreamID string          `json:"streamId,omitempty"`
+	Payload  json.RawMessage `json:"payload"`
+}
+
+func benchmarkV1Frame(b *testing.B, payloadBytes int) []byte {
+	b.Helper()
+	data := make([]byte, payloadBytes)
+	for index := range data {
+		data[index] = byte(index)
+	}
+	inner, err := json.Marshal(struct {
+		Kind     string `json:"kind"`
+		StreamID string `json:"streamId"`
+		Seq      uint64 `json:"seq"`
+		Data     string `json:"data"`
+	}{
+		Kind:     "stream_data",
+		StreamID: "benchmark",
+		Seq:      0,
+		Data:     base64.StdEncoding.EncodeToString(data),
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	// V1 wrapped nonce(24) || ciphertext || tag(16) as base64 JSON. A zeroed
+	// nonce/tag keeps this benchmark deterministic while preserving wire length.
+	ciphertext := make([]byte, 24+len(inner)+16)
+	copy(ciphertext[24:], inner)
+	payload, err := json.Marshal(struct {
+		Ciphertext string `json:"ciphertext"`
+	}{Ciphertext: base64.StdEncoding.EncodeToString(ciphertext)})
+	if err != nil {
+		b.Fatal(err)
+	}
+	frame, err := encodeBenchmarkV1Envelope(benchmarkV1Envelope{
+		Version: 1,
+		RoomID:  "room_benchmark",
+		Seq:     1,
+		Kind:    KindRelayDataFrame,
+		Payload: payload,
+	}, 1<<20)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return frame
+}
+
+func parseBenchmarkV1Envelope(data []byte, maxBytes int64) (benchmarkV1Envelope, error) {
+	if maxBytes > 0 && int64(len(data)) > maxBytes {
+		return benchmarkV1Envelope{}, ErrFrameTooLarge
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var env benchmarkV1Envelope
+	if err := decoder.Decode(&env); err != nil {
+		return benchmarkV1Envelope{}, fmt.Errorf("%w: %v", ErrInvalidEnvelope, err)
+	}
+	var extra json.RawMessage
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return benchmarkV1Envelope{}, ErrInvalidEnvelope
+	}
+	if err := validateBenchmarkV1Envelope(env, maxBytes); err != nil {
+		return benchmarkV1Envelope{}, err
+	}
+	return env, nil
+}
+
+func encodeBenchmarkV1Envelope(env benchmarkV1Envelope, maxBytes int64) ([]byte, error) {
+	if err := validateBenchmarkV1Envelope(env, maxBytes); err != nil {
+		return nil, err
+	}
+	encoded, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling benchmark v1 envelope: %w", err)
+	}
+	return encoded, nil
+}
+
+func validateBenchmarkV1Envelope(env benchmarkV1Envelope, maxBytes int64) error {
+	if env.Version != 1 || env.RoomID == "" || env.Kind == "" || len(env.Payload) == 0 {
+		return ErrInvalidEnvelope
+	}
+	if env.Kind != KindRelayDataFrame && env.Kind != KindPeerClosed && env.Kind != KindRelayError {
+		return ErrInvalidEnvelope
+	}
+	if maxBytes > 0 {
+		encoded, err := json.Marshal(env)
+		if err != nil {
+			return fmt.Errorf("marshaling benchmark v1 envelope: %w", err)
+		}
+		if int64(len(encoded)) > maxBytes {
+			return ErrFrameTooLarge
+		}
+	}
+	return nil
 }

--- a/apps/relayd/internal/relay/forward_benchmark_test.go
+++ b/apps/relayd/internal/relay/forward_benchmark_test.go
@@ -74,12 +74,12 @@ func BenchmarkRelayForwardPath(b *testing.B) {
 
 func benchmarkV2Frame(b *testing.B, payloadBytes int) []byte {
 	b.Helper()
-	// V2 stream_data plaintext is one byte kind, two bytes stream-id length,
-	// four bytes sequence, the stream id, and payload. XChaCha20-Poly1305 adds
-	// a 24-byte nonce plus a 16-byte authentication tag. relayd only sees the
-	// resulting opaque payload, so a deterministic byte slice has the exact
-	// relevant length without doing endpoint cryptography in this Go benchmark.
-	payload := make([]byte, payloadBytes+7+len("benchmark")+24+16)
+	// V2 raw stream_data plaintext is one byte kind, two bytes stream-id length,
+	// four bytes sequence, the stream id, and payload. Bulk AES-256-GCM adds a
+	// 12-byte nonce plus a 16-byte authentication tag. relayd only sees the
+	// resulting opaque payload, so deterministic bytes preserve the exact length
+	// without doing endpoint cryptography in this Go benchmark.
+	payload := make([]byte, payloadBytes+7+len("benchmark")+12+16)
 	for index := range payload {
 		payload[index] = byte(index)
 	}

--- a/apps/relayd/internal/relay/hub.go
+++ b/apps/relayd/internal/relay/hub.go
@@ -100,6 +100,7 @@ type peerScheduler struct {
 	maxDataBytes    int64
 	maxDataCount    int
 	signal          chan struct{}
+	space           chan struct{}
 }
 
 func newPeerScheduler(maxCount int, maxBytes, maxFrameBytes int64) *peerScheduler {
@@ -114,12 +115,35 @@ func newPeerScheduler(maxCount int, maxBytes, maxFrameBytes int64) *peerSchedule
 		maxDataCount: maxCount - controlReserveCount,
 		maxDataBytes: maxBytes - controlReserveBytes,
 		signal:       make(chan struct{}, 1),
+		space:        make(chan struct{}, 1),
 	}
 }
 
 func (s *peerScheduler) enqueue(item queuedEnvelope, priority, streamID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.enqueueLocked(item, priority, streamID)
+}
+
+func (s *peerScheduler) enqueueWait(ctx context.Context, done <-chan struct{}, item queuedEnvelope, priority, streamID string) error {
+	for {
+		s.mu.Lock()
+		err := s.enqueueLocked(item, priority, streamID)
+		s.mu.Unlock()
+		if !errors.Is(err, ErrSlowConsumer) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-done:
+			return net.ErrClosed
+		case <-s.space:
+		}
+	}
+}
+
+func (s *peerScheduler) enqueueLocked(item queuedEnvelope, priority, streamID string) error {
 	if s.queuedBytes+item.size > s.maxBytes || s.queuedCount >= s.maxCount {
 		return ErrSlowConsumer
 	}
@@ -151,15 +175,24 @@ func (s *peerScheduler) enqueue(item queuedEnvelope, priority, streamID string) 
 	return nil
 }
 
+func (s *peerScheduler) signalSpace() {
+	select {
+	case s.space <- struct{}{}:
+	default:
+	}
+}
+
 func (s *peerScheduler) next(ctx context.Context) (queuedEnvelope, error) {
 	for {
 		s.mu.Lock()
 		if len(s.control) > 0 {
 			item := s.control[0]
+			s.control[0] = queuedEnvelope{}
 			s.control = s.control[1:]
 			s.queuedBytes -= item.size
 			s.queuedCount--
 			s.mu.Unlock()
+			s.signalSpace()
 			return item, nil
 		}
 		for checked := 0; checked < len(s.streamOrder); checked++ {
@@ -187,6 +220,7 @@ func (s *peerScheduler) next(ctx context.Context) (queuedEnvelope, error) {
 			s.queuedDataBytes -= item.size
 			s.queuedDataCount--
 			s.mu.Unlock()
+			s.signalSpace()
 			return item, nil
 		}
 		s.mu.Unlock()
@@ -403,15 +437,15 @@ func (h *Hub) unregister(state *connState) {
 	}
 }
 
-func (h *Hub) forward(from *connState, data []byte, env Envelope) error {
+func (h *Hub) forward(ctx context.Context, from *connState, data []byte, env Envelope) error {
 	if env.RoomID != from.roomID {
 		return fmt.Errorf("%w: room mismatch", ErrInvalidEnvelope)
 	}
 
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	room, ok := h.rooms[from.roomID]
 	if !ok {
+		h.mu.Unlock()
 		return ErrRoomNotFound
 	}
 	var peer *connState
@@ -421,17 +455,15 @@ func (h *Hub) forward(from *connState, data []byte, env Envelope) error {
 		peer = room.host
 	}
 	if peer == nil {
+		h.mu.Unlock()
 		return ErrPeerNotConnected
 	}
+	h.mu.Unlock()
 	// data is the completed WebSocket message returned by Conn.Read. It has
 	// already passed the same V2 validation as env and is not mutated, so queue
 	// the original bytes instead of copying the opaque payload and re-encoding
 	// an equivalent envelope.
-	if err := peer.enqueue(data, env.Priority, env.StreamID); err != nil {
-		if h.cfg.Metrics != nil && errors.Is(err, ErrSlowConsumer) {
-			h.cfg.Metrics.SlowConsumerCloses.Add(1)
-		}
-		peer.close(websocket.StatusPolicyViolation, "slow consumer")
+	if err := peer.enqueueWait(ctx, data, env.Priority, env.StreamID); err != nil {
 		return err
 	}
 	if h.cfg.Metrics != nil {
@@ -524,7 +556,7 @@ func (c *connState) readLoop(ctx context.Context, cancel context.CancelFunc) err
 			cancel()
 			return err
 		}
-		if err := c.hub.forward(c, data, env); err != nil {
+		if err := c.hub.forward(ctx, c, data, env); err != nil {
 			status := websocket.StatusPolicyViolation
 			if errors.Is(err, ErrPeerNotConnected) {
 				status = websocket.StatusTryAgainLater
@@ -607,6 +639,17 @@ func (c *connState) ping(ctx context.Context) error {
 func (c *connState) enqueue(data []byte, priority, streamID string) error {
 	size := int64(len(data))
 	return c.scheduler.enqueue(queuedEnvelope{data: data, size: size}, priority, streamID)
+}
+
+func (c *connState) enqueueWait(ctx context.Context, data []byte, priority, streamID string) error {
+	size := int64(len(data))
+	return c.scheduler.enqueueWait(
+		ctx,
+		c.done,
+		queuedEnvelope{data: data, size: size},
+		priority,
+		streamID,
+	)
 }
 
 func (c *connState) close(status websocket.StatusCode, reason string) {

--- a/apps/relayd/internal/relay/hub.go
+++ b/apps/relayd/internal/relay/hub.go
@@ -86,20 +86,35 @@ type queuedEnvelope struct {
 // data round-robin by stream. relayd learns only the coarse priority and stream
 // id from the outer envelope; the payload remains opaque.
 type peerScheduler struct {
-	mu           sync.Mutex
-	control      []queuedEnvelope
-	dataByStream map[string][]queuedEnvelope
-	streamOrder  []string
-	nextStream   int
-	queuedBytes  int64
-	queuedCount  int
-	maxBytes     int64
-	maxCount     int
-	signal       chan struct{}
+	mu              sync.Mutex
+	control         []queuedEnvelope
+	dataByStream    map[string][]queuedEnvelope
+	streamOrder     []string
+	nextStream      int
+	queuedBytes     int64
+	queuedCount     int
+	queuedDataBytes int64
+	queuedDataCount int
+	maxBytes        int64
+	maxCount        int
+	maxDataBytes    int64
+	maxDataCount    int
+	signal          chan struct{}
 }
 
-func newPeerScheduler(maxCount int, maxBytes int64) *peerScheduler {
-	return &peerScheduler{dataByStream: map[string][]queuedEnvelope{}, maxCount: maxCount, maxBytes: maxBytes, signal: make(chan struct{}, 1)}
+func newPeerScheduler(maxCount int, maxBytes, maxFrameBytes int64) *peerScheduler {
+	controlReserveCount := max(1, maxCount/8)
+	controlReserveCount = min(controlReserveCount, maxCount)
+	controlReserveBytes := max(maxBytes/8, maxFrameBytes)
+	controlReserveBytes = min(controlReserveBytes, maxBytes)
+	return &peerScheduler{
+		dataByStream: map[string][]queuedEnvelope{},
+		maxCount:     maxCount,
+		maxBytes:     maxBytes,
+		maxDataCount: maxCount - controlReserveCount,
+		maxDataBytes: maxBytes - controlReserveBytes,
+		signal:       make(chan struct{}, 1),
+	}
 }
 
 func (s *peerScheduler) enqueue(item queuedEnvelope, priority, streamID string) error {
@@ -111,6 +126,12 @@ func (s *peerScheduler) enqueue(item queuedEnvelope, priority, streamID string) 
 	if priority == PriorityControl {
 		s.control = append(s.control, item)
 	} else {
+		// Data must leave space for at least one maximum-sized control frame.
+		// Without this separate budget, a bulk sender can fill the shared queue
+		// and force an ACK, close, or peer notification to be rejected.
+		if s.queuedDataBytes+item.size > s.maxDataBytes || s.queuedDataCount >= s.maxDataCount {
+			return ErrSlowConsumer
+		}
 		if streamID == "" {
 			streamID = "_unclassified"
 		}
@@ -118,6 +139,8 @@ func (s *peerScheduler) enqueue(item queuedEnvelope, priority, streamID string) 
 			s.streamOrder = append(s.streamOrder, streamID)
 		}
 		s.dataByStream[streamID] = append(s.dataByStream[streamID], item)
+		s.queuedDataBytes += item.size
+		s.queuedDataCount++
 	}
 	s.queuedBytes += item.size
 	s.queuedCount++
@@ -143,18 +166,26 @@ func (s *peerScheduler) next(ctx context.Context) (queuedEnvelope, error) {
 			index := s.nextStream % len(s.streamOrder)
 			streamID := s.streamOrder[index]
 			items := s.dataByStream[streamID]
-			s.nextStream = (index + 1) % len(s.streamOrder)
 			if len(items) == 0 {
 				continue
 			}
 			item := items[0]
 			if len(items) == 1 {
 				delete(s.dataByStream, streamID)
+				s.streamOrder = append(s.streamOrder[:index], s.streamOrder[index+1:]...)
+				if len(s.streamOrder) == 0 {
+					s.nextStream = 0
+				} else {
+					s.nextStream = index % len(s.streamOrder)
+				}
 			} else {
 				s.dataByStream[streamID] = items[1:]
+				s.nextStream = (index + 1) % len(s.streamOrder)
 			}
 			s.queuedBytes -= item.size
 			s.queuedCount--
+			s.queuedDataBytes -= item.size
+			s.queuedDataCount--
 			s.mu.Unlock()
 			return item, nil
 		}
@@ -303,7 +334,7 @@ func (h *Hub) register(role token.Role, assertion token.Assertion, ws *websocket
 		role:      role,
 		roomID:    assertion.RoomID,
 		conn:      ws,
-		scheduler: newPeerScheduler(h.cfg.MaxQueuedEnvelopes, h.cfg.MaxQueuedBytes),
+		scheduler: newPeerScheduler(h.cfg.MaxQueuedEnvelopes, h.cfg.MaxQueuedBytes, h.cfg.MaxFrameBytes),
 		done:      make(chan struct{}),
 		cfg:       h.cfg,
 		hub:       h,

--- a/apps/relayd/internal/relay/hub.go
+++ b/apps/relayd/internal/relay/hub.go
@@ -403,13 +403,9 @@ func (h *Hub) unregister(state *connState) {
 	}
 }
 
-func (h *Hub) forward(from *connState, env Envelope) error {
+func (h *Hub) forward(from *connState, data []byte, env Envelope) error {
 	if env.RoomID != from.roomID {
 		return fmt.Errorf("%w: room mismatch", ErrInvalidEnvelope)
-	}
-	encoded, err := EncodeEnvelope(env, from.cfg.MaxFrameBytes)
-	if err != nil {
-		return err
 	}
 
 	h.mu.Lock()
@@ -427,7 +423,11 @@ func (h *Hub) forward(from *connState, env Envelope) error {
 	if peer == nil {
 		return ErrPeerNotConnected
 	}
-	if err := peer.enqueue(encoded, env.Priority, env.StreamID); err != nil {
+	// data is the completed WebSocket message returned by Conn.Read. It has
+	// already passed the same V2 validation as env and is not mutated, so queue
+	// the original bytes instead of copying the opaque payload and re-encoding
+	// an equivalent envelope.
+	if err := peer.enqueue(data, env.Priority, env.StreamID); err != nil {
 		if h.cfg.Metrics != nil && errors.Is(err, ErrSlowConsumer) {
 			h.cfg.Metrics.SlowConsumerCloses.Add(1)
 		}
@@ -436,7 +436,7 @@ func (h *Hub) forward(from *connState, env Envelope) error {
 	}
 	if h.cfg.Metrics != nil {
 		h.cfg.Metrics.ForwardedEnvelopes.Add(1)
-		h.cfg.Metrics.ForwardedBytes.Add(int64(len(encoded)))
+		h.cfg.Metrics.ForwardedBytes.Add(int64(len(data)))
 	}
 	return nil
 }
@@ -515,7 +515,7 @@ func (c *connState) readLoop(ctx context.Context, cancel context.CancelFunc) err
 			return ErrInvalidEnvelope
 		}
 		c.lastSeenUnix.Store(time.Now().UnixNano())
-		env, err := ParseEnvelope(data, c.cfg.MaxFrameBytes)
+		env, err := ParseEnvelopeView(data, c.cfg.MaxFrameBytes)
 		if err != nil {
 			if c.cfg.Metrics != nil {
 				c.cfg.Metrics.ValidationFailures.Add(1)
@@ -524,7 +524,7 @@ func (c *connState) readLoop(ctx context.Context, cancel context.CancelFunc) err
 			cancel()
 			return err
 		}
-		if err := c.hub.forward(c, env); err != nil {
+		if err := c.hub.forward(c, data, env); err != nil {
 			status := websocket.StatusPolicyViolation
 			if errors.Is(err, ErrPeerNotConnected) {
 				status = websocket.StatusTryAgainLater

--- a/apps/relayd/internal/relay/hub.go
+++ b/apps/relayd/internal/relay/hub.go
@@ -67,11 +67,10 @@ type connState struct {
 	role         token.Role
 	roomID       string
 	conn         *websocket.Conn
-	outbound     chan queuedEnvelope
+	scheduler    *peerScheduler
 	done         chan struct{}
 	closeOnce    sync.Once
 	writeMu      sync.Mutex
-	pendingBytes atomic.Int64
 	lastSeenUnix atomic.Int64
 	cfg          HubConfig
 	hub          *Hub
@@ -81,6 +80,91 @@ type connState struct {
 type queuedEnvelope struct {
 	data []byte
 	size int64
+}
+
+// peerScheduler reserves queue capacity for control traffic and serves bulk
+// data round-robin by stream. relayd learns only the coarse priority and stream
+// id from the outer envelope; the payload remains opaque.
+type peerScheduler struct {
+	mu           sync.Mutex
+	control      []queuedEnvelope
+	dataByStream map[string][]queuedEnvelope
+	streamOrder  []string
+	nextStream   int
+	queuedBytes  int64
+	queuedCount  int
+	maxBytes     int64
+	maxCount     int
+	signal       chan struct{}
+}
+
+func newPeerScheduler(maxCount int, maxBytes int64) *peerScheduler {
+	return &peerScheduler{dataByStream: map[string][]queuedEnvelope{}, maxCount: maxCount, maxBytes: maxBytes, signal: make(chan struct{}, 1)}
+}
+
+func (s *peerScheduler) enqueue(item queuedEnvelope, priority, streamID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.queuedBytes+item.size > s.maxBytes || s.queuedCount >= s.maxCount {
+		return ErrSlowConsumer
+	}
+	if priority == PriorityControl {
+		s.control = append(s.control, item)
+	} else {
+		if streamID == "" {
+			streamID = "_unclassified"
+		}
+		if _, exists := s.dataByStream[streamID]; !exists {
+			s.streamOrder = append(s.streamOrder, streamID)
+		}
+		s.dataByStream[streamID] = append(s.dataByStream[streamID], item)
+	}
+	s.queuedBytes += item.size
+	s.queuedCount++
+	select {
+	case s.signal <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (s *peerScheduler) next(ctx context.Context) (queuedEnvelope, error) {
+	for {
+		s.mu.Lock()
+		if len(s.control) > 0 {
+			item := s.control[0]
+			s.control = s.control[1:]
+			s.queuedBytes -= item.size
+			s.queuedCount--
+			s.mu.Unlock()
+			return item, nil
+		}
+		for checked := 0; checked < len(s.streamOrder); checked++ {
+			index := s.nextStream % len(s.streamOrder)
+			streamID := s.streamOrder[index]
+			items := s.dataByStream[streamID]
+			s.nextStream = (index + 1) % len(s.streamOrder)
+			if len(items) == 0 {
+				continue
+			}
+			item := items[0]
+			if len(items) == 1 {
+				delete(s.dataByStream, streamID)
+			} else {
+				s.dataByStream[streamID] = items[1:]
+			}
+			s.queuedBytes -= item.size
+			s.queuedCount--
+			s.mu.Unlock()
+			return item, nil
+		}
+		s.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return queuedEnvelope{}, ctx.Err()
+		case <-s.signal:
+		}
+	}
 }
 
 func NewHub(cfg HubConfig) *Hub {
@@ -216,14 +300,14 @@ func (h *Hub) register(role token.Role, assertion token.Assertion, ws *websocket
 	}
 
 	state := &connState{
-		role:     role,
-		roomID:   assertion.RoomID,
-		conn:     ws,
-		outbound: make(chan queuedEnvelope, h.cfg.MaxQueuedEnvelopes),
-		done:     make(chan struct{}),
-		cfg:      h.cfg,
-		hub:      h,
-		logger:   h.logger,
+		role:      role,
+		roomID:    assertion.RoomID,
+		conn:      ws,
+		scheduler: newPeerScheduler(h.cfg.MaxQueuedEnvelopes, h.cfg.MaxQueuedBytes),
+		done:      make(chan struct{}),
+		cfg:       h.cfg,
+		hub:       h,
+		logger:    h.logger,
 	}
 	state.lastSeenUnix.Store(h.now().UnixNano())
 	// Renew the room's TTL on every (re)connect so a reconnecting peer never
@@ -312,7 +396,7 @@ func (h *Hub) forward(from *connState, env Envelope) error {
 	if peer == nil {
 		return ErrPeerNotConnected
 	}
-	if err := peer.enqueue(encoded); err != nil {
+	if err := peer.enqueue(encoded, env.Priority, env.StreamID); err != nil {
 		if h.cfg.Metrics != nil && errors.Is(err, ErrSlowConsumer) {
 			h.cfg.Metrics.SlowConsumerCloses.Add(1)
 		}
@@ -343,7 +427,7 @@ func (h *Hub) notifyPeerLocked(peer *connState, role token.Role, reason string) 
 		h.logger.Warn("encoding peer close envelope failed", "error", err)
 		return
 	}
-	if err := peer.enqueue(encoded); err != nil {
+	if err := peer.enqueue(encoded, PriorityControl, ""); err != nil {
 		peer.close(websocket.StatusPolicyViolation, "slow consumer")
 	}
 }
@@ -386,13 +470,18 @@ func (h *Hub) renewRoom(roomID string, now time.Time) {
 func (c *connState) readLoop(ctx context.Context, cancel context.CancelFunc) error {
 	c.conn.SetReadLimit(c.cfg.MaxFrameBytes)
 	for {
-		_, data, err := c.conn.Read(ctx)
+		messageType, data, err := c.conn.Read(ctx)
 		if err != nil {
 			cancel()
 			if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
 				return nil
 			}
 			return fmt.Errorf("reading websocket: %w", err)
+		}
+		if messageType != websocket.MessageBinary {
+			c.close(websocket.StatusUnsupportedData, "relay frames must be binary")
+			cancel()
+			return ErrInvalidEnvelope
 		}
 		c.lastSeenUnix.Store(time.Now().UnixNano())
 		env, err := ParseEnvelope(data, c.cfg.MaxFrameBytes)
@@ -418,18 +507,16 @@ func (c *connState) readLoop(ctx context.Context, cancel context.CancelFunc) err
 
 func (c *connState) writeLoop(ctx context.Context, cancel context.CancelFunc) {
 	for {
-		select {
-		case <-ctx.Done():
+		item, err := c.scheduler.next(ctx)
+		if err != nil {
 			return
-		case item := <-c.outbound:
-			c.pendingBytes.Add(-item.size)
-			writeCtx, stop := context.WithTimeout(ctx, 10*time.Second)
-			err := c.write(writeCtx, item.data)
-			stop()
-			if err != nil {
-				cancel()
-				return
-			}
+		}
+		writeCtx, stop := context.WithTimeout(ctx, 10*time.Second)
+		err = c.write(writeCtx, item.data)
+		stop()
+		if err != nil {
+			cancel()
+			return
 		}
 	}
 }
@@ -477,7 +564,7 @@ func (c *connState) heartbeatLoop(ctx context.Context, cancel context.CancelFunc
 func (c *connState) write(ctx context.Context, data []byte) error {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
-	return c.conn.Write(ctx, websocket.MessageText, data)
+	return c.conn.Write(ctx, websocket.MessageBinary, data)
 }
 
 func (c *connState) ping(ctx context.Context) error {
@@ -486,20 +573,9 @@ func (c *connState) ping(ctx context.Context) error {
 	return c.conn.Ping(ctx)
 }
 
-func (c *connState) enqueue(data []byte) error {
+func (c *connState) enqueue(data []byte, priority, streamID string) error {
 	size := int64(len(data))
-	nextBytes := c.pendingBytes.Add(size)
-	if nextBytes > c.cfg.MaxQueuedBytes {
-		c.pendingBytes.Add(-size)
-		return ErrSlowConsumer
-	}
-	select {
-	case c.outbound <- queuedEnvelope{data: data, size: size}:
-		return nil
-	default:
-		c.pendingBytes.Add(-size)
-		return ErrSlowConsumer
-	}
+	return c.scheduler.enqueue(queuedEnvelope{data: data, size: size}, priority, streamID)
 }
 
 func (c *connState) close(status websocket.StatusCode, reason string) {

--- a/apps/relayd/internal/relay/hub_test.go
+++ b/apps/relayd/internal/relay/hub_test.go
@@ -99,6 +99,48 @@ func TestHubRenewRoomExtendsExpiry(t *testing.T) {
 	}
 }
 
+func TestHubForwardQueuesOriginalValidatedFrame(t *testing.T) {
+	now := time.Unix(1000, 0)
+	hub := newTestHub(func() time.Time { return now })
+	frame, err := EncodeEnvelope(Envelope{
+		Version:  ProtocolVersion,
+		RoomID:   "room_forward",
+		Seq:      7,
+		Kind:     KindRelayDataFrame,
+		Priority: PriorityData,
+		StreamID: "stream_1",
+		Payload:  []byte("opaque ciphertext"),
+	}, hub.cfg.MaxFrameBytes)
+	if err != nil {
+		t.Fatalf("EncodeEnvelope() error = %v", err)
+	}
+	env, err := ParseEnvelopeView(frame, hub.cfg.MaxFrameBytes)
+	if err != nil {
+		t.Fatalf("ParseEnvelopeView() error = %v", err)
+	}
+	from := &connState{role: RoleHost, roomID: env.RoomID, cfg: hub.cfg}
+	peer := &connState{
+		role:      RoleController,
+		roomID:    env.RoomID,
+		scheduler: newPeerScheduler(hub.cfg.MaxQueuedEnvelopes, hub.cfg.MaxQueuedBytes, hub.cfg.MaxFrameBytes),
+	}
+	hub.rooms[env.RoomID] = &room{id: env.RoomID, host: from, controller: peer}
+
+	if err := hub.forward(from, frame, env); err != nil {
+		t.Fatalf("forward() error = %v", err)
+	}
+	item, err := peer.scheduler.next(t.Context())
+	if err != nil {
+		t.Fatalf("scheduler.next() error = %v", err)
+	}
+	if string(item.data) != string(frame) {
+		t.Fatalf("forwarded bytes differ from original frame")
+	}
+	if &item.data[0] != &frame[0] {
+		t.Fatal("forwarded frame does not retain the original byte slice")
+	}
+}
+
 func TestHubCreateRoomIdempotentRenews(t *testing.T) {
 	now := time.Unix(1000, 0)
 	hub := newTestHub(func() time.Time { return now })

--- a/apps/relayd/internal/relay/hub_test.go
+++ b/apps/relayd/internal/relay/hub_test.go
@@ -123,3 +123,29 @@ func TestHubCreateRoomIdempotentRenews(t *testing.T) {
 		t.Fatal("createdAt should be preserved across idempotent renewal")
 	}
 }
+
+func TestPeerSchedulerPrioritizesControlAndRoundRobinsDataStreams(t *testing.T) {
+	scheduler := newPeerScheduler(8, 4096)
+	for _, item := range []struct{ stream, data string }{
+		{"a", "a1"}, {"a", "a2"}, {"b", "b1"},
+	} {
+		if err := scheduler.enqueue(queuedEnvelope{data: []byte(item.data), size: int64(len(item.data))}, PriorityData, item.stream); err != nil {
+			t.Fatalf("enqueue data: %v", err)
+		}
+	}
+	if err := scheduler.enqueue(queuedEnvelope{data: []byte("ack"), size: 3}, PriorityControl, ""); err != nil {
+		t.Fatalf("enqueue control: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	want := []string{"ack", "a1", "b1", "a2"}
+	for _, expected := range want {
+		item, err := scheduler.next(ctx)
+		if err != nil {
+			t.Fatalf("next() error = %v", err)
+		}
+		if got := string(item.data); got != expected {
+			t.Fatalf("next() = %q, expected %q", got, expected)
+		}
+	}
+}

--- a/apps/relayd/internal/relay/hub_test.go
+++ b/apps/relayd/internal/relay/hub_test.go
@@ -126,7 +126,7 @@ func TestHubForwardQueuesOriginalValidatedFrame(t *testing.T) {
 	}
 	hub.rooms[env.RoomID] = &room{id: env.RoomID, host: from, controller: peer}
 
-	if err := hub.forward(from, frame, env); err != nil {
+	if err := hub.forward(t.Context(), from, frame, env); err != nil {
 		t.Fatalf("forward() error = %v", err)
 	}
 	item, err := peer.scheduler.next(t.Context())
@@ -226,5 +226,64 @@ func TestPeerSchedulerReservesCapacityForControlAndPrunesDrainedStreams(t *testi
 	}
 	if got := len(scheduler.dataByStream); got != 0 {
 		t.Fatalf("dataByStream retains drained streams: %d", got)
+	}
+}
+
+func TestPeerSchedulerBackpressuresAndResumesDataInsteadOfDroppingPeer(t *testing.T) {
+	scheduler := newPeerScheduler(4, 4096, 1024)
+	for index := range 3 {
+		if err := scheduler.enqueue(queuedEnvelope{data: []byte{byte(index)}, size: 1024}, PriorityData, "bulk"); err != nil {
+			t.Fatalf("fill data queue %d: %v", index, err)
+		}
+	}
+
+	done := make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		result <- scheduler.enqueueWait(
+			t.Context(),
+			done,
+			queuedEnvelope{data: []byte("next"), size: 1024},
+			PriorityData,
+			"bulk",
+		)
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("enqueueWait returned before queue space was available: %v", err)
+	default:
+	}
+	if _, err := scheduler.next(t.Context()); err != nil {
+		t.Fatalf("drain one queued frame: %v", err)
+	}
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("enqueueWait after drain: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("enqueueWait did not resume after queue space became available")
+	}
+}
+
+func TestPeerSchedulerBackpressureStopsWhenContextIsCancelled(t *testing.T) {
+	scheduler := newPeerScheduler(4, 4096, 1024)
+	for index := range 3 {
+		if err := scheduler.enqueue(queuedEnvelope{data: []byte{byte(index)}, size: 1024}, PriorityData, "bulk"); err != nil {
+			t.Fatalf("fill data queue %d: %v", index, err)
+		}
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err := scheduler.enqueueWait(
+		ctx,
+		make(chan struct{}),
+		queuedEnvelope{data: []byte("next"), size: 1024},
+		PriorityData,
+		"bulk",
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("enqueueWait cancellation error = %v, expected context.Canceled", err)
 	}
 }

--- a/apps/relayd/internal/relay/hub_test.go
+++ b/apps/relayd/internal/relay/hub_test.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -125,7 +126,7 @@ func TestHubCreateRoomIdempotentRenews(t *testing.T) {
 }
 
 func TestPeerSchedulerPrioritizesControlAndRoundRobinsDataStreams(t *testing.T) {
-	scheduler := newPeerScheduler(8, 4096)
+	scheduler := newPeerScheduler(8, 4096, 1024)
 	for _, item := range []struct{ stream, data string }{
 		{"a", "a1"}, {"a", "a2"}, {"b", "b1"},
 	} {
@@ -147,5 +148,41 @@ func TestPeerSchedulerPrioritizesControlAndRoundRobinsDataStreams(t *testing.T) 
 		if got := string(item.data); got != expected {
 			t.Fatalf("next() = %q, expected %q", got, expected)
 		}
+	}
+}
+
+func TestPeerSchedulerReservesCapacityForControlAndPrunesDrainedStreams(t *testing.T) {
+	scheduler := newPeerScheduler(4, 4096, 1024)
+	for index := 0; index < 3; index++ {
+		if err := scheduler.enqueue(queuedEnvelope{data: []byte("bulk"), size: 1024}, PriorityData, "bulk"); err != nil {
+			t.Fatalf("enqueue reserved data %d: %v", index, err)
+		}
+	}
+	if err := scheduler.enqueue(queuedEnvelope{data: []byte("overflow"), size: 1024}, PriorityData, "bulk"); !errors.Is(err, ErrSlowConsumer) {
+		t.Fatalf("enqueue data into control reserve = %v, expected ErrSlowConsumer", err)
+	}
+	if err := scheduler.enqueue(queuedEnvelope{data: []byte("ack"), size: 1024}, PriorityControl, ""); err != nil {
+		t.Fatalf("enqueue control into reserved capacity: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	first, err := scheduler.next(ctx)
+	if err != nil {
+		t.Fatalf("next control: %v", err)
+	}
+	if got := string(first.data); got != "ack" {
+		t.Fatalf("next control = %q, expected ack", got)
+	}
+	for range 3 {
+		if _, err := scheduler.next(ctx); err != nil {
+			t.Fatalf("drain data: %v", err)
+		}
+	}
+	if got := len(scheduler.streamOrder); got != 0 {
+		t.Fatalf("streamOrder retains drained streams: %d", got)
+	}
+	if got := len(scheduler.dataByStream); got != 0 {
+		t.Fatalf("dataByStream retains drained streams: %d", got)
 	}
 }

--- a/apps/relayd/package.json
+++ b/apps/relayd/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build:desktop-resource": "node scripts/build-desktop-resource.mjs",
+    "benchmark:forward": "go test -run '^$' -bench BenchmarkRelayForwardPath -benchmem ./internal/relay",
     "test": "go test ./..."
   }
 }

--- a/apps/relayd/package.json
+++ b/apps/relayd/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "build:desktop-resource": "node scripts/build-desktop-resource.mjs",
-    "benchmark:forward": "go test -run '^$' -bench BenchmarkRelayForwardPath -benchmem ./internal/relay",
+    "benchmark:compare": "pnpm run benchmark:forward && pnpm --dir ../server benchmark:relay",
+    "benchmark:forward": "node scripts/relay-forward-benchmark.mjs",
     "test": "go test ./..."
   }
 }

--- a/apps/relayd/scripts/relay-forward-benchmark.mjs
+++ b/apps/relayd/scripts/relay-forward-benchmark.mjs
@@ -1,0 +1,56 @@
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const relaydDir = fileURLToPath(new URL('..', import.meta.url))
+const output = execFileSync(
+  'go',
+  ['test', '-count=1', '-run', '^$', '-bench', 'BenchmarkRelayForwardPath', '-benchmem', './internal/relay'],
+  { cwd: relaydDir, encoding: 'utf8' },
+)
+
+process.stdout.write(output)
+
+const expectedGenerations = [
+  'v1-json-parse-reencode',
+  'v2-before-parse-reencode',
+  'v2-current-validated-passthrough',
+]
+const samples = new Map()
+const linePattern = /^BenchmarkRelayForwardPath\/(?<size>[^/]+)\/(?<generation>.+)-\d+\s+\d+\s+(?<ns>[\d.]+) ns\/op\s+[\d.]+ MB\/s\s+(?<bytes>\d+) B\/op\s+(?<allocs>\d+) allocs\/op$/
+
+for (const line of output.split('\n')) {
+  const match = line.match(linePattern)
+  if (!match?.groups) { continue }
+  const { size, generation, ns, bytes, allocs } = match.groups
+  if (!expectedGenerations.includes(generation)) { continue }
+  const byGeneration = samples.get(size) ?? new Map()
+  byGeneration.set(generation, { ns, bytes, allocs })
+  samples.set(size, byGeneration)
+}
+
+const sizes = ['1KiB', '64KiB', '256KiB']
+for (const size of sizes) {
+  const byGeneration = samples.get(size)
+  if (!byGeneration || expectedGenerations.some(generation => !byGeneration.has(generation))) {
+    throw new Error(`Missing Relay benchmark result for ${size}; refusing to print a partial comparison.`)
+  }
+}
+
+function renderSample(sample) {
+  return `${sample.ns} ns/op · ${sample.bytes} B/op · ${sample.allocs} allocs/op`
+}
+
+console.info([
+  '# Relay forwarding — actual three-generation comparison',
+  '',
+  'Same logical payload per row. Each generation processes its own actual wire frame; V1 JSON/Base64 is therefore intentionally larger than V2 binary.',
+  '',
+  '| Logical payload | V1 JSON parse + re-encode | V2 before pass-through | V2 current pass-through |',
+  '| ---: | --- | --- | --- |',
+  ...sizes.map((size) => {
+    const byGeneration = samples.get(size)
+    return `| ${size} | ${renderSample(byGeneration.get('v1-json-parse-reencode'))} | ${renderSample(byGeneration.get('v2-before-parse-reencode'))} | ${renderSample(byGeneration.get('v2-current-validated-passthrough'))} |`
+  }),
+  '',
+  'V1 → V2 includes protocol/encoding changes. V2-before → V2-current keeps identical V2 wire bytes and isolates the Relay copy/re-encode elimination.',
+].join('\n'))

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -33,7 +33,8 @@
     "test": "pnpm --filter @cradle/plugin-sdk build && pnpm --filter \"../../plugins/*\" build && vitest run",
     "test:watch": "vitest",
     "benchmark:relay": "vitest run tests/relay-transport/performance-compare.test.ts --reporter=verbose",
-    "benchmark:relay:runtime": "vitest run tests/relay-transport/e2e.test.ts --reporter=verbose"
+    "benchmark:relay:full": "pnpm run benchmark:relay && pnpm run benchmark:relay:runtime",
+    "benchmark:relay:runtime": "vitest run tests/relay-transport/e2e.test.ts tests/relay-transport/latency-window-benchmark.test.ts --reporter=verbose"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.76",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,7 +31,9 @@
     "typecheck": "pnpm --filter @cradle/plugin-sdk build && tsc --noEmit && pnpm check:boundaries",
     "check:boundaries": "tsx scripts/check-module-boundaries.ts",
     "test": "pnpm --filter @cradle/plugin-sdk build && pnpm --filter \"../../plugins/*\" build && vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "benchmark:relay": "vitest run tests/relay-transport/performance-compare.test.ts --reporter=verbose",
+    "benchmark:relay:runtime": "vitest run tests/relay-transport/e2e.test.ts --reporter=verbose"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.76",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -33,8 +33,9 @@
     "test": "pnpm --filter @cradle/plugin-sdk build && pnpm --filter \"../../plugins/*\" build && vitest run",
     "test:watch": "vitest",
     "benchmark:relay": "vitest run tests/relay-transport/performance-compare.test.ts --reporter=verbose",
+    "benchmark:relay:codec": "vitest run tests/relay-transport/codec-throughput-benchmark.test.ts --reporter=verbose --maxWorkers=1 --no-file-parallelism",
     "benchmark:relay:full": "pnpm run benchmark:relay && pnpm run benchmark:relay:runtime",
-    "benchmark:relay:runtime": "vitest run tests/relay-transport/e2e.test.ts tests/relay-transport/latency-window-benchmark.test.ts --reporter=verbose"
+    "benchmark:relay:runtime": "vitest run tests/relay-transport/codec-throughput-benchmark.test.ts tests/relay-transport/adverse-network-benchmark.test.ts tests/relay-transport/e2e.test.ts tests/relay-transport/latency-window-benchmark.test.ts --reporter=verbose --maxWorkers=1 --no-file-parallelism"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.76",

--- a/apps/server/src/modules/relay-transport/README.md
+++ b/apps/server/src/modules/relay-transport/README.md
@@ -99,7 +99,9 @@ other's windows. After sustained successful application acknowledgements, the
 sender may grow its bounded window up to 8 MiB. The receiver only emits
 cumulative `stream_ack` frames after the local transport has applied the bytes
 (TCP write success), typically every 64 KiB, so a slow consumer cannot inflate
-the peer's send window.
+the peer's send window. A separate 16 MiB connection-wide cap bounds the sum
+of all streams' in-flight data, so concurrent transfers cannot multiply the
+per-stream maximum without limit.
 
 ## Performance checkpoints and benchmark
 

--- a/apps/server/src/modules/relay-transport/README.md
+++ b/apps/server/src/modules/relay-transport/README.md
@@ -90,13 +90,38 @@ The controller side opens a local listener on `127.0.0.1:<port>` and returns
 socket; they become encrypted `stream_data` frames over relayd and exit on the
 host side as a TCP connection to the host Cradle Server's own local HTTP port.
 
-The stream protocol uses 256 KiB chunks and a 512 KiB unacknowledged credit
-window. Send-side credit (`peerAckedBytes` / `bytesInFlight`) and receive-side
-progress (`appliedBytes` / `ackedToPeerBytes`) are tracked separately on each
-stream — HTTP request and response share one `streamId` and must not corrupt
-each other's windows. The receiver only emits cumulative `stream_ack` frames
-after the local transport has applied the bytes (TCP write success), typically
-every 64 KiB, so a slow consumer cannot inflate the peer's send window.
+The binary v2 stream protocol uses 64 KiB maximum data chunks and starts each
+stream at a 512 KiB unacknowledged credit window. Send-side credit
+(`peerAckedBytes` / `bytesInFlight`) and receive-side progress
+(`appliedBytes` / `ackedToPeerBytes`) are tracked separately on each stream —
+HTTP request and response share one `streamId` and must not corrupt each
+other's windows. After sustained successful application acknowledgements, the
+sender may grow its bounded window up to 8 MiB. The receiver only emits
+cumulative `stream_ack` frames after the local transport has applied the bytes
+(TCP write success), typically every 64 KiB, so a slow consumer cannot inflate
+the peer's send window.
+
+## Performance checkpoints and benchmark
+
+`RelayControllerTransportHandle.getPerformanceSnapshot()` records a bounded,
+in-memory timeline for each controller tunnel: connection attempt start,
+WebSocket open, encrypted handshake ready, local listener ready, and the
+open/first-request-byte/first-response-byte/close timestamps for recent
+streams. It retains no HTTP path, header, or payload bytes.
+
+`GET /remote-hosts/:hostId/cradle-server/health` exposes this timeline as
+`relayPerformance` for Relay transports; other transports return `null`. A
+remote host is `warming` while its startup connection promise is pending.
+
+Run the reproducible Old/New model with:
+
+    pnpm --filter @cradle/server benchmark:relay
+
+It prints a named Run, Markdown table, and machine-readable JSON for codec
+bytes, FIFO-versus-priority scheduling, and bounded-window behavior at several
+RTTs. Run `pnpm --filter @cradle/server benchmark:relay:runtime` for the
+separate real-relayd cold/warm timestamp sample. The latter is a local sample,
+not an Internet-latency forecast.
 
 Pairing codes are returned on create (as `pairingString`) and may be re-read
 only via `GET .../pairing-string` while the enrollment is still pairable.

--- a/apps/server/src/modules/relay-transport/README.md
+++ b/apps/server/src/modules/relay-transport/README.md
@@ -25,9 +25,14 @@ relay server registry rows. The controller-side remote host row remains owned by
 
 - `protocol.ts`: relayd envelope mirror plus the encrypted inner frame schemas.
 - `crypto.ts`: X25519 key agreement, HKDF key derivation, pairing confirmation,
-  public-key fingerprints, and XChaCha20-Poly1305 frame encryption.
+  public-key fingerprints, and size-adaptive XChaCha20-Poly1305/AES-256-GCM
+  frame encryption.
+- `compression.ts`: independent Zstandard chunk encoding with bounded decode
+  output and raw fallback for data that does not shrink.
 - `session.ts`: shared controller/host handshake state machine, encrypted frame
   handling, stream multiplexing, and credit-based flow control.
+- `websocket-data.ts`: zero-copy WebSocket `RawData` views for the endpoint hot
+  path.
 - `controller-transport.ts`: controller-side WebSocket connection and local TCP
   listener. It returns the shared `LocalTunnelHandle` contract owned by
   `src/runtime/local-tunnel.ts`.
@@ -90,18 +95,26 @@ The controller side opens a local listener on `127.0.0.1:<port>` and returns
 socket; they become encrypted `stream_data` frames over relayd and exit on the
 host side as a TCP connection to the host Cradle Server's own local HTTP port.
 
-The binary v2 stream protocol uses 64 KiB maximum data chunks and starts each
-stream at a 512 KiB unacknowledged credit window. Send-side credit
+The binary v2 stream protocol uses 64 KiB maximum data chunks. Chunks of at
+least 1 KiB are compressed independently with native Zstandard level 1 only
+when the result is at least 64 bytes smaller; incompressible and interactive
+small chunks remain raw. Small protocol frames retain low-fixed-cost
+XChaCha20-Poly1305, while bulk frames use native AES-256-GCM. Both choices are
+authenticated end to end and opaque to relayd.
+
+Each stream starts with a 512 KiB unacknowledged credit window. Send-side credit
 (`peerAckedBytes` / `bytesInFlight`) and receive-side progress
 (`appliedBytes` / `ackedToPeerBytes`) are tracked separately on each stream —
 HTTP request and response share one `streamId` and must not corrupt each
 other's windows. After sustained successful application acknowledgements, the
 sender may grow its bounded window up to 8 MiB. The receiver only emits
 cumulative `stream_ack` frames after the local transport has applied the bytes
-(TCP write success), typically every 64 KiB, so a slow consumer cannot inflate
+(TCP write success), typically every 256 KiB, so a slow consumer cannot inflate
 the peer's send window. A separate 16 MiB connection-wide cap bounds the sum
 of all streams' in-flight data, so concurrent transfers cannot multiply the
-per-stream maximum without limit.
+per-stream maximum without limit. RelaySession serves ready streams round-robin,
+and relayd now backpressures a saturated peer queue instead of disconnecting it;
+control frames retain reserved capacity and priority.
 
 ## Performance checkpoints and benchmark
 
@@ -115,15 +128,17 @@ streams. It retains no HTTP path, header, or payload bytes.
 `relayPerformance` for Relay transports; other transports return `null`. A
 remote host is `warming` while its startup connection promise is pending.
 
-Run the reproducible Old/New model with:
+Run the reproducible V2 before/after model with:
 
     pnpm --filter @cradle/server benchmark:relay
 
 It prints a named Run, Markdown table, and machine-readable JSON for codec
 bytes, FIFO-versus-priority scheduling, and bounded-window behavior at several
-RTTs. Run `pnpm --filter @cradle/server benchmark:relay:runtime` for the
-separate real-relayd cold/warm timestamp sample. The latter is a local sample,
-not an Internet-latency forecast.
+RTTs. Run `pnpm --filter @cradle/server benchmark:relay:runtime` for endpoint
+codec CPU throughput, deterministic bandwidth/RTT/jitter/loss scenarios,
+virtual high-RTT flow-control results, and the real-relayd cold/warm/concurrency
+sample. Run `benchmark:relay:full` for both groups. The real-relayd timing is a
+loopback sample, not an Internet-latency forecast.
 
 Pairing codes are returned on create (as `pairingString`) and may be re-read
 only via `GET .../pairing-string` while the enrollment is still pairable.

--- a/apps/server/src/modules/relay-transport/compression.ts
+++ b/apps/server/src/modules/relay-transport/compression.ts
@@ -1,0 +1,110 @@
+import {
+  constants as zlibConstants,
+  zstdCompressSync,
+  zstdDecompressSync,
+} from 'node:zlib'
+
+import { AppError } from '../../errors/app-error'
+import { RELAY_MAX_STREAM_CHUNK_BYTES } from './protocol'
+
+export const RELAY_COMPRESSION_KIND = {
+  none: 'none',
+  zstd: 'zstd',
+} as const
+
+export type RelayCompressionKind
+  = (typeof RELAY_COMPRESSION_KIND)[keyof typeof RELAY_COMPRESSION_KIND]
+
+export interface EncodedRelayChunk {
+  data: Uint8Array
+  compression: RelayCompressionKind
+  uncompressedBytes: number
+}
+
+export const RELAY_MIN_COMPRESSION_INPUT_BYTES = 1024
+const MIN_COMPRESSION_SAVINGS_BYTES = 64
+const ZSTD_OPTIONS = {
+  params: {
+    [zlibConstants.ZSTD_c_compressionLevel]: 1,
+  },
+} as const
+
+function bufferView(bytes: Uint8Array): Buffer {
+  return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+}
+
+/**
+ * Compress one independently decodable stream chunk before encryption. Level 1
+ * keeps compression below the cost of the old pure-JS cipher on 64 KiB chunks.
+ * Incompressible and tiny chunks stay raw so compression never expands the wire.
+ */
+export function encodeRelayChunk(
+  data: Uint8Array,
+  compressionEnabled = true,
+): EncodedRelayChunk {
+  if (data.byteLength < RELAY_MIN_COMPRESSION_INPUT_BYTES || !compressionEnabled) {
+    return {
+      data,
+      compression: RELAY_COMPRESSION_KIND.none,
+      uncompressedBytes: data.byteLength,
+    }
+  }
+
+  const compressed = zstdCompressSync(bufferView(data), ZSTD_OPTIONS)
+  if (compressed.byteLength + MIN_COMPRESSION_SAVINGS_BYTES >= data.byteLength) {
+    return {
+      data,
+      compression: RELAY_COMPRESSION_KIND.none,
+      uncompressedBytes: data.byteLength,
+    }
+  }
+  return {
+    data: new Uint8Array(compressed.buffer, compressed.byteOffset, compressed.byteLength),
+    compression: RELAY_COMPRESSION_KIND.zstd,
+    uncompressedBytes: data.byteLength,
+  }
+}
+
+export function decodeRelayChunk(chunk: EncodedRelayChunk): Uint8Array {
+  if (chunk.compression === RELAY_COMPRESSION_KIND.none) {
+    if (chunk.data.byteLength !== chunk.uncompressedBytes) {
+      throw compressionError('Raw Relay chunk length does not match its declared length.')
+    }
+    return chunk.data
+  }
+  if (
+    chunk.uncompressedBytes <= 0
+    || chunk.uncompressedBytes > RELAY_MAX_STREAM_CHUNK_BYTES
+  ) {
+    throw compressionError('Compressed Relay chunk declares an invalid output length.')
+  }
+  try {
+    const decompressed = zstdDecompressSync(bufferView(chunk.data), {
+      maxOutputLength: chunk.uncompressedBytes,
+    })
+    if (decompressed.byteLength !== chunk.uncompressedBytes) {
+      throw compressionError('Compressed Relay chunk output length does not match its declaration.')
+    }
+    return new Uint8Array(
+      decompressed.buffer,
+      decompressed.byteOffset,
+      decompressed.byteLength,
+    )
+  }
+  catch (error) {
+    if (error instanceof AppError) {
+      throw error
+    }
+    throw compressionError(
+      `Relay chunk decompression failed: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}
+
+function compressionError(message: string): AppError {
+  return new AppError({
+    code: 'relay_protocol_invalid_compression',
+    status: 400,
+    message,
+  })
+}

--- a/apps/server/src/modules/relay-transport/controller-transport.ts
+++ b/apps/server/src/modules/relay-transport/controller-transport.ts
@@ -51,12 +51,44 @@ export interface RelayControllerTransportHandle extends LocalTunnelHandle {
   readonly controllerPublicKeyBase64: string
   /** The host public key learned during the handshake (pin it for reconnect). */
   readonly hostPublicKeyBase64: string | null
+  /**
+   * In-memory timestamps for the current tunnel. These contain no request
+   * contents; callers can use them to compare cold setup with warm streams.
+   */
+  getPerformanceSnapshot: () => RelayControllerPerformanceSnapshot
 }
 
 interface ActiveStream {
   socket: net.Socket
   streamId: string
+  checkpoint: RelayStreamCheckpoint
 }
+
+export interface RelayConnectionAttemptCheckpoint {
+  attempt: number
+  startedAt: number
+  websocketOpenedAt: number | null
+  handshakeReadyAt: number | null
+  failedAt: number | null
+}
+
+export interface RelayStreamCheckpoint {
+  streamId: string
+  openedAt: number
+  firstRequestByteAt: number | null
+  firstResponseByteAt: number | null
+  closedAt: number | null
+}
+
+export interface RelayControllerPerformanceSnapshot {
+  connectionAttempts: RelayConnectionAttemptCheckpoint[]
+  localListenerReadyAt: number | null
+  activeStreams: RelayStreamCheckpoint[]
+  completedStreams: RelayStreamCheckpoint[]
+}
+
+const MAX_RELAY_CONNECTION_ATTEMPTS = 16
+const MAX_RELAY_COMPLETED_STREAMS = 32
 
 export async function startRelayControllerTransport(
   options: RelayControllerTransportOptions,
@@ -89,6 +121,9 @@ class ControllerTransport {
   private streamCounter = 0
   private closed = false
   private hostPublicKeyBase64: string | null = null
+  private readonly connectionAttempts: RelayConnectionAttemptCheckpoint[] = []
+  private readonly completedStreams: RelayStreamCheckpoint[] = []
+  private localListenerReadyAt: number | null = null
 
   constructor(
     private readonly options: RelayControllerTransportOptions,
@@ -110,6 +145,7 @@ class ControllerTransport {
       }
  catch (error) {
         lastError = error
+        this.failCurrentConnectionAttempt()
         await this.teardown()
         if (Date.now() >= deadline) {
           break
@@ -125,6 +161,7 @@ class ControllerTransport {
   }
 
   private connectAndHandshake(remainingMs: number): Promise<void> {
+    const checkpoint = this.startConnectionAttempt()
     const wsUrl = toWebSocketUrl(this.options.relayUrl, '/ws/controller')
     return new Promise<void>((resolve, reject) => {
       let settled = false
@@ -185,6 +222,7 @@ class ControllerTransport {
             }
           },
           onReady: () => {
+            checkpoint.handshakeReadyAt = Date.now()
             // Swap the handshake close handler for a post-ready one: a drop
             // after ready is a tunnel exit, not a handshake failure.
             ws.removeAllListeners('close')
@@ -206,7 +244,10 @@ class ControllerTransport {
       )
       this.session = session
 
-      ws.once('open', () => session.start())
+      ws.once('open', () => {
+        checkpoint.websocketOpenedAt = Date.now()
+        session.start()
+      })
       ws.on('message', (data: WebSocket.RawData) => {
         try {
           session.handleEnvelope(
@@ -242,6 +283,7 @@ class ControllerTransport {
       }
       const onListening = () => {
         server.off('error', onError)
+        this.localListenerReadyAt = Date.now()
         resolve()
       }
       server.once('error', onError)
@@ -257,19 +299,27 @@ class ControllerTransport {
       return
     }
     const streamId = `c${++this.streamCounter}`
-    this.streams.set(streamId, { socket, streamId })
+    const checkpoint: RelayStreamCheckpoint = {
+      streamId,
+      openedAt: Date.now(),
+      firstRequestByteAt: null,
+      firstResponseByteAt: null,
+      closedAt: null,
+    }
+    this.streams.set(streamId, { socket, streamId, checkpoint })
     session.openStream(streamId)
 
     socket.on('data', (chunk: Buffer) => {
+      checkpoint.firstRequestByteAt ??= Date.now()
       session.writeStreamData(streamId, new Uint8Array(chunk))
     })
     socket.on('close', () => {
       session.closeStream(streamId, 'local socket closed')
-      this.streams.delete(streamId)
+      this.completeStream(streamId)
     })
     socket.on('error', () => {
       session.closeStream(streamId, 'local socket error')
-      this.streams.delete(streamId)
+      this.completeStream(streamId)
     })
   }
 
@@ -279,6 +329,7 @@ class ControllerTransport {
     if (!stream || !session) {
       return
     }
+    stream.checkpoint.firstResponseByteAt ??= Date.now()
     const chunk = Buffer.from(data)
     const accepted = stream.socket.write(chunk, (error) => {
       if (error) {
@@ -306,7 +357,7 @@ class ControllerTransport {
       return
     }
     stream.socket.destroy()
-    this.streams.delete(streamId)
+    this.completeStream(streamId)
   }
 
   private fireExit(code: number | null, signal: NodeJS.Signals | null): void {
@@ -340,7 +391,53 @@ class ControllerTransport {
     for (const { socket } of this.streams.values()) {
       socket.destroy()
     }
-    this.streams.clear()
+    for (const streamId of [...this.streams.keys()]) {
+      this.completeStream(streamId)
+    }
+  }
+
+  private startConnectionAttempt(): RelayConnectionAttemptCheckpoint {
+    const checkpoint: RelayConnectionAttemptCheckpoint = {
+      attempt: this.connectionAttempts.length + 1,
+      startedAt: Date.now(),
+      websocketOpenedAt: null,
+      handshakeReadyAt: null,
+      failedAt: null,
+    }
+    this.connectionAttempts.push(checkpoint)
+    if (this.connectionAttempts.length > MAX_RELAY_CONNECTION_ATTEMPTS) {
+      this.connectionAttempts.shift()
+    }
+    return checkpoint
+  }
+
+  private failCurrentConnectionAttempt(): void {
+    const checkpoint = this.connectionAttempts.at(-1)
+    if (checkpoint && !checkpoint.handshakeReadyAt && !checkpoint.failedAt) {
+      checkpoint.failedAt = Date.now()
+    }
+  }
+
+  private completeStream(streamId: string): void {
+    const stream = this.streams.get(streamId)
+    if (!stream) {
+      return
+    }
+    stream.checkpoint.closedAt ??= Date.now()
+    this.streams.delete(streamId)
+    this.completedStreams.push(stream.checkpoint)
+    if (this.completedStreams.length > MAX_RELAY_COMPLETED_STREAMS) {
+      this.completedStreams.shift()
+    }
+  }
+
+  getPerformanceSnapshot(): RelayControllerPerformanceSnapshot {
+    return {
+      connectionAttempts: this.connectionAttempts.map(checkpoint => ({ ...checkpoint })),
+      localListenerReadyAt: this.localListenerReadyAt,
+      activeStreams: Array.from(this.streams.values(), stream => ({ ...stream.checkpoint })),
+      completedStreams: this.completedStreams.map(checkpoint => ({ ...checkpoint })),
+    }
   }
 
   toHandle(): RelayControllerTransportHandle {
@@ -359,6 +456,7 @@ class ControllerTransport {
         return keypair.publicKeyBase64
       },
       hostPublicKeyBase64: this.hostPublicKeyBase64,
+      getPerformanceSnapshot: () => this.getPerformanceSnapshot(),
       onExit: (listener) => {
         exitListeners.add(listener)
       },

--- a/apps/server/src/modules/relay-transport/controller-transport.ts
+++ b/apps/server/src/modules/relay-transport/controller-transport.ts
@@ -9,7 +9,7 @@ import type { SignedRelayAssertion } from '../relay-servers/relay-signature-serv
 import { relayAssertionHeaders } from '../relay-servers/relay-signature-service'
 import { generateRelayKeyPair, publicKeyFromPrivate } from './crypto'
 import type { RelayEnvelope } from './protocol'
-import { relayEnvelopeSchema } from './protocol'
+import { decodeRelayEnvelope } from './protocol'
 import { RelaySession } from './session'
 
 /**
@@ -65,7 +65,8 @@ export async function startRelayControllerTransport(
   const keypair = options.controllerPrivateKeyBase64
     ? {
         privateKeyBase64: options.controllerPrivateKeyBase64,
-        publicKeyBase64: options.controllerPublicKeyBase64
+        publicKeyBase64:
+          options.controllerPublicKeyBase64
           ?? publicKeyFromPrivate(options.controllerPrivateKeyBase64),
       }
     : generateRelayKeyPair()
@@ -78,7 +79,10 @@ export async function startRelayControllerTransport(
 
 class ControllerTransport {
   private readonly streams = new Map<string, ActiveStream>()
-  private readonly exitListeners = new Set<(exit: { code: number | null, signal: NodeJS.Signals | null }) => void>()
+  private readonly exitListeners = new Set<
+    (exit: { code: number | null, signal: NodeJS.Signals | null }) => void
+  >()
+
   private session: RelaySession | null = null
   private ws: WebSocket | null = null
   private server: net.Server | null = null
@@ -104,7 +108,7 @@ class ControllerTransport {
         await this.startLocalServer()
         return
       }
-      catch (error) {
+ catch (error) {
         lastError = error
         await this.teardown()
         if (Date.now() >= deadline) {
@@ -124,13 +128,18 @@ class ControllerTransport {
     const wsUrl = toWebSocketUrl(this.options.relayUrl, '/ws/controller')
     return new Promise<void>((resolve, reject) => {
       let settled = false
-      const timeout = setTimeout(() => {
-        finish(new AppError({
-          code: 'relay_controller_handshake_timeout',
-          status: 503,
-          message: `Relay controller handshake did not complete within ${Math.max(0, Math.floor(remainingMs))}ms.`,
-        }))
-      }, Math.max(1, remainingMs))
+      const timeout = setTimeout(
+        () => {
+          finish(
+            new AppError({
+              code: 'relay_controller_handshake_timeout',
+              status: 503,
+              message: `Relay controller handshake did not complete within ${Math.max(0, Math.floor(remainingMs))}ms.`,
+            }),
+          )
+        },
+        Math.max(1, remainingMs),
+      )
       timeout.unref?.()
       const finish = (error?: Error) => {
         if (settled) {
@@ -141,7 +150,7 @@ class ControllerTransport {
         if (error) {
           reject(error)
         }
-        else {
+ else {
           resolve()
         }
       }
@@ -150,7 +159,7 @@ class ControllerTransport {
       try {
         ws = new WebSocket(wsUrl, { headers: relayAssertionHeaders(this.options.wsAssertion) })
       }
-      catch (error) {
+ catch (error) {
         finish(error instanceof Error ? error : new Error(String(error)))
         return
       }
@@ -163,7 +172,9 @@ class ControllerTransport {
           roomId: this.options.roomId,
           ourPublicKeyBase64: this.keypair.publicKeyBase64,
           ...(this.options.pairingCode ? { pairingCode: this.options.pairingCode } : {}),
-          ...(this.options.pinnedHostPubkey ? { pinnedPeerPubkey: this.options.pinnedHostPubkey } : {}),
+          ...(this.options.pinnedHostPubkey
+            ? { pinnedPeerPubkey: this.options.pinnedHostPubkey }
+            : {}),
           ...(this.options.controllerName ? { ourName: this.options.controllerName } : {}),
           ourSigningPubkey: this.options.wsAssertion.assertion.pubkey,
         },
@@ -198,18 +209,22 @@ class ControllerTransport {
       ws.once('open', () => session.start())
       ws.on('message', (data: WebSocket.RawData) => {
         try {
-          const env = relayEnvelopeSchema.parse(JSON.parse(data.toString('utf8')))
-          session.handleEnvelope(env as RelayEnvelope)
+          session.handleEnvelope(
+            decodeRelayEnvelope(new Uint8Array(data as Buffer)) as RelayEnvelope,
+          )
         }
-        catch (error) {
+ catch (error) {
           finish(error instanceof Error ? error : new Error(String(error)))
         }
       })
-      ws.once('close', () => finish(new AppError({
-        code: 'relay_controller_ws_closed',
-        status: 503,
-        message: 'Relayd closed the controller websocket before the handshake completed.',
-      })))
+      ws.once('close', () =>
+        finish(
+          new AppError({
+            code: 'relay_controller_ws_closed',
+            status: 503,
+            message: 'Relayd closed the controller websocket before the handshake completed.',
+          }),
+        ))
       ws.once('error', error => finish(error))
     })
   }
@@ -360,7 +375,7 @@ function toWebSocketUrl(relayUrl: string, path: string): string {
   if (url.protocol === 'http:') {
     url.protocol = 'ws:'
   }
-  else if (url.protocol === 'https:') {
+ else if (url.protocol === 'https:') {
     url.protocol = 'wss:'
   }
   return url.toString()

--- a/apps/server/src/modules/relay-transport/controller-transport.ts
+++ b/apps/server/src/modules/relay-transport/controller-transport.ts
@@ -11,6 +11,7 @@ import { generateRelayKeyPair, publicKeyFromPrivate } from './crypto'
 import type { RelayEnvelope } from './protocol'
 import { decodeRelayEnvelope } from './protocol'
 import { RelaySession } from './session'
+import { relayWebSocketDataView } from './websocket-data'
 
 /**
  * Controller-side relay transport.
@@ -251,7 +252,7 @@ class ControllerTransport {
       ws.on('message', (data: WebSocket.RawData) => {
         try {
           session.handleEnvelope(
-            decodeRelayEnvelope(new Uint8Array(data as Buffer)) as RelayEnvelope,
+            decodeRelayEnvelope(relayWebSocketDataView(data)) as RelayEnvelope,
           )
         }
  catch (error) {
@@ -311,7 +312,10 @@ class ControllerTransport {
 
     socket.on('data', (chunk: Buffer) => {
       checkpoint.firstRequestByteAt ??= Date.now()
-      session.writeStreamData(streamId, new Uint8Array(chunk))
+      session.writeStreamData(
+        streamId,
+        new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+      )
     })
     socket.on('close', () => {
       session.closeStream(streamId, 'local socket closed')
@@ -330,7 +334,7 @@ class ControllerTransport {
       return
     }
     stream.checkpoint.firstResponseByteAt ??= Date.now()
-    const chunk = Buffer.from(data)
+    const chunk = Buffer.from(data.buffer, data.byteOffset, data.byteLength)
     const accepted = stream.socket.write(chunk, (error) => {
       if (error) {
         stream.socket.destroy()

--- a/apps/server/src/modules/relay-transport/crypto.ts
+++ b/apps/server/src/modules/relay-transport/crypto.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto'
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
 
 import { xchacha20poly1305 } from '@noble/ciphers/chacha'
 import { x25519 } from '@noble/curves/ed25519'
@@ -10,26 +10,31 @@ import { utf8ToBytes } from '@noble/hashes/utils.js'
 import { AppError } from '../../errors/app-error'
 
 /**
- * End-to-end crypto for the relay tunnel, built on audited pure-JS primitives:
+ * End-to-end crypto for the relay tunnel:
  *
  * - X25519 ECDH (`@noble/curves`) for key agreement.
  * - HKDF-SHA512 (`@noble/hashes`) with a distinct `info` label per key.
- * - XChaCha20-Poly1305 (`@noble/ciphers`) for per-frame AEAD. Its 192-bit nonce
- *   is large enough that we use a fresh random nonce per frame — this removes
- *   the entire counter / direction-tag nonce management that GCM would force
- *   us to hand-roll (and where nonce reuse is catastrophic).
+ * - XChaCha20-Poly1305 for small frames, where avoiding an OpenSSL call has
+ *   lower fixed latency.
+ * - Native AES-256-GCM for bulk frames, where hardware acceleration provides
+ *   materially higher throughput. Fresh random nonces avoid counter state
+ *   across reconnects.
  *
  * relayd never sees any of this: it forwards opaque `relay_data_frame` blobs.
  */
 
-const HKDF_INFO_PREFIX = 'cradle/relay/v1'
+const HKDF_INFO_PREFIX = 'cradle/relay/v2'
 const KEY_BYTES = 32
 const XCHACHA_NONCE_BYTES = 24
+const AES_GCM_NONCE_BYTES = 12
+const AES_GCM_TAG_BYTES = 16
+const XCHACHA_ALGORITHM_BIT = 0x80
+const NATIVE_AES_MIN_PLAINTEXT_BYTES = 1024
 
 /** Roles for key derivation: each direction's key is tagged with the sender. */
 export type RelayCryptoRole = 'host' | 'controller'
 
-export const RELAY_CRYPTO_ALG = 'xchacha20poly1305'
+export const RELAY_CRYPTO_ALG = 'xchacha20poly1305-small+aes-256-gcm-bulk'
 
 export interface RelayKeyPair {
   /** X25519 private key (raw 32 bytes, base64). Safe to persist as a managed secret. */
@@ -171,15 +176,14 @@ export function relayPublicKeyFingerprint(publicKeyBase64: string): string {
 }
 
 /**
- * Stateful encryptor for one direction of the tunnel. XChaCha20-Poly1305's
- * 192-bit nonce makes random-per-frame nonces safe, so there is no counter and
- * no risk of nonce reuse under a key — each frame just needs a fresh 24-byte
- * random nonce, which we prepend to the ciphertext.
+ * Stateful encryptor for one direction of the tunnel. Each frame carries its
+ * random nonce so reconnects can safely reuse the long-lived derived key.
  */
 export class RelayCipher {
   private readonly key: Uint8Array
+  private readonly nativeBulkEnabled: boolean
 
-  constructor(key: Uint8Array) {
+  constructor(key: Uint8Array, nativeBulkEnabled = true) {
     if (key.length !== KEY_BYTES) {
       throw new AppError({
         code: 'relay_crypto_invalid_key',
@@ -188,29 +192,49 @@ export class RelayCipher {
       })
     }
     this.key = key
+    this.nativeBulkEnabled = nativeBulkEnabled
   }
 
-  /** Encrypt plaintext → raw `nonce(24) || ciphertext || tag(16)` bytes. */
+  /** Encrypt a frame with the latency- or throughput-optimized V2 AEAD. */
   encrypt(plaintext: Uint8Array): Uint8Array {
-    const nonce = randomBytes(XCHACHA_NONCE_BYTES)
-    const cipher = xchacha20poly1305(this.key, nonce)
-    const sealed = cipher.encrypt(plaintext)
-    return concatBytes(nonce, sealed)
+    if (plaintext.byteLength < NATIVE_AES_MIN_PLAINTEXT_BYTES || !this.nativeBulkEnabled) {
+      const nonce = randomBytes(XCHACHA_NONCE_BYTES)
+      nonce[0] |= XCHACHA_ALGORITHM_BIT
+      return concatBytes(nonce, xchacha20poly1305(this.key, nonce).encrypt(plaintext))
+    }
+    const nonce = randomBytes(AES_GCM_NONCE_BYTES)
+    nonce[0] &= ~XCHACHA_ALGORITHM_BIT
+    const cipher = createCipheriv('aes-256-gcm', this.key, nonce)
+    const ciphertext = cipher.update(plaintext)
+    cipher.final()
+    return concatBytes(nonce, ciphertext, cipher.getAuthTag())
   }
 
   /** Decrypt a raw blob produced by the peer's matching cipher. */
   decrypt(blob: Uint8Array): Uint8Array {
-    if (blob.length < XCHACHA_NONCE_BYTES + 16) {
+    if (blob.length < AES_GCM_NONCE_BYTES + AES_GCM_TAG_BYTES) {
       throw new AppError({
         code: 'relay_crypto_decrypt_failed',
         status: 400,
         message: 'Relay ciphertext too short.',
       })
     }
-    const nonce = blob.subarray(0, XCHACHA_NONCE_BYTES)
-    const sealed = blob.subarray(XCHACHA_NONCE_BYTES)
     try {
-      return xchacha20poly1305(this.key, nonce).decrypt(sealed)
+      if (blob[0] & XCHACHA_ALGORITHM_BIT) {
+        if (blob.length < XCHACHA_NONCE_BYTES + AES_GCM_TAG_BYTES) {
+          throw new Error('Relay XChaCha ciphertext is too short.')
+        }
+        const nonce = blob.subarray(0, XCHACHA_NONCE_BYTES)
+        return xchacha20poly1305(this.key, nonce).decrypt(blob.subarray(XCHACHA_NONCE_BYTES))
+      }
+      const nonce = blob.subarray(0, AES_GCM_NONCE_BYTES)
+      const ciphertext = blob.subarray(AES_GCM_NONCE_BYTES, -AES_GCM_TAG_BYTES)
+      const tag = blob.subarray(-AES_GCM_TAG_BYTES)
+      const decipher = createDecipheriv('aes-256-gcm', this.key, nonce)
+      decipher.setAuthTag(tag)
+      const plaintext = decipher.update(ciphertext)
+      decipher.final()
+      return new Uint8Array(plaintext.buffer, plaintext.byteOffset, plaintext.byteLength)
     }
  catch (error) {
       throw new AppError({

--- a/apps/server/src/modules/relay-transport/crypto.ts
+++ b/apps/server/src/modules/relay-transport/crypto.ts
@@ -85,7 +85,7 @@ export function computeRelaySharedSecret(
   try {
     return x25519.getSharedSecret(ourPrivate, peerPublic)
   }
-  catch (error) {
+ catch (error) {
     throw new AppError({
       code: 'relay_crypto_invalid_peer_public_key',
       status: 400,
@@ -108,7 +108,13 @@ export interface RelayDerivedKeys {
 }
 
 function deriveKey(secret: Uint8Array, pairingCode: string, label: string): Uint8Array {
-  return hkdf(sha512, secret, utf8ToBytes(pairingCode), utf8ToBytes(`${HKDF_INFO_PREFIX}/${label}`), KEY_BYTES)
+  return hkdf(
+    sha512,
+    secret,
+    utf8ToBytes(pairingCode),
+    utf8ToBytes(`${HKDF_INFO_PREFIX}/${label}`),
+    KEY_BYTES,
+  )
 }
 
 export function deriveRelayKeys(sharedSecret: Uint8Array, pairingCode: string): RelayDerivedKeys {
@@ -184,17 +190,16 @@ export class RelayCipher {
     this.key = key
   }
 
-  /** Encrypt plaintext → base64 `nonce(24) || ciphertext || tag(16)`. */
-  encrypt(plaintext: Uint8Array): string {
+  /** Encrypt plaintext → raw `nonce(24) || ciphertext || tag(16)` bytes. */
+  encrypt(plaintext: Uint8Array): Uint8Array {
     const nonce = randomBytes(XCHACHA_NONCE_BYTES)
     const cipher = xchacha20poly1305(this.key, nonce)
     const sealed = cipher.encrypt(plaintext)
-    return bytesToBase64(concatBytes(nonce, sealed))
+    return concatBytes(nonce, sealed)
   }
 
-  /** Decrypt a base64 blob produced by the peer's matching cipher. */
-  decrypt(blobBase64: string): Uint8Array {
-    const blob = base64ToBytes(blobBase64)
+  /** Decrypt a raw blob produced by the peer's matching cipher. */
+  decrypt(blob: Uint8Array): Uint8Array {
     if (blob.length < XCHACHA_NONCE_BYTES + 16) {
       throw new AppError({
         code: 'relay_crypto_decrypt_failed',
@@ -207,7 +212,7 @@ export class RelayCipher {
     try {
       return xchacha20poly1305(this.key, nonce).decrypt(sealed)
     }
-    catch (error) {
+ catch (error) {
       throw new AppError({
         code: 'relay_crypto_decrypt_failed',
         status: 400,

--- a/apps/server/src/modules/relay-transport/host-connector.ts
+++ b/apps/server/src/modules/relay-transport/host-connector.ts
@@ -15,6 +15,7 @@ import type { RelayEnvelope } from './protocol'
 import { decodeRelayEnvelope } from './protocol'
 import { readOrCreateHostRelayAuthToken } from './relay-auth-token-service'
 import { RelaySession } from './session'
+import { relayWebSocketDataView } from './websocket-data'
 
 const logger = createChildLogger({ module: 'relay-host-connector' })
 
@@ -257,7 +258,7 @@ class HostConnection {
       ws.on('message', (data: WebSocket.RawData) => {
         try {
           session.handleEnvelope(
-            decodeRelayEnvelope(new Uint8Array(data as Buffer)) as RelayEnvelope,
+            decodeRelayEnvelope(relayWebSocketDataView(data)) as RelayEnvelope,
           )
         }
  catch (error) {
@@ -286,7 +287,10 @@ class HostConnection {
     this.streams.set(streamId, { socket, streamId, requestWriter })
 
     socket.on('data', (chunk: Buffer) => {
-      session.writeStreamData(streamId, new Uint8Array(chunk))
+      session.writeStreamData(
+        streamId,
+        new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+      )
     })
     socket.on('close', () => {
       session.closeStream(streamId, 'local server socket closed')
@@ -520,12 +524,12 @@ class RelayHttpRequestWriter {
    * the on-wire size, but credit tracks the peer's plaintext stream).
    */
   write(data: Uint8Array, onConsumed: (bytes: number) => void): void {
+    const chunk = Buffer.from(data.buffer, data.byteOffset, data.byteLength)
     if (this.released) {
-      this.writeToSocket(Buffer.from(data), data.byteLength, onConsumed)
+      this.writeToSocket(chunk, data.byteLength, onConsumed)
       return
     }
 
-    const chunk = Buffer.from(data)
     this.buffered.push(chunk)
     this.bufferedLength += chunk.byteLength
     this.pendingOriginalBytes += chunk.byteLength

--- a/apps/server/src/modules/relay-transport/host-connector.ts
+++ b/apps/server/src/modules/relay-transport/host-connector.ts
@@ -12,7 +12,7 @@ import { relayAssertionHeaders, signRelayAssertion } from '../relay-servers/rela
 import { readSecret, upsertSecret } from '../secrets/service'
 import { loadPrivateKeyBytes, publicKeyFromPrivate } from './crypto'
 import type { RelayEnvelope } from './protocol'
-import { relayEnvelopeSchema } from './protocol'
+import { decodeRelayEnvelope } from './protocol'
 import { readOrCreateHostRelayAuthToken } from './relay-auth-token-service'
 import { RelaySession } from './session'
 
@@ -75,7 +75,10 @@ class HostConnection {
     private readonly config: HostConnectorConfig,
     private readonly reloadEnrollment: () => Promise<HostEnrollmentRecord>,
     private readonly onPaired: (controllerPubkey: string, controllerSigningPubkey: string) => void,
-    private readonly onStatus: (status: 'pending' | 'paired' | 'offline', lastError?: string) => void,
+    private readonly onStatus: (
+      status: 'pending' | 'paired' | 'offline',
+      lastError?: string,
+    ) => void,
   ) {}
 
   start(): void {
@@ -112,9 +115,12 @@ class HostConnection {
       await this.connectAndServe(enrollment)
       // If connectAndServe returns normally, the connection dropped; schedule reconnect.
     }
-    catch (error) {
+ catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      logger.warn('relay host connection dropped', { enrollmentId: this.enrollmentId, err: message })
+      logger.warn('relay host connection dropped', {
+        enrollmentId: this.enrollmentId,
+        err: message,
+      })
       this.onStatus('offline', message)
     }
     await this.teardown()
@@ -182,7 +188,7 @@ class HostConnection {
       try {
         ws = new WebSocket(wsUrl, { headers: relayAssertionHeaders(hostWsAssertion) })
       }
-      catch (error) {
+ catch (error) {
         drop(error instanceof Error ? error : new Error(String(error)))
         return
       }
@@ -197,7 +203,9 @@ class HostConnection {
         {
           roomId: enrollment.roomId,
           ourPublicKeyBase64: enrollment.hostPubkey,
-          ...(isReconnect ? { pinnedPeerPubkey: enrollment.pinnedControllerPubkey! } : { pairingCode: enrollment.pairingCode ?? '' }),
+          ...(isReconnect
+            ? { pinnedPeerPubkey: enrollment.pinnedControllerPubkey! }
+            : { pairingCode: enrollment.pairingCode ?? '' }),
         },
         {
           send: (data) => {
@@ -212,7 +220,11 @@ class HostConnection {
             ws.on('error', () => drop(new Error('relayd host websocket error')))
             this.backoffMs = 1_000 // reset backoff after a clean ready
             this.lastReadyAt = Date.now()
-            if (!enrollment.pinnedControllerPubkey && learnedControllerPubkey && learnedControllerSigningPubkey) {
+            if (
+              !enrollment.pinnedControllerPubkey
+              && learnedControllerPubkey
+              && learnedControllerSigningPubkey
+            ) {
               this.onPaired(learnedControllerPubkey, learnedControllerSigningPubkey)
             }
             this.onStatus('paired')
@@ -244,10 +256,11 @@ class HostConnection {
       ws.once('open', () => session.start())
       ws.on('message', (data: WebSocket.RawData) => {
         try {
-          const env = relayEnvelopeSchema.parse(JSON.parse(data.toString('utf8')))
-          session.handleEnvelope(env as RelayEnvelope)
+          session.handleEnvelope(
+            decodeRelayEnvelope(new Uint8Array(data as Buffer)) as RelayEnvelope,
+          )
         }
-        catch (error) {
+ catch (error) {
           drop(error instanceof Error ? error : new Error(String(error)))
         }
       })
@@ -261,7 +274,10 @@ class HostConnection {
     if (!session) {
       return
     }
-    const socket = net.connect({ host: this.config.localServerHost, port: this.config.localServerPort })
+    const socket = net.connect({
+      host: this.config.localServerHost,
+      port: this.config.localServerPort,
+    })
     const requestWriter = new RelayHttpRequestWriter(socket, relayAuthToken, () => {
       session.closeStream(streamId, 'invalid relay HTTP request')
       socket.destroy()
@@ -336,10 +352,7 @@ export class HostConnectorService {
 
   constructor(private readonly config: HostConnectorConfig) {}
   startAll(): void {
-    const enrollments = db()
-      .select()
-      .from(relayHostEnrollments)
-      .all()
+    const enrollments = db().select().from(relayHostEnrollments).all()
     for (const enrollment of enrollments) {
       this.startForEnrollment(enrollment.id)
     }
@@ -362,7 +375,11 @@ export class HostConnectorService {
         .where(eq(relayHostEnrollments.id, enrollmentId))
         .get()
       if (!row) {
-        throw new AppError({ code: 'relay_host_enrollment_not_found', status: 404, message: 'Relay host enrollment not found.' })
+        throw new AppError({
+          code: 'relay_host_enrollment_not_found',
+          status: 404,
+          message: 'Relay host enrollment not found.',
+        })
       }
       return {
         id: row.id,
@@ -389,10 +406,19 @@ export class HostConnectorService {
       })
       db()
         .update(relayHostEnrollments)
-        .set({ pinnedControllerPubkey: controllerPubkey, status: 'paired', pairingCode: null, lastError: null, updatedAt: now })
+        .set({
+          pinnedControllerPubkey: controllerPubkey,
+          status: 'paired',
+          pairingCode: null,
+          lastError: null,
+          updatedAt: now,
+        })
         .where(eq(relayHostEnrollments.id, enrollmentId))
         .run()
-      logger.info('relay host enrollment paired', { enrollmentId, controllerPubkeyFingerprint: controllerPubkey.slice(0, 16) })
+      logger.info('relay host enrollment paired', {
+        enrollmentId,
+        controllerPubkeyFingerprint: controllerPubkey.slice(0, 16),
+      })
     }
     const onStatus = (status, lastError) => {
       const now = Math.floor(Date.now() / 1000)
@@ -444,7 +470,7 @@ function readHostSigningPrivateKey(enrollmentId: string): string {
   try {
     return readSecret(`relay-host-sign-key:${enrollmentId}`)
   }
-  catch (error) {
+ catch (error) {
     throw new AppError({
       code: 'relay_host_enrollment_signing_key_missing',
       status: 409,
@@ -458,11 +484,12 @@ function readHostControllerSigningPubkey(enrollmentId: string): string {
   try {
     return readSecret(hostControllerSigningPubkeySecretId(enrollmentId))
   }
-  catch (error) {
+ catch (error) {
     throw new AppError({
       code: 'relay_host_enrollment_controller_signing_key_missing',
       status: 409,
-      message: 'Relay host enrollment is missing the controller signing public key. Re-create the pairing.',
+      message:
+        'Relay host enrollment is missing the controller signing public key. Re-create the pairing.',
       details: { enrollmentId, cause: error instanceof Error ? error.message : String(error) },
     })
   }
@@ -528,16 +555,17 @@ class RelayHttpRequestWriter {
     this.pendingOriginalBytes = 0
     const body = buffered.subarray(headerEnd + 4)
     this.writeToSocket(
-      Buffer.concat([
-        Buffer.from(`${rewrittenHeader}\r\n\r\n`, 'latin1'),
-        body,
-      ]),
+      Buffer.concat([Buffer.from(`${rewrittenHeader}\r\n\r\n`, 'latin1'), body]),
       originalBytes,
       onConsumed,
     )
   }
 
-  private writeToSocket(data: Buffer, originalBytes: number, onConsumed: (bytes: number) => void): void {
+  private writeToSocket(
+    data: Buffer,
+    originalBytes: number,
+    onConsumed: (bytes: number) => void,
+  ): void {
     this.socket.write(data, (error) => {
       if (error) {
         this.socket.destroy()
@@ -548,7 +576,10 @@ class RelayHttpRequestWriter {
   }
 }
 
-export function rewriteRelayHttpRequestHead(headerBlock: string, relayAuthToken: string): string | null {
+export function rewriteRelayHttpRequestHead(
+  headerBlock: string,
+  relayAuthToken: string,
+): string | null {
   const lines = headerBlock.split('\r\n')
   const requestLine = lines[0]
   if (!requestLine || !/^[A-Z!#$%&'*+.^_`|~-]+ \S+ HTTP\/1\.[01]$/.test(requestLine)) {
@@ -557,13 +588,13 @@ export function rewriteRelayHttpRequestHead(headerBlock: string, relayAuthToken:
 
   const headers = lines.slice(1).filter((line) => {
     const lower = line.toLowerCase()
-    return !lower.startsWith(`${CRADLE_RELAY_TOKEN_HEADER}:`)
-      && !lower.startsWith('connection:')
+    return !lower.startsWith(`${CRADLE_RELAY_TOKEN_HEADER}:`) && !lower.startsWith('connection:')
   })
   const isUpgrade = lines.slice(1).some((line) => {
     const lower = line.toLowerCase()
-    return lower.startsWith('upgrade:')
-      || (lower.startsWith('connection:') && lower.includes('upgrade'))
+    return (
+      lower.startsWith('upgrade:') || (lower.startsWith('connection:') && lower.includes('upgrade'))
+    )
   })
 
   return [
@@ -595,7 +626,7 @@ function toWebSocketUrl(relayUrl: string, path: string): string {
   if (url.protocol === 'http:') {
     url.protocol = 'ws:'
   }
-  else if (url.protocol === 'https:') {
+ else if (url.protocol === 'https:') {
     url.protocol = 'wss:'
   }
   return url.toString()

--- a/apps/server/src/modules/relay-transport/protocol.ts
+++ b/apps/server/src/modules/relay-transport/protocol.ts
@@ -11,6 +11,7 @@ export const RELAY_MAX_FRAME_BYTES = 1 << 20 // 1 MiB
 export const RELAY_MAX_STREAM_CHUNK_BYTES = 64 * 1024 // 64 KiB
 export const RELAY_STREAM_MIN_CREDIT_BYTES = 512 * 1024
 export const RELAY_STREAM_MAX_CREDIT_BYTES = 8 * 1024 * 1024
+export const RELAY_CONNECTION_MAX_CREDIT_BYTES = 16 * 1024 * 1024
 
 export const RELAY_ENVELOPE_KIND = {
   dataFrame: 'relay_data_frame',

--- a/apps/server/src/modules/relay-transport/protocol.ts
+++ b/apps/server/src/modules/relay-transport/protocol.ts
@@ -1,4 +1,5 @@
 import { AppError } from '../../errors/app-error'
+import type { RelayCompressionKind } from './compression'
 
 /**
  * Relay transport protocol. relayd validates and schedules only this outer
@@ -61,7 +62,14 @@ export type InnerFrame
     }
     | { kind: 'hello_confirm', confirm: string }
     | { kind: 'stream_open', streamId: string }
-    | { kind: 'stream_data', streamId: string, seq: number, data: Uint8Array }
+    | {
+      kind: 'stream_data'
+      streamId: string
+      seq: number
+      data: Uint8Array
+      compression?: RelayCompressionKind
+      uncompressedBytes?: number
+    }
     | { kind: 'stream_ack', streamId: string, ackedBytes: number }
     | { kind: 'stream_close', streamId: string, reason?: string }
 
@@ -69,6 +77,7 @@ const encoder = new TextEncoder()
 const decoder = new TextDecoder('utf8', { fatal: true })
 const OUTER_HEADER_BYTES = 16
 const FLAG_HAS_STREAM_ID = 1
+const COMPRESSED_STREAM_DATA_CODE = 7
 
 const envelopeKindCode: Record<RelayEnvelopeKind, number> = {
   [RELAY_ENVELOPE_KIND.dataFrame]: 1,
@@ -217,7 +226,7 @@ export function decodeRelayEnvelope(
   const streamOffset = OUTER_HEADER_BYTES + roomLength
   const streamId
     = streamLength > 0 ? readString(bytes, streamOffset, streamLength, 'stream id') : undefined
-  const payload = bytes.slice(streamOffset + streamLength)
+  const payload = bytes.subarray(streamOffset + streamLength)
   return {
     version: RELAY_PROTOCOL_VERSION,
     roomId,
@@ -309,14 +318,35 @@ export function encodeInnerFrame(frame: InnerFrame): Uint8Array {
     case INNER_FRAME_KIND.streamData: {
       checkedUint32(frame.seq, 'Stream sequence')
       const streamId = bytesForString(frame.streamId, 'Stream id')
-      if (frame.data.length === 0 || frame.data.length > RELAY_MAX_STREAM_CHUNK_BYTES) { throw protocolError('Invalid stream-data length.') }
-      const out = new Uint8Array(7 + streamId.length + frame.data.length)
+      const isCompressed = frame.compression === 'zstd'
+      if (frame.compression && frame.compression !== 'none' && !isCompressed) {
+        throw protocolError('Unknown stream-data compression.')
+      }
+      const dataLength = frame.data.byteLength
+      const uncompressedBytes = frame.uncompressedBytes ?? dataLength
+      if (
+        dataLength === 0
+        || dataLength > RELAY_MAX_STREAM_CHUNK_BYTES
+        || !Number.isSafeInteger(uncompressedBytes)
+        || uncompressedBytes <= 0
+        || uncompressedBytes > RELAY_MAX_STREAM_CHUNK_BYTES
+        || (!isCompressed && uncompressedBytes !== dataLength)
+        || (isCompressed && dataLength >= uncompressedBytes)
+      ) {
+        throw protocolError('Invalid stream-data length.')
+      }
+      const headerBytes = isCompressed ? 11 : 7
+      const out = new Uint8Array(headerBytes + streamId.length + dataLength)
       const view = new DataView(out.buffer)
-      out[0] = innerFrameCode[frame.kind]
+      out[0] = isCompressed ? COMPRESSED_STREAM_DATA_CODE : innerFrameCode[frame.kind]
       view.setUint16(1, streamId.length)
       view.setUint32(3, frame.seq)
-      out.set(streamId, 7)
-      out.set(frame.data, 7 + streamId.length)
+      if (isCompressed) {
+        view.setUint32(7, uncompressedBytes)
+      }
+      const dataOffset = headerBytes + streamId.length
+      out.set(streamId, headerBytes)
+      out.set(frame.data, dataOffset)
       return out
     }
     case INNER_FRAME_KIND.streamAck: {
@@ -363,16 +393,30 @@ export function decodeInnerFrame(bytes: Uint8Array): InnerFrame {
     }
     case 3:
       return decodeStreamStringFrame(bytes, view, INNER_FRAME_KIND.streamOpen)
-    case 4: {
-      if (bytes.length < 7) { throw protocolError('Stream-data frame is too short.') }
+    case 4:
+    case COMPRESSED_STREAM_DATA_CODE: {
+      const compressed = bytes[0] === COMPRESSED_STREAM_DATA_CODE
+      const headerBytes = compressed ? 11 : 7
+      if (bytes.length < headerBytes) { throw protocolError('Stream-data frame is too short.') }
       const streamLength = view.getUint16(1)
       const seq = view.getUint32(3)
-      if (streamLength === 0 || 7 + streamLength >= bytes.length) { throw protocolError('Invalid stream-data length.') }
+      const uncompressedBytes = compressed ? view.getUint32(7) : undefined
+      if (
+        streamLength === 0
+        || headerBytes + streamLength >= bytes.length
+        || (!compressed && bytes.length - headerBytes - streamLength > RELAY_MAX_STREAM_CHUNK_BYTES)
+        || (compressed && (!uncompressedBytes || uncompressedBytes > RELAY_MAX_STREAM_CHUNK_BYTES))
+      ) { throw protocolError('Invalid stream-data length.') }
+      const data = bytes.subarray(headerBytes + streamLength)
+      if (data.length > RELAY_MAX_STREAM_CHUNK_BYTES || (compressed && data.length >= uncompressedBytes!)) {
+        throw protocolError('Invalid compressed stream-data length.')
+      }
       return {
         kind: INNER_FRAME_KIND.streamData,
-        streamId: readString(bytes, 7, streamLength, 'stream id'),
+        streamId: readString(bytes, headerBytes, streamLength, 'stream id'),
         seq,
-        data: bytes.slice(7 + streamLength),
+        data,
+        ...(compressed ? { compression: 'zstd' as const, uncompressedBytes } : {}),
       }
     }
     case 5: {

--- a/apps/server/src/modules/relay-transport/protocol.ts
+++ b/apps/server/src/modules/relay-transport/protocol.ts
@@ -1,81 +1,44 @@
-import { z } from 'zod'
+import { AppError } from '../../errors/app-error'
 
 /**
- * Relay transport protocol — mirrors the relayd envelope
- * (apps/relayd/internal/relay/envelope.go) and defines the inner frame
- * schemas that ride inside `relay_data_frame.payload`.
- *
- * The envelope is the only thing relayd can see. After the `hello` handshake
- * every inner frame is encrypted (see crypto.ts), so `payload` is an opaque
- * base64 ciphertext to the relay.
+ * Relay transport protocol. relayd validates and schedules only this outer
+ * envelope. All inner frames after the initial key exchange are encrypted end
+ * to end, and data bytes never pass through JSON or Base64.
  */
+export const RELAY_PROTOCOL_VERSION = 2
 
-export const RELAY_PROTOCOL_VERSION = 1
-
-/** Maximum bytes of a single relayd WebSocket frame (mirrors relayd default). */
 export const RELAY_MAX_FRAME_BYTES = 1 << 20 // 1 MiB
+export const RELAY_MAX_STREAM_CHUNK_BYTES = 64 * 1024 // 64 KiB
+export const RELAY_STREAM_MIN_CREDIT_BYTES = 512 * 1024
+export const RELAY_STREAM_MAX_CREDIT_BYTES = 8 * 1024 * 1024
 
-/** Maximum bytes of a single inner stream_data chunk (stays under frame cap). */
-export const RELAY_MAX_STREAM_CHUNK_BYTES = 256 * 1024 // 256 KiB
-
-/** relayd envelope `kind` values — must match envelope.go. */
 export const RELAY_ENVELOPE_KIND = {
   dataFrame: 'relay_data_frame',
   peerClosed: 'relay_peer_closed',
   relayError: 'relay_error',
 } as const
 
-export type RelayEnvelopeKind
-  = | typeof RELAY_ENVELOPE_KIND.dataFrame
-    | typeof RELAY_ENVELOPE_KIND.peerClosed
-    | typeof RELAY_ENVELOPE_KIND.relayError
+export type RelayEnvelopeKind = (typeof RELAY_ENVELOPE_KIND)[keyof typeof RELAY_ENVELOPE_KIND]
+export type RelayPriority = 'control' | 'data'
 
-/**
- * Outer envelope as relayd forwards it. `payload` is a raw JSON value.
- *
- * Dual-written with `apps/relayd/internal/relay/envelope.go`. Keep the shapes
- * in lockstep: any field rename needs a coordinated Go + TS change.
- *
- * Field usage today:
- * - `seq`: set by the sender for ordering/debug; relayd and peers do not
- *   enforce it yet (reserved for anti-replay hardening).
- * - `ack` / `streamId` (outer): reserved / unused by the current transport.
- *   Stream multiplexing and credit live in *inner* frames (`stream_data`,
- *   `stream_ack`), not on the outer envelope. Do not invent semantics for
- *   these fields without a protocol version bump.
- */
-export const relayEnvelopeSchema = z.object({
-  version: z.literal(RELAY_PROTOCOL_VERSION),
-  roomId: z.string().min(1),
-  seq: z.number().int().nonnegative(),
-  ack: z.number().int().nonnegative().optional(),
-  kind: z.enum([
-    RELAY_ENVELOPE_KIND.dataFrame,
-    RELAY_ENVELOPE_KIND.peerClosed,
-    RELAY_ENVELOPE_KIND.relayError,
-  ]),
-  streamId: z.string().optional(),
-  payload: z.unknown(),
-})
+export interface RelayEnvelope {
+  version: typeof RELAY_PROTOCOL_VERSION
+  roomId: string
+  seq: number
+  kind: RelayEnvelopeKind
+  priority: RelayPriority
+  streamId?: string
+  payload: Uint8Array
+}
 
-export type RelayEnvelope = z.infer<typeof relayEnvelopeSchema>
+export interface RelayPeerClosedPayload {
+  role?: string
+  reason?: string
+}
 
-/** relayd peer-closed control payload. */
-export const peerClosedPayloadSchema = z.object({
-  role: z.string().optional(),
-  reason: z.string().optional(),
-}).passthrough()
-
-export type PeerClosedPayload = z.infer<typeof peerClosedPayloadSchema>
-
-/** relayd error control payload. */
-export const relayErrorPayloadSchema = z.object({
-  error: z.string().optional(),
-}).passthrough()
-
-export type RelayErrorPayload = z.infer<typeof relayErrorPayloadSchema>
-
-// ── Inner frames (plaintext, encrypted in transit after hello) ──
+export interface RelayErrorPayload {
+  error?: string
+}
 
 export const INNER_FRAME_KIND = {
   hello: 'hello',
@@ -86,119 +49,427 @@ export const INNER_FRAME_KIND = {
   streamClose: 'stream_close',
 } as const
 
-export type InnerFrameKind
-  = | typeof INNER_FRAME_KIND.hello
-    | typeof INNER_FRAME_KIND.helloConfirm
-    | typeof INNER_FRAME_KIND.streamOpen
-    | typeof INNER_FRAME_KIND.streamData
-    | typeof INNER_FRAME_KIND.streamAck
-    | typeof INNER_FRAME_KIND.streamClose
+export type InnerFrame
+  = | {
+      kind: 'hello'
+      version: number
+      pubkey: string
+      pinnedPubkey?: string
+      name?: string
+      signingPubkey?: string
+    }
+    | { kind: 'hello_confirm', confirm: string }
+    | { kind: 'stream_open', streamId: string }
+    | { kind: 'stream_data', streamId: string, seq: number, data: Uint8Array }
+    | { kind: 'stream_ack', streamId: string, ackedBytes: number }
+    | { kind: 'stream_close', streamId: string, reason?: string }
 
-/**
- * Handshake step 1: exchange X25519 public keys.
- *
- * - `pubkey`: this peer's X25519 public key (base64, 32 bytes).
- * - `pinnedPubkey`: the public key this peer expects from the other side. Sent
- *   on reconnect so a peer can refuse a key rotation it did not initiate.
- *   Empty/absent on first pairing.
- * - `name`: optional human-readable label for this peer (e.g. the controller's
- *   machine name), so the other side can show "paired with X" instead of just a
- *   fingerprint. Sent in plaintext alongside the pubkey — keep it non-sensitive.
- * - `signingPubkey`: optional Ed25519 relay assertion public key. The host
- *   persists the controller value after first pairing so it can restore relayd
- *   room controller authorization after relayd restarts.
- *   Unknown keys are stripped by Zod, so old peers ignore it (backward compatible).
- *
- * Note: the pairing `confirm` cannot ride in this frame — it is an HMAC over a
- * transcript that includes *both* public keys, which each peer only knows once
- * it has received the other's `hello`. So the proof is sent separately in
- * `hello_confirm` (first pairing only; reconnect relies on pinned-pubkey
- * verification and skips it).
- */
-export const helloFrameSchema = z.object({
-  kind: z.literal(INNER_FRAME_KIND.hello),
-  version: z.number().int().nonnegative(),
-  pubkey: z.string().min(1),
-  pinnedPubkey: z.string().optional(),
-  name: z.string().max(128).optional(),
-  signingPubkey: z.string().min(1).optional(),
-})
+const encoder = new TextEncoder()
+const decoder = new TextDecoder('utf8', { fatal: true })
+const OUTER_HEADER_BYTES = 16
+const FLAG_HAS_STREAM_ID = 1
 
-/**
- * Handshake step 2 (first pairing only): prove knowledge of the pairing code.
- *
- * `confirm` = HMAC(confirmKey, canonicalTranscript) where the transcript is
- * role-tagged so both sides compute the identical value:
- *   "controller" || controllerPub || "host" || hostPub || sharedSecret
- * A relay MITM that substitutes public keys during pairing breaks the ECDH
- * secret, and thus the confirmKey and confirm, so the honest peer rejects.
- */
-export const helloConfirmFrameSchema = z.object({
-  kind: z.literal(INNER_FRAME_KIND.helloConfirm),
-  confirm: z.string().min(1),
-})
+const envelopeKindCode: Record<RelayEnvelopeKind, number> = {
+  [RELAY_ENVELOPE_KIND.dataFrame]: 1,
+  [RELAY_ENVELOPE_KIND.peerClosed]: 2,
+  [RELAY_ENVELOPE_KIND.relayError]: 3,
+}
 
-export const streamOpenFrameSchema = z.object({
-  kind: z.literal(INNER_FRAME_KIND.streamOpen),
-  streamId: z.string().min(1),
-})
+const envelopeKindFromCode: Record<number, RelayEnvelopeKind | undefined> = {
+  1: RELAY_ENVELOPE_KIND.dataFrame,
+  2: RELAY_ENVELOPE_KIND.peerClosed,
+  3: RELAY_ENVELOPE_KIND.relayError,
+}
 
-export const streamDataFrameSchema = z.object({
-  kind: z.literal(INNER_FRAME_KIND.streamData),
-  streamId: z.string().min(1),
-  seq: z.number().int().nonnegative(),
-  data: z.string().min(1), // base64
-})
+const innerFrameCode: Record<InnerFrame['kind'], number> = {
+  [INNER_FRAME_KIND.hello]: 1,
+  [INNER_FRAME_KIND.helloConfirm]: 2,
+  [INNER_FRAME_KIND.streamOpen]: 3,
+  [INNER_FRAME_KIND.streamData]: 4,
+  [INNER_FRAME_KIND.streamAck]: 5,
+  [INNER_FRAME_KIND.streamClose]: 6,
+}
 
-export const streamAckFrameSchema = z.object({
-  kind: z.literal(INNER_FRAME_KIND.streamAck),
-  streamId: z.string().min(1),
-  ackedBytes: z.number().int().nonnegative(),
-})
+function protocolError(message: string): AppError {
+  return new AppError({ code: 'relay_protocol_invalid_frame', status: 400, message })
+}
 
-export const streamCloseFrameSchema = z.object({
-  kind: z.literal(INNER_FRAME_KIND.streamClose),
-  streamId: z.string().min(1),
-  reason: z.string().optional(),
-})
+function checkedUint32(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 0xFFFF_FFFF) {
+    throw protocolError(`${label} must be an unsigned 32-bit integer.`)
+  }
+}
 
-export const innerFrameSchema = z.discriminatedUnion('kind', [
-  helloFrameSchema,
-  helloConfirmFrameSchema,
-  streamOpenFrameSchema,
-  streamDataFrameSchema,
-  streamAckFrameSchema,
-  streamCloseFrameSchema,
-])
+function bytesForString(value: string, label: string, maxBytes = 0xFFFF): Uint8Array {
+  const bytes = encoder.encode(value)
+  if (bytes.length === 0 || bytes.length > maxBytes) {
+    throw protocolError(`${label} must contain between 1 and ${maxBytes} UTF-8 bytes.`)
+  }
+  return bytes
+}
 
-export type InnerFrame = z.infer<typeof innerFrameSchema>
-export type HelloFrame = z.infer<typeof helloFrameSchema>
-export type HelloConfirmFrame = z.infer<typeof helloConfirmFrameSchema>
-export type StreamOpenFrame = z.infer<typeof streamOpenFrameSchema>
-export type StreamDataFrame = z.infer<typeof streamDataFrameSchema>
-export type StreamAckFrame = z.infer<typeof streamAckFrameSchema>
-export type StreamCloseFrame = z.infer<typeof streamCloseFrameSchema>
+function optionalString(value: string | undefined, label: string, maxBytes = 0xFFFF): Uint8Array {
+  if (!value) {
+    return new Uint8Array()
+  }
+  return bytesForString(value, label, maxBytes)
+}
 
-/**
- * The on-the-wire form of an inner frame on the controller<->host tunnel:
- * a length-prefixed ciphertext blob. We serialize the plaintext frame as JSON,
- * encrypt it, and wrap as `{ ciphertext: base64 }`. This wrapper is what goes
- * into `relay_data_frame.payload`.
- */
-export const encryptedPayloadSchema = z.object({
-  ciphertext: z.string().min(1), // base64 (nonce || tag || ciphertext)
-})
+function readString(bytes: Uint8Array, start: number, length: number, label: string): string {
+  if (length <= 0 || start < 0 || start + length > bytes.length) {
+    throw protocolError(`Invalid ${label} length.`)
+  }
+  try {
+    return decoder.decode(bytes.subarray(start, start + length))
+  }
+ catch {
+    throw protocolError(`Invalid UTF-8 ${label}.`)
+  }
+}
 
-export type EncryptedPayload = z.infer<typeof encryptedPayloadSchema>
+function base64ToBytes(value: string, label: string): Uint8Array {
+  const bytes = new Uint8Array(Buffer.from(value, 'base64'))
+  if (bytes.length === 0) {
+    throw protocolError(`Invalid ${label}.`)
+  }
+  return bytes
+}
 
-/** Default high-water mark for credit-based flow control (see session.ts). */
-export const RELAY_STREAM_CREDIT_BYTES = 512 * 1024 // 512 KiB unacked window
+export function encodeRelayEnvelope(envelope: RelayEnvelope): Uint8Array {
+  if (envelope.version !== RELAY_PROTOCOL_VERSION) {
+    throw protocolError(`Unsupported relay protocol version ${envelope.version}.`)
+  }
+  checkedUint32(envelope.seq, 'Relay sequence')
+  const roomId = bytesForString(envelope.roomId, 'Room id')
+  const streamId = envelope.streamId
+    ? bytesForString(envelope.streamId, 'Stream id')
+    : new Uint8Array()
+  const kind = envelopeKindCode[envelope.kind]
+  if (
+    !kind
+    || (envelope.priority !== 'control' && envelope.priority !== 'data')
+    || envelope.payload.length === 0
+  ) {
+    throw protocolError('Invalid relay envelope.')
+  }
+  if (roomId.length > 0xFFFF || streamId.length > 0xFFFF || envelope.payload.length > 0xFFFF_FFFF) {
+    throw protocolError('Relay envelope exceeds binary field bounds.')
+  }
+  const out = new Uint8Array(
+    OUTER_HEADER_BYTES + roomId.length + streamId.length + envelope.payload.length,
+  )
+  const view = new DataView(out.buffer, out.byteOffset, out.byteLength)
+  out[0] = RELAY_PROTOCOL_VERSION
+  out[1] = kind
+  out[2] = envelope.priority === 'control' ? 1 : 2
+  out[3] = streamId.length > 0 ? FLAG_HAS_STREAM_ID : 0
+  view.setUint16(4, roomId.length)
+  view.setUint16(6, streamId.length)
+  view.setUint32(8, envelope.seq)
+  view.setUint32(12, envelope.payload.length)
+  out.set(roomId, OUTER_HEADER_BYTES)
+  out.set(streamId, OUTER_HEADER_BYTES + roomId.length)
+  out.set(envelope.payload, OUTER_HEADER_BYTES + roomId.length + streamId.length)
+  return out
+}
 
-/**
- * Prefix a streamId with a role tag so controller-initiated and host-initiated
- * stream ids never collide. Only the controller opens streams in v1, but the
- * prefix keeps the namespace safe for future bidirectional use.
- */
-export function controllerStreamId(n: number): string {
-  return `c${n}`
+export function decodeRelayEnvelope(
+  bytes: Uint8Array,
+  maxFrameBytes = RELAY_MAX_FRAME_BYTES,
+): RelayEnvelope {
+  if (bytes.length > maxFrameBytes) {
+    throw new AppError({
+      code: 'relay_protocol_frame_too_large',
+      status: 400,
+      message: 'Relay frame exceeds the configured maximum.',
+    })
+  }
+  if (bytes.length < OUTER_HEADER_BYTES) {
+    throw protocolError('Relay envelope is too short.')
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  if (bytes[0] !== RELAY_PROTOCOL_VERSION) {
+    throw protocolError(`Unsupported relay protocol version ${bytes[0]}.`)
+  }
+  const kind = envelopeKindFromCode[bytes[1]]
+  const priority = bytes[2] === 1 ? 'control' : bytes[2] === 2 ? 'data' : undefined
+  const flags = bytes[3]
+  const roomLength = view.getUint16(4)
+  const streamLength = view.getUint16(6)
+  const seq = view.getUint32(8)
+  const payloadLength = view.getUint32(12)
+  const expectedLength = OUTER_HEADER_BYTES + roomLength + streamLength + payloadLength
+  if (
+    !kind
+    || !priority
+    || (flags & ~FLAG_HAS_STREAM_ID) !== 0
+    || expectedLength !== bytes.length
+    || roomLength === 0
+    || payloadLength === 0
+  ) {
+    throw protocolError('Invalid relay envelope fields.')
+  }
+  if (Boolean(flags & FLAG_HAS_STREAM_ID) !== (streamLength > 0)) {
+    throw protocolError('Relay envelope stream-id flag does not match its length.')
+  }
+  const roomId = readString(bytes, OUTER_HEADER_BYTES, roomLength, 'room id')
+  const streamOffset = OUTER_HEADER_BYTES + roomLength
+  const streamId
+    = streamLength > 0 ? readString(bytes, streamOffset, streamLength, 'stream id') : undefined
+  const payload = bytes.slice(streamOffset + streamLength)
+  return {
+    version: RELAY_PROTOCOL_VERSION,
+    roomId,
+    seq,
+    kind,
+    priority,
+    ...(streamId ? { streamId } : {}),
+    payload,
+  }
+}
+
+export function encodeRelayControlPayload(
+  value: RelayPeerClosedPayload | RelayErrorPayload,
+): Uint8Array {
+  return encoder.encode(JSON.stringify(value))
+}
+
+export function decodeRelayPeerClosedPayload(bytes: Uint8Array): RelayPeerClosedPayload {
+  return decodeControlPayload(bytes, 'peer closed')
+}
+
+export function decodeRelayErrorPayload(bytes: Uint8Array): RelayErrorPayload {
+  return decodeControlPayload(bytes, 'relay error')
+}
+
+function decodeControlPayload(
+  bytes: Uint8Array,
+  label: string,
+): { role?: string, reason?: string, error?: string } {
+  try {
+    const value: { role?: string, reason?: string, error?: string } = JSON.parse(
+      decoder.decode(bytes),
+    )
+    if (typeof value !== 'object' || value === null) {
+      throw new Error('not an object')
+    }
+    return value
+  }
+ catch {
+    throw protocolError(`Invalid ${label} control payload.`)
+  }
+}
+
+export function encodeInnerFrame(frame: InnerFrame): Uint8Array {
+  switch (frame.kind) {
+    case INNER_FRAME_KIND.hello: {
+      const pubkey = base64ToBytes(frame.pubkey, 'hello public key')
+      const pinned = frame.pinnedPubkey
+        ? base64ToBytes(frame.pinnedPubkey, 'pinned public key')
+        : new Uint8Array()
+      if (pubkey.length !== 32 || (pinned.length > 0 && pinned.length !== 32)) {
+        throw protocolError('Hello public keys must be 32 bytes.')
+      }
+      const name = optionalString(frame.name, 'Peer name', 128)
+      const signing = optionalString(frame.signingPubkey, 'Signing public key', 128)
+      const out = new Uint8Array(8 + pubkey.length + pinned.length + name.length + signing.length)
+      const view = new DataView(out.buffer)
+      out[0] = innerFrameCode[frame.kind]
+      out[1] = frame.version
+      out[2] = (pinned.length ? 1 : 0) | (name.length ? 2 : 0) | (signing.length ? 4 : 0)
+      out[3] = 0
+      view.setUint16(4, name.length)
+      view.setUint16(6, signing.length)
+      let offset = 8
+      out.set(pubkey, offset)
+      offset += pubkey.length
+      if (pinned.length) {
+        out.set(pinned, offset)
+        offset += pinned.length
+      }
+      out.set(name, offset)
+      offset += name.length
+      out.set(signing, offset)
+      return out
+    }
+    case INNER_FRAME_KIND.helloConfirm: {
+      const confirm = base64ToBytes(frame.confirm, 'hello confirmation')
+      if (confirm.length > 0xFFFF) { throw protocolError('Hello confirmation is too large.') }
+      const out = new Uint8Array(3 + confirm.length)
+      out[0] = innerFrameCode[frame.kind]
+      new DataView(out.buffer).setUint16(1, confirm.length)
+      out.set(confirm, 3)
+      return out
+    }
+    case INNER_FRAME_KIND.streamOpen:
+      return encodeStreamStringFrame(innerFrameCode[frame.kind], frame.streamId)
+    case INNER_FRAME_KIND.streamClose:
+      return encodeStreamStringFrame(innerFrameCode[frame.kind], frame.streamId, frame.reason)
+    case INNER_FRAME_KIND.streamData: {
+      checkedUint32(frame.seq, 'Stream sequence')
+      const streamId = bytesForString(frame.streamId, 'Stream id')
+      if (frame.data.length === 0 || frame.data.length > RELAY_MAX_STREAM_CHUNK_BYTES) { throw protocolError('Invalid stream-data length.') }
+      const out = new Uint8Array(7 + streamId.length + frame.data.length)
+      const view = new DataView(out.buffer)
+      out[0] = innerFrameCode[frame.kind]
+      view.setUint16(1, streamId.length)
+      view.setUint32(3, frame.seq)
+      out.set(streamId, 7)
+      out.set(frame.data, 7 + streamId.length)
+      return out
+    }
+    case INNER_FRAME_KIND.streamAck: {
+      checkedUint32(frame.ackedBytes, 'Acknowledged byte count')
+      const streamId = bytesForString(frame.streamId, 'Stream id')
+      const out = new Uint8Array(7 + streamId.length)
+      const view = new DataView(out.buffer)
+      out[0] = innerFrameCode[frame.kind]
+      view.setUint16(1, streamId.length)
+      view.setUint32(3, frame.ackedBytes)
+      out.set(streamId, 7)
+      return out
+    }
+  }
+}
+
+function encodeStreamStringFrame(kind: number, streamIdValue: string, reason?: string): Uint8Array {
+  const streamId = bytesForString(streamIdValue, 'Stream id')
+  const reasonBytes = reason ? optionalString(reason, 'Close reason') : new Uint8Array()
+  const out = new Uint8Array(5 + streamId.length + reasonBytes.length)
+  const view = new DataView(out.buffer)
+  out[0] = kind
+  view.setUint16(1, streamId.length)
+  view.setUint16(3, reasonBytes.length)
+  out.set(streamId, 5)
+  out.set(reasonBytes, 5 + streamId.length)
+  return out
+}
+
+export function decodeInnerFrame(bytes: Uint8Array): InnerFrame {
+  if (bytes.length < 1) { throw protocolError('Inner frame is empty.') }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  switch (bytes[0]) {
+    case 1:
+      return decodeHelloFrame(bytes, view)
+    case 2: {
+      if (bytes.length < 3) { throw protocolError('Hello confirmation is too short.') }
+      const length = view.getUint16(1)
+      if (length === 0 || length + 3 !== bytes.length) { throw protocolError('Invalid hello confirmation length.') }
+      return {
+        kind: INNER_FRAME_KIND.helloConfirm,
+        confirm: Buffer.from(bytes.subarray(3)).toString('base64'),
+      }
+    }
+    case 3:
+      return decodeStreamStringFrame(bytes, view, INNER_FRAME_KIND.streamOpen)
+    case 4: {
+      if (bytes.length < 7) { throw protocolError('Stream-data frame is too short.') }
+      const streamLength = view.getUint16(1)
+      const seq = view.getUint32(3)
+      if (streamLength === 0 || 7 + streamLength >= bytes.length) { throw protocolError('Invalid stream-data length.') }
+      return {
+        kind: INNER_FRAME_KIND.streamData,
+        streamId: readString(bytes, 7, streamLength, 'stream id'),
+        seq,
+        data: bytes.slice(7 + streamLength),
+      }
+    }
+    case 5: {
+      if (bytes.length < 7) { throw protocolError('Stream-ack frame is too short.') }
+      const streamLength = view.getUint16(1)
+      if (streamLength === 0 || 7 + streamLength !== bytes.length) { throw protocolError('Invalid stream-ack length.') }
+      return {
+        kind: INNER_FRAME_KIND.streamAck,
+        streamId: readString(bytes, 7, streamLength, 'stream id'),
+        ackedBytes: view.getUint32(3),
+      }
+    }
+    case 6:
+      return decodeStreamStringFrame(bytes, view, INNER_FRAME_KIND.streamClose)
+    default:
+      throw protocolError(`Unknown inner frame code ${bytes[0]}.`)
+  }
+}
+
+function decodeHelloFrame(bytes: Uint8Array, view: DataView): InnerFrame {
+  if (bytes.length < 40) { throw protocolError('Hello frame is too short.') }
+  const flags = bytes[2]
+  const nameLength = view.getUint16(4)
+  const signingLength = view.getUint16(6)
+  if ((flags & ~7) !== 0) { throw protocolError('Invalid hello flags.') }
+  let offset = 8
+  const pubkey = bytes.slice(offset, offset + 32)
+  offset += 32
+  let pinnedPubkey: string | undefined
+  if (flags & 1) {
+    if (offset + 32 > bytes.length) { throw protocolError('Hello pinned key is truncated.') }
+    pinnedPubkey = Buffer.from(bytes.subarray(offset, offset + 32)).toString('base64')
+    offset += 32
+  }
+  if (
+    offset + nameLength + signingLength !== bytes.length
+    || Boolean(flags & 2) !== (nameLength > 0)
+    || Boolean(flags & 4) !== (signingLength > 0)
+  ) {
+    throw protocolError('Invalid hello field lengths.')
+  }
+  const name = nameLength ? readString(bytes, offset, nameLength, 'peer name') : undefined
+  offset += nameLength
+  const signingPubkey = signingLength
+    ? readString(bytes, offset, signingLength, 'signing public key')
+    : undefined
+  return {
+    kind: INNER_FRAME_KIND.hello,
+    version: bytes[1],
+    pubkey: Buffer.from(pubkey).toString('base64'),
+    ...(pinnedPubkey ? { pinnedPubkey } : {}),
+    ...(name ? { name } : {}),
+    ...(signingPubkey ? { signingPubkey } : {}),
+  }
+}
+
+function decodeStreamStringFrame(
+  bytes: Uint8Array,
+  view: DataView,
+  kind: 'stream_open' | 'stream_close',
+): InnerFrame {
+  if (bytes.length < 5) { throw protocolError(`${kind} frame is too short.`) }
+  const streamLength = view.getUint16(1)
+  const reasonLength = view.getUint16(3)
+  if (
+    streamLength === 0
+    || 5 + streamLength + reasonLength !== bytes.length
+    || (kind === INNER_FRAME_KIND.streamOpen && reasonLength !== 0)
+  ) {
+    throw protocolError(`Invalid ${kind} lengths.`)
+  }
+  const streamId = readString(bytes, 5, streamLength, 'stream id')
+  if (kind === INNER_FRAME_KIND.streamOpen) { return { kind, streamId } }
+  const reason = reasonLength
+    ? readString(bytes, 5 + streamLength, reasonLength, 'close reason')
+    : undefined
+  return { kind, streamId, ...(reason ? { reason } : {}) }
+}
+
+export function relayPriorityForInnerFrame(frame: InnerFrame): RelayPriority {
+  return frame.kind === INNER_FRAME_KIND.streamData ? 'data' : 'control'
+}
+
+export function legacyV1WireBytesForStreamData(data: Uint8Array): number {
+  const legacyInner = JSON.stringify({
+    kind: 'stream_data',
+    streamId: 'c1',
+    seq: 0,
+    data: Buffer.from(data).toString('base64'),
+  })
+  const legacyCiphertext = Buffer.from(legacyInner).toString('base64')
+  return Buffer.byteLength(
+    JSON.stringify({
+      version: 1,
+      roomId: 'room_compare',
+      seq: 0,
+      kind: 'relay_data_frame',
+      payload: { ciphertext: legacyCiphertext },
+    }),
+  )
 }

--- a/apps/server/src/modules/relay-transport/protocol.ts
+++ b/apps/server/src/modules/relay-transport/protocol.ts
@@ -459,15 +459,22 @@ export function relayPriorityForInnerFrame(frame: InnerFrame): RelayPriority {
 export function legacyV1WireBytesForStreamData(data: Uint8Array): number {
   const legacyInner = JSON.stringify({
     kind: 'stream_data',
-    streamId: 'c1',
+    streamId: 'benchmark',
     seq: 0,
     data: Buffer.from(data).toString('base64'),
   })
-  const legacyCiphertext = Buffer.from(legacyInner).toString('base64')
+  // V1 serialized nonce(24) || ciphertext || tag(16) as base64. The nonce
+  // and tag values are irrelevant to the exact wire length, so use zero bytes
+  // here instead of performing random encryption in a deterministic benchmark.
+  const legacyCiphertext = Buffer.concat([
+    Buffer.alloc(24),
+    Buffer.from(legacyInner),
+    Buffer.alloc(16),
+  ]).toString('base64')
   return Buffer.byteLength(
     JSON.stringify({
       version: 1,
-      roomId: 'room_compare',
+      roomId: 'room_benchmark',
       seq: 0,
       kind: 'relay_data_frame',
       payload: { ciphertext: legacyCiphertext },

--- a/apps/server/src/modules/relay-transport/session.ts
+++ b/apps/server/src/modules/relay-transport/session.ts
@@ -13,16 +13,18 @@ import {
 } from './crypto'
 import type { InnerFrame, RelayEnvelope } from './protocol'
 import {
-  encryptedPayloadSchema,
-  helloFrameSchema,
+  decodeInnerFrame,
+  decodeRelayErrorPayload,
+  decodeRelayPeerClosedPayload,
+  encodeInnerFrame,
+  encodeRelayEnvelope,
   INNER_FRAME_KIND,
-  innerFrameSchema,
-  peerClosedPayloadSchema,
   RELAY_ENVELOPE_KIND,
   RELAY_MAX_STREAM_CHUNK_BYTES,
   RELAY_PROTOCOL_VERSION,
-  RELAY_STREAM_CREDIT_BYTES,
-  relayErrorPayloadSchema,
+  RELAY_STREAM_MAX_CREDIT_BYTES,
+  RELAY_STREAM_MIN_CREDIT_BYTES,
+  relayPriorityForInnerFrame,
 } from './protocol'
 
 /**
@@ -57,11 +59,15 @@ export interface RelaySessionOptions {
   ourName?: string
   /** Optional Ed25519 relay assertion public key sent in our `hello`. */
   ourSigningPubkey?: string
+  /** Initial per-stream in-flight byte allowance. Defaults to 512 KiB. */
+  initialStreamCreditBytes?: number
+  /** Hard per-stream byte allowance. Defaults to 8 MiB. */
+  maxStreamCreditBytes?: number
 }
 
 export interface RelaySessionCallbacks {
-  /** Write serialized envelope bytes (JSON string) to the relayd WebSocket. */
-  send: (data: string) => void
+  /** Write one encoded binary envelope to relayd. */
+  send: (data: Uint8Array) => void
   onReady?: () => void
   onPeerPubkey?: (peerPubkey: string, fingerprint: string) => void
   /** Fires with the peer's reported label (from its `hello.name`) once known. */
@@ -83,6 +89,8 @@ type SessionState = 'idle' | 'handshake' | 'ready' | 'closed'
 interface StreamFlowState {
   /** Whether the local source is currently paused due to flow control. */
   paused: boolean
+  creditBytes: number
+  pendingData: Uint8Array[]
   /** Total plaintext bytes sent on this stream. */
   sentBytes: number
   /**
@@ -91,6 +99,7 @@ interface StreamFlowState {
    * streamId, so send credit and receive progress must not share a counter.
    */
   peerAckedBytes: number
+  ackedSinceCreditIncrease: number
   /** Total plaintext bytes delivered to the local transport callback. */
   receivedBytes: number
   /** Cumulative bytes the local transport has applied (TCP write / drain). */
@@ -100,11 +109,14 @@ interface StreamFlowState {
   closed: boolean
 }
 
-function createStreamFlowState(): StreamFlowState {
+function createStreamFlowState(creditBytes: number): StreamFlowState {
   return {
     paused: false,
+    creditBytes,
+    pendingData: [],
     sentBytes: 0,
     peerAckedBytes: 0,
+    ackedSinceCreditIncrease: 0,
     receivedBytes: 0,
     appliedBytes: 0,
     ackedToPeerBytes: 0,
@@ -114,6 +126,18 @@ function createStreamFlowState(): StreamFlowState {
 
 function bytesInFlight(flow: StreamFlowState): number {
   return Math.max(0, flow.sentBytes - flow.peerAckedBytes)
+}
+
+function streamIdForFrame(frame: InnerFrame): string | undefined {
+  switch (frame.kind) {
+    case INNER_FRAME_KIND.streamOpen:
+    case INNER_FRAME_KIND.streamData:
+    case INNER_FRAME_KIND.streamAck:
+    case INNER_FRAME_KIND.streamClose:
+      return frame.streamId
+    default:
+      return undefined
+  }
 }
 
 const ACK_INTERVAL_BYTES = 64 * 1024
@@ -144,6 +168,8 @@ export class RelaySession {
   /** Set when we've verified the peer's hello_confirm (first pairing). */
   private confirmVerified = false
   private readonly isReconnect: boolean
+  private readonly initialStreamCreditBytes: number
+  private readonly maxStreamCreditBytes: number
 
   constructor(
     role: RelaySessionRole,
@@ -157,15 +183,31 @@ export class RelaySession {
     this.pairingCode = options.pairingCode
     this.pinnedPeerPubkey = options.pinnedPeerPubkey
     this.cb = callbacks
-    this.ourPublicKeyBase64 = options.ourPublicKeyBase64 ?? publicKeyFromPrivateKey(ourPrivateKeyBase64)
+    this.ourPublicKeyBase64
+      = options.ourPublicKeyBase64 ?? publicKeyFromPrivateKey(ourPrivateKeyBase64)
     this.isReconnect = Boolean(options.pinnedPeerPubkey)
     // The controller initiates the hello exchange; the host waits for it. This
     // matches the relay model where the host is always-on and the controller
     // connects later — if the host sent hello first, relayd would close it
     // (TryAgainLater) because no controller peer is connected yet.
-    this.initiateHello = options.initiateHello ?? (role === 'controller')
+    this.initiateHello = options.initiateHello ?? role === 'controller'
     this.ourName = options.ourName
     this.ourSigningPubkey = options.ourSigningPubkey
+    this.initialStreamCreditBytes
+      = options.initialStreamCreditBytes ?? RELAY_STREAM_MIN_CREDIT_BYTES
+    this.maxStreamCreditBytes = options.maxStreamCreditBytes ?? RELAY_STREAM_MAX_CREDIT_BYTES
+    if (
+      !Number.isSafeInteger(this.initialStreamCreditBytes)
+      || !Number.isSafeInteger(this.maxStreamCreditBytes)
+      || this.initialStreamCreditBytes < RELAY_STREAM_MIN_CREDIT_BYTES
+      || this.maxStreamCreditBytes < this.initialStreamCreditBytes
+    ) {
+      throw new AppError({
+        code: 'relay_credit_config_invalid',
+        status: 500,
+        message: 'Relay stream credit bounds are invalid.',
+      })
+    }
   }
 
   get isReady(): boolean {
@@ -199,7 +241,13 @@ export class RelaySession {
       return
     }
     if (env.version !== RELAY_PROTOCOL_VERSION) {
-      this.fail(new AppError({ code: 'relay_protocol_version', status: 400, message: `Unsupported relay protocol version ${env.version}` }))
+      this.fail(
+        new AppError({
+          code: 'relay_protocol_version',
+          status: 400,
+          message: `Unsupported relay protocol version ${env.version}`,
+        }),
+      )
       return
     }
     switch (env.kind) {
@@ -213,7 +261,13 @@ export class RelaySession {
         this.handleRelayError(env)
         break
       default:
-        this.fail(new AppError({ code: 'relay_protocol_unknown_kind', status: 400, message: `Unknown relay envelope kind ${env.kind}` }))
+        this.fail(
+          new AppError({
+            code: 'relay_protocol_unknown_kind',
+            status: 400,
+            message: `Unknown relay envelope kind ${env.kind}`,
+          }),
+        )
     }
   }
 
@@ -231,7 +285,6 @@ export class RelaySession {
       ...(this.ourName ? { name: this.ourName } : {}),
       ...(this.ourSigningPubkey ? { signingPubkey: this.ourSigningPubkey } : {}),
     }
-    helloFrameSchema.parse(frame)
     // Set helloSent BEFORE sendPlainEnvelope: sendPlainEnvelope is delivered
     // synchronously by the test transport, which can re-enter handleHello →
     // sendHello before this call returns. Without this guard the host would
@@ -248,16 +301,30 @@ export class RelaySession {
         // Pre-key: only plaintext handshake frames are accepted.
         frame = this.parsePlainFrame(env.payload)
         if (frame.kind !== INNER_FRAME_KIND.hello && frame.kind !== INNER_FRAME_KIND.helloConfirm) {
-          this.fail(new AppError({ code: 'relay_handshake_unexpected_frame', status: 400, message: `Unexpected pre-handshake frame ${frame.kind}` }))
+          this.fail(
+            new AppError({
+              code: 'relay_handshake_unexpected_frame',
+              status: 400,
+              message: `Unexpected pre-handshake frame ${frame.kind}`,
+            }),
+          )
           return
         }
       }
-      else {
+ else {
         frame = this.decryptFrame(env.payload)
       }
     }
-    catch (error) {
-      this.fail(error instanceof Error ? error : new AppError({ code: 'relay_protocol_invalid_frame', status: 400, message: String(error) }))
+ catch (error) {
+      this.fail(
+        error instanceof Error
+          ? error
+          : new AppError({
+              code: 'relay_protocol_invalid_frame',
+              status: 400,
+              message: String(error),
+            }),
+      )
       return
     }
 
@@ -281,40 +348,66 @@ export class RelaySession {
         this.handleStreamCloseFrame(frame.streamId, frame.reason)
         break
       default:
-        this.fail(new AppError({ code: 'relay_protocol_unknown_frame', status: 400, message: `Unknown inner frame kind ${(frame as { kind: string }).kind}` }))
+        this.fail(
+          new AppError({
+            code: 'relay_protocol_unknown_frame',
+            status: 400,
+            message: `Unknown inner frame kind ${(frame as { kind: string }).kind}`,
+          }),
+        )
     }
   }
 
-  private handleHello(frame: { kind: 'hello', version: number, pubkey: string, pinnedPubkey?: string, name?: string, signingPubkey?: string }): void {
+  private handleHello(frame: {
+    kind: 'hello'
+    version: number
+    pubkey: string
+    pinnedPubkey?: string
+    name?: string
+    signingPubkey?: string
+  }): void {
     if (this.peerPubkey !== null) {
-      this.fail(new AppError({ code: 'relay_handshake_duplicate_hello', status: 400, message: 'Received duplicate hello frame.' }))
+      this.fail(
+        new AppError({
+          code: 'relay_handshake_duplicate_hello',
+          status: 400,
+          message: 'Received duplicate hello frame.',
+        }),
+      )
       return
     }
     // Reconnect: the peer's pubkey must match the pinned value.
     if (this.isReconnect) {
       if (!this.pinnedPeerPubkey || frame.pubkey !== this.pinnedPeerPubkey) {
-        this.fail(new AppError({
-          code: 'relay_handshake_pubkey_mismatch',
-          status: 400,
-          message: 'Peer public key does not match the pinned value.',
-        }))
+        this.fail(
+          new AppError({
+            code: 'relay_handshake_pubkey_mismatch',
+            status: 400,
+            message: 'Peer public key does not match the pinned value.',
+          }),
+        )
         return
       }
     }
     // The peer's pinnedPubkey (if any) must match ours too.
     if (frame.pinnedPubkey && frame.pinnedPubkey !== this.ourPublicKeyBase64) {
-      this.fail(new AppError({
-        code: 'relay_handshake_pubkey_mismatch',
-        status: 400,
-        message: 'Peer expected a different local public key.',
-      }))
+      this.fail(
+        new AppError({
+          code: 'relay_handshake_pubkey_mismatch',
+          status: 400,
+          message: 'Peer expected a different local public key.',
+        }),
+      )
       return
     }
 
     this.peerPubkey = frame.pubkey
     this.cb.onPeerPubkey?.(frame.pubkey, peerFingerprint(frame.pubkey))
     if (frame.name || frame.signingPubkey) {
-      this.cb.onPeerInfo?.({ ...(frame.name ? { name: frame.name } : {}), ...(frame.signingPubkey ? { signingPubkey: frame.signingPubkey } : {}) })
+      this.cb.onPeerInfo?.({
+        ...(frame.name ? { name: frame.name } : {}),
+        ...(frame.signingPubkey ? { signingPubkey: frame.signingPubkey } : {}),
+      })
     }
     this.deriveKeys()
 
@@ -328,7 +421,7 @@ export class RelaySession {
       // Pinning verified → ready immediately, no confirm exchange needed.
       this.markReady()
     }
-    else {
+ else {
       // First pairing: try to send hello_confirm now (only fires once we have
       // both sent our own hello and learned the peer's pubkey).
       this.maybeSendConfirm()
@@ -341,8 +434,12 @@ export class RelaySession {
     }
     const sharedSecret = computeRelaySharedSecret(this.ourPrivateKeyBase64, this.peerPubkey)
     this.keys = deriveRelayKeys(sharedSecret, this.pairingCode ?? '')
-    this.sendCipher = new RelayCipher(this.role === 'host' ? this.keys.hostSendKey : this.keys.controllerSendKey)
-    this.receiveCipher = new RelayCipher(this.role === 'host' ? this.keys.controllerSendKey : this.keys.hostSendKey)
+    this.sendCipher = new RelayCipher(
+      this.role === 'host' ? this.keys.hostSendKey : this.keys.controllerSendKey,
+    )
+    this.receiveCipher = new RelayCipher(
+      this.role === 'host' ? this.keys.controllerSendKey : this.keys.hostSendKey,
+    )
   }
 
   /**
@@ -392,17 +489,25 @@ export class RelaySession {
 
   private handleHelloConfirm(frame: { kind: 'hello_confirm', confirm: string }): void {
     if (this.isReconnect || !this.keys || !this.peerPubkey) {
-      this.fail(new AppError({ code: 'relay_handshake_unexpected_confirm', status: 400, message: 'Unexpected hello_confirm frame.' }))
+      this.fail(
+        new AppError({
+          code: 'relay_handshake_unexpected_confirm',
+          status: 400,
+          message: 'Unexpected hello_confirm frame.',
+        }),
+      )
       return
     }
     const sharedSecret = computeRelaySharedSecret(this.ourPrivateKeyBase64, this.peerPubkey)
     const expected = this.buildConfirm(sharedSecret)
     if (!confirmEquals(frame.confirm, expected)) {
-      this.fail(new AppError({
-        code: 'relay_handshake_confirm_mismatch',
-        status: 400,
-        message: 'Pairing confirmation failed. Check the pairing code.',
-      }))
+      this.fail(
+        new AppError({
+          code: 'relay_handshake_confirm_mismatch',
+          status: 400,
+          message: 'Pairing confirmation failed. Check the pairing code.',
+        }),
+      )
       return
     }
     this.confirmVerified = true
@@ -430,9 +535,13 @@ export class RelaySession {
   /** Controller side: open a new stream. Returns the streamId. */
   openStream(streamId: string): void {
     if (!this.isReady) {
-      throw new AppError({ code: 'relay_not_ready', status: 503, message: 'Relay session is not ready.' })
+      throw new AppError({
+        code: 'relay_not_ready',
+        status: 503,
+        message: 'Relay session is not ready.',
+      })
     }
-    this.streams.set(streamId, createStreamFlowState())
+    this.streams.set(streamId, createStreamFlowState(this.initialStreamCreditBytes))
     this.sendEncryptedFrame({ kind: INNER_FRAME_KIND.streamOpen, streamId })
   }
 
@@ -450,21 +559,9 @@ export class RelaySession {
     if (!flow || flow.closed || !this.isReady) {
       return
     }
-    let offset = 0
-    while (offset < data.length) {
-      const chunkEnd = Math.min(offset + RELAY_MAX_STREAM_CHUNK_BYTES, data.length)
-      const chunk = data.subarray(offset, chunkEnd)
-      const seq = flow.sentBytes
-      this.sendEncryptedFrame({
-        kind: INNER_FRAME_KIND.streamData,
-        streamId,
-        seq,
-        data: Buffer.from(chunk).toString('base64'),
-      })
-      flow.sentBytes += chunk.length
-      offset = chunkEnd
-    }
-    if (bytesInFlight(flow) >= RELAY_STREAM_CREDIT_BYTES && !flow.paused) {
+    flow.pendingData.push(data)
+    this.flushOutboundStream(streamId, flow)
+    if ((flow.pendingData.length > 0 || bytesInFlight(flow) >= flow.creditBytes) && !flow.paused) {
       flow.paused = true
       this.cb.onPauseStream?.(streamId)
     }
@@ -479,7 +576,11 @@ export class RelaySession {
    * Cumulative `stream_ack` frames are emitted every {@link ACK_INTERVAL_BYTES}.
    * Pass `flush: true` (or close the stream) to advertise any remainder.
    */
-  reportStreamDataConsumed(streamId: string, consumedBytes: number, options?: { flush?: boolean }): void {
+  reportStreamDataConsumed(
+    streamId: string,
+    consumedBytes: number,
+    options?: { flush?: boolean },
+  ): void {
     const flow = this.streams.get(streamId)
     if (!flow || flow.closed || !this.isReady || consumedBytes <= 0) {
       return
@@ -537,24 +638,33 @@ export class RelaySession {
     }
     this.maybeSendReceiveAck(streamId, flow, true)
     flow.closed = true
-    this.sendEncryptedFrame({ kind: INNER_FRAME_KIND.streamClose, streamId, ...(reason ? { reason } : {}) })
+    this.sendEncryptedFrame({
+      kind: INNER_FRAME_KIND.streamClose,
+      streamId,
+      ...(reason ? { reason } : {}),
+    })
   }
 
   private handleStreamOpen(streamId: string): void {
     if (this.streams.has(streamId)) {
-      this.fail(new AppError({ code: 'relay_stream_duplicate', status: 400, message: `Stream ${streamId} already open.` }))
+      this.fail(
+        new AppError({
+          code: 'relay_stream_duplicate',
+          status: 400,
+          message: `Stream ${streamId} already open.`,
+        }),
+      )
       return
     }
-    this.streams.set(streamId, createStreamFlowState())
+    this.streams.set(streamId, createStreamFlowState(this.initialStreamCreditBytes))
     this.cb.onStreamOpen?.(streamId)
   }
 
-  private handleStreamData(streamId: string, dataBase64: string): void {
+  private handleStreamData(streamId: string, data: Uint8Array): void {
     const flow = this.streams.get(streamId)
     if (!flow || flow.closed) {
       return
     }
-    const data = new Uint8Array(Buffer.from(dataBase64, 'base64'))
     flow.receivedBytes += data.length
     // Deliver first; credit is released only when the transport reports the
     // bytes were applied (TCP write success / drain). See reportStreamDataConsumed.
@@ -569,9 +679,20 @@ export class RelaySession {
     if (ackedBytes > flow.sentBytes) {
       return
     }
+    const previousAckedBytes = flow.peerAckedBytes
     // Send-side credit only — never touch receive-side counters here.
     flow.peerAckedBytes = Math.max(flow.peerAckedBytes, ackedBytes)
-    if (flow.paused && bytesInFlight(flow) < RELAY_STREAM_CREDIT_BYTES / 2) {
+    const releasedBytes = flow.peerAckedBytes - previousAckedBytes
+    flow.ackedSinceCreditIncrease += releasedBytes
+    if (
+      flow.ackedSinceCreditIncrease >= flow.creditBytes / 2
+      && flow.creditBytes < this.maxStreamCreditBytes
+    ) {
+      flow.creditBytes = Math.min(this.maxStreamCreditBytes, flow.creditBytes * 2)
+      flow.ackedSinceCreditIncrease = 0
+    }
+    this.flushOutboundStream(streamId, flow)
+    if (flow.paused && bytesInFlight(flow) < flow.creditBytes / 2) {
       flow.paused = false
       this.cb.onResumeStream?.(streamId)
     }
@@ -586,75 +707,101 @@ export class RelaySession {
     this.cb.onStreamClose?.(streamId, reason)
   }
 
+  private flushOutboundStream(streamId: string, flow: StreamFlowState): void {
+    while (flow.pendingData.length > 0 && bytesInFlight(flow) < flow.creditBytes) {
+      const pending = flow.pendingData[0]
+      const capacity = flow.creditBytes - bytesInFlight(flow)
+      const length = Math.min(pending.byteLength, capacity, RELAY_MAX_STREAM_CHUNK_BYTES)
+      if (length <= 0) {
+        break
+      }
+      const chunk = pending.subarray(0, length)
+      if (length === pending.byteLength) {
+        flow.pendingData.shift()
+      }
+ else {
+        flow.pendingData[0] = pending.subarray(length)
+      }
+      const seq = flow.sentBytes
+      flow.sentBytes += chunk.byteLength
+      this.sendEncryptedFrame({ kind: INNER_FRAME_KIND.streamData, streamId, seq, data: chunk })
+    }
+  }
+
   private handlePeerClosed(env: RelayEnvelope): void {
-    const parsed = peerClosedPayloadSchema.safeParse(env.payload)
-    this.cb.onPeerClosed?.(parsed.success ? parsed.data.reason : undefined)
+    try {
+      this.cb.onPeerClosed?.(decodeRelayPeerClosedPayload(env.payload).reason)
+    }
+ catch {
+      this.cb.onPeerClosed?.()
+    }
   }
 
   private handleRelayError(env: RelayEnvelope): void {
-    const parsed = relayErrorPayloadSchema.safeParse(env.payload)
-    this.fail(new AppError({
-      code: 'relay_error',
-      status: 502,
-      message: parsed.success ? (parsed.data.error ?? 'relay error') : 'relay error',
-    }))
+    let message = 'relay error'
+    try {
+      message = decodeRelayErrorPayload(env.payload).error ?? message
+    }
+ catch {
+      // Keep a stable error when the untrusted control payload is malformed.
+    }
+    this.fail(
+      new AppError({
+        code: 'relay_error',
+        status: 502,
+        message,
+      }),
+    )
   }
 
   // ── Frame send helpers ──
 
-  private sendPlainEnvelope(payload: unknown): void {
+  private sendPlainEnvelope(frame: InnerFrame): void {
     const env: RelayEnvelope = {
       version: RELAY_PROTOCOL_VERSION,
       roomId: this.roomId,
       seq: this.outboundSeq++,
       kind: RELAY_ENVELOPE_KIND.dataFrame,
-      payload,
+      priority: relayPriorityForInnerFrame(frame),
+      ...(streamIdForFrame(frame) ? { streamId: streamIdForFrame(frame) } : {}),
+      payload: encodeInnerFrame(frame),
     }
-    this.cb.send(JSON.stringify(env))
+    this.cb.send(encodeRelayEnvelope(env))
   }
 
   private sendEncryptedFrame(frame: InnerFrame): void {
     if (!this.sendCipher) {
-      throw new AppError({ code: 'relay_not_ready', status: 503, message: 'Relay session keys not derived.' })
+      throw new AppError({
+        code: 'relay_not_ready',
+        status: 503,
+        message: 'Relay session keys not derived.',
+      })
     }
-    innerFrameSchema.parse(frame)
-    const plaintext = Buffer.from(JSON.stringify(frame), 'utf8')
-    const ciphertext = this.sendCipher.encrypt(new Uint8Array(plaintext))
-    const payload = { ciphertext }
-    encryptedPayloadSchema.parse(payload)
-    this.sendPlainEnvelope(payload)
+    const env: RelayEnvelope = {
+      version: RELAY_PROTOCOL_VERSION,
+      roomId: this.roomId,
+      seq: this.outboundSeq++,
+      kind: RELAY_ENVELOPE_KIND.dataFrame,
+      priority: relayPriorityForInnerFrame(frame),
+      ...(streamIdForFrame(frame) ? { streamId: streamIdForFrame(frame) } : {}),
+      payload: this.sendCipher.encrypt(encodeInnerFrame(frame)),
+    }
+    this.cb.send(encodeRelayEnvelope(env))
   }
 
-  private parsePlainFrame(payload: unknown): InnerFrame {
-    // Plaintext handshake frames arrive as bare JSON objects.
-    const parsed = innerFrameSchema.safeParse(payload)
-    if (!parsed.success) {
-      throw new AppError({ code: 'relay_protocol_invalid_frame', status: 400, message: `Invalid inner frame: ${parsed.error.message}` })
-    }
-    return parsed.data
+  private parsePlainFrame(payload: Uint8Array): InnerFrame {
+    return decodeInnerFrame(payload)
   }
 
-  private decryptFrame(payload: unknown): InnerFrame {
+  private decryptFrame(payload: Uint8Array): InnerFrame {
     if (!this.receiveCipher) {
-      throw new AppError({ code: 'relay_not_ready', status: 503, message: 'Relay session keys not derived.' })
+      throw new AppError({
+        code: 'relay_not_ready',
+        status: 503,
+        message: 'Relay session keys not derived.',
+      })
     }
-    const encryptedParsed = encryptedPayloadSchema.safeParse(payload)
-    if (!encryptedParsed.success) {
-      throw new AppError({ code: 'relay_protocol_invalid_payload', status: 400, message: 'Invalid encrypted payload.' })
-    }
-    const plaintext = this.receiveCipher.decrypt(encryptedParsed.data.ciphertext)
-    let json: unknown
-    try {
-      json = JSON.parse(Buffer.from(plaintext).toString('utf8'))
-    }
-    catch (error) {
-      throw new AppError({ code: 'relay_protocol_invalid_frame', status: 400, message: `Decrypted frame is not JSON: ${error instanceof Error ? error.message : String(error)}` })
-    }
-    const frameParsed = innerFrameSchema.safeParse(json)
-    if (!frameParsed.success) {
-      throw new AppError({ code: 'relay_protocol_invalid_frame', status: 400, message: `Invalid decrypted inner frame: ${frameParsed.error.message}` })
-    }
-    return frameParsed.data
+    return decodeInnerFrame(this.receiveCipher.decrypt(payload))
   }
 
   private fail(error: Error): void {
@@ -679,7 +826,9 @@ export class RelaySession {
 }
 
 function publicKeyFromPrivateKey(privateKeyBase64: string): string {
-  return Buffer.from(x25519.scalarMultBase(new Uint8Array(Buffer.from(privateKeyBase64, 'base64')))).toString('base64')
+  return Buffer.from(
+    x25519.scalarMultBase(new Uint8Array(Buffer.from(privateKeyBase64, 'base64'))),
+  ).toString('base64')
 }
 
 function peerFingerprint(publicKeyBase64: string): string {

--- a/apps/server/src/modules/relay-transport/session.ts
+++ b/apps/server/src/modules/relay-transport/session.ts
@@ -3,6 +3,11 @@ import { timingSafeEqual } from 'node:crypto'
 import { x25519 } from '@noble/curves/ed25519'
 
 import { AppError } from '../../errors/app-error'
+import {
+  decodeRelayChunk,
+  encodeRelayChunk,
+  RELAY_MIN_COMPRESSION_INPUT_BYTES,
+} from './compression'
 import type { RelayCryptoRole, RelayDerivedKeys } from './crypto'
 import {
   computeRelayConfirm,
@@ -33,7 +38,7 @@ import {
  * transports. It owns:
  *
  * 1. The `hello` / `hello_confirm` handshake (ECDH → key derivation → pinning).
- * 2. Per-frame XChaCha20-Poly1305 encryption of inner stream frames.
+ * 2. Size-adaptive XChaCha20-Poly1305/AES-256-GCM encryption of inner frames.
  * 3. Stream multiplexing over the single relayd room.
  * 4. Credit-based flow control so a fast sender can't overrun the relayd queue
  *    (64 frames / 4 MiB) or the peer.
@@ -66,6 +71,8 @@ export interface RelaySessionOptions {
   maxStreamCreditBytes?: number
   /** Hard aggregate byte allowance across all streams. Defaults to 16 MiB. */
   maxConnectionCreditBytes?: number
+  /** Disable Zstandard and bulk AES together for controlled V2 before/after benchmarks. */
+  optimizedCodecEnabled?: boolean
 }
 
 export interface RelaySessionCallbacks {
@@ -143,7 +150,7 @@ function streamIdForFrame(frame: InnerFrame): string | undefined {
   }
 }
 
-const ACK_INTERVAL_BYTES = 64 * 1024
+const ACK_INTERVAL_BYTES = 256 * 1024
 
 export class RelaySession {
   readonly role: RelaySessionRole
@@ -174,6 +181,10 @@ export class RelaySession {
   private readonly initialStreamCreditBytes: number
   private readonly maxStreamCreditBytes: number
   private readonly maxConnectionCreditBytes: number
+  private readonly optimizedCodecEnabled: boolean
+  private connectionInFlightBytes = 0
+  private flushCursor = 0
+  private flushingOutbound = false
 
   constructor(
     role: RelaySessionRole,
@@ -202,6 +213,7 @@ export class RelaySession {
     this.maxStreamCreditBytes = options.maxStreamCreditBytes ?? RELAY_STREAM_MAX_CREDIT_BYTES
     this.maxConnectionCreditBytes
       = options.maxConnectionCreditBytes ?? RELAY_CONNECTION_MAX_CREDIT_BYTES
+    this.optimizedCodecEnabled = options.optimizedCodecEnabled ?? true
     if (
       !Number.isSafeInteger(this.initialStreamCreditBytes)
       || !Number.isSafeInteger(this.maxStreamCreditBytes)
@@ -347,7 +359,7 @@ export class RelaySession {
         this.handleStreamOpen(frame.streamId)
         break
       case INNER_FRAME_KIND.streamData:
-        this.handleStreamData(frame.streamId, frame.data)
+        this.handleStreamData(frame)
         break
       case INNER_FRAME_KIND.streamAck:
         this.handleStreamAck(frame.streamId, frame.ackedBytes)
@@ -444,9 +456,11 @@ export class RelaySession {
     this.keys = deriveRelayKeys(sharedSecret, this.pairingCode ?? '')
     this.sendCipher = new RelayCipher(
       this.role === 'host' ? this.keys.hostSendKey : this.keys.controllerSendKey,
+      this.optimizedCodecEnabled,
     )
     this.receiveCipher = new RelayCipher(
       this.role === 'host' ? this.keys.controllerSendKey : this.keys.hostSendKey,
+      this.optimizedCodecEnabled,
     )
   }
 
@@ -645,6 +659,10 @@ export class RelaySession {
     }
     this.maybeSendReceiveAck(streamId, flow, true)
     flow.closed = true
+    this.connectionInFlightBytes = Math.max(
+      0,
+      this.connectionInFlightBytes - bytesInFlight(flow),
+    )
     this.sendEncryptedFrame({
       kind: INNER_FRAME_KIND.streamClose,
       streamId,
@@ -668,11 +686,27 @@ export class RelaySession {
     this.cb.onStreamOpen?.(streamId)
   }
 
-  private handleStreamData(streamId: string, data: Uint8Array): void {
+  private handleStreamData(frame: Extract<InnerFrame, { kind: 'stream_data' }>): void {
+    const streamId = frame.streamId
     const flow = this.streams.get(streamId)
     if (!flow || flow.closed) {
       return
     }
+    if (frame.seq !== flow.receivedBytes) {
+      this.fail(
+        new AppError({
+          code: 'relay_stream_sequence_invalid',
+          status: 400,
+          message: `Unexpected stream sequence ${frame.seq}; expected ${flow.receivedBytes}.`,
+        }),
+      )
+      return
+    }
+    const data = decodeRelayChunk({
+      data: frame.data,
+      compression: frame.compression ?? 'none',
+      uncompressedBytes: frame.uncompressedBytes ?? frame.data.byteLength,
+    })
     flow.receivedBytes += data.length
     // Deliver first; credit is released only when the transport reports the
     // bytes were applied (TCP write success / drain). See reportStreamDataConsumed.
@@ -691,6 +725,7 @@ export class RelaySession {
     // Send-side credit only — never touch receive-side counters here.
     flow.peerAckedBytes = Math.max(flow.peerAckedBytes, ackedBytes)
     const releasedBytes = flow.peerAckedBytes - previousAckedBytes
+    this.connectionInFlightBytes = Math.max(0, this.connectionInFlightBytes - releasedBytes)
     flow.ackedSinceCreditIncrease += releasedBytes
     if (
       flow.ackedSinceCreditIncrease >= flow.creditBytes / 2
@@ -707,57 +742,95 @@ export class RelaySession {
   private handleStreamCloseFrame(streamId: string, reason?: string): void {
     const flow = this.streams.get(streamId)
     if (flow) {
+      this.connectionInFlightBytes = Math.max(
+        0,
+        this.connectionInFlightBytes - bytesInFlight(flow),
+      )
       flow.closed = true
       this.streams.delete(streamId)
     }
     this.cb.onStreamClose?.(streamId, reason)
   }
 
-  private connectionBytesInFlight(): number {
-    let total = 0
-    for (const flow of this.streams.values()) {
-      if (!flow.closed) {
-        total += bytesInFlight(flow)
-      }
-    }
-    return total
-  }
-
   private flushOutboundStreams(): void {
-    for (const [streamId, flow] of this.streams) {
-      this.flushOutboundStream(streamId, flow)
-      if (this.connectionBytesInFlight() >= this.maxConnectionCreditBytes) {
-        break
+    if (this.flushingOutbound) {
+      return
+    }
+    this.flushingOutbound = true
+    try {
+      const streams = [...this.streams.entries()].filter(([, flow]) => !flow.closed)
+      if (streams.length === 0) {
+        return
       }
+      let madeProgress = true
+      while (madeProgress && this.connectionInFlightBytes < this.maxConnectionCreditBytes) {
+        madeProgress = false
+        for (let offset = 0; offset < streams.length; offset++) {
+          const index = (this.flushCursor + offset) % streams.length
+          const [streamId, flow] = streams[index]
+          if (this.flushOutboundChunk(streamId, flow)) {
+            madeProgress = true
+            this.flushCursor = (index + 1) % streams.length
+          }
+          if (this.connectionInFlightBytes >= this.maxConnectionCreditBytes) {
+            break
+          }
+        }
+      }
+    }
+    finally {
+      this.flushingOutbound = false
     }
   }
 
-  private flushOutboundStream(streamId: string, flow: StreamFlowState): void {
-    while (
-      flow.pendingData.length > 0
-      && bytesInFlight(flow) < flow.creditBytes
-      && this.connectionBytesInFlight() < this.maxConnectionCreditBytes
+  private flushOutboundChunk(streamId: string, flow: StreamFlowState): boolean {
+    if (
+      flow.closed
+      || flow.pendingData.length === 0
+      || bytesInFlight(flow) >= flow.creditBytes
+      || this.connectionInFlightBytes >= this.maxConnectionCreditBytes
     ) {
-      const pending = flow.pendingData[0]
-      const capacity = Math.min(
-        flow.creditBytes - bytesInFlight(flow),
-        this.maxConnectionCreditBytes - this.connectionBytesInFlight(),
-      )
-      const length = Math.min(pending.byteLength, capacity, RELAY_MAX_STREAM_CHUNK_BYTES)
-      if (length <= 0) {
-        break
-      }
-      const chunk = pending.subarray(0, length)
-      if (length === pending.byteLength) {
-        flow.pendingData.shift()
-      }
- else {
-        flow.pendingData[0] = pending.subarray(length)
-      }
-      const seq = flow.sentBytes
-      flow.sentBytes += chunk.byteLength
-      this.sendEncryptedFrame({ kind: INNER_FRAME_KIND.streamData, streamId, seq, data: chunk })
+      return false
     }
+    const pending = flow.pendingData[0]
+    const capacity = Math.min(
+      flow.creditBytes - bytesInFlight(flow),
+      this.maxConnectionCreditBytes - this.connectionInFlightBytes,
+    )
+    const length = Math.min(pending.byteLength, capacity, RELAY_MAX_STREAM_CHUNK_BYTES)
+    if (length <= 0) {
+      return false
+    }
+    const chunk = pending.subarray(0, length)
+    if (length === pending.byteLength) {
+      flow.pendingData.shift()
+    }
+ else {
+      flow.pendingData[0] = pending.subarray(length)
+    }
+    const seq = flow.sentBytes
+    flow.sentBytes += chunk.byteLength
+    this.connectionInFlightBytes += chunk.byteLength
+    if (chunk.byteLength < RELAY_MIN_COMPRESSION_INPUT_BYTES || !this.optimizedCodecEnabled) {
+      this.sendEncryptedFrame({
+        kind: INNER_FRAME_KIND.streamData,
+        streamId,
+        seq,
+        data: chunk,
+      })
+      return true
+    }
+    const encoded = encodeRelayChunk(chunk)
+    this.sendEncryptedFrame({
+      kind: INNER_FRAME_KIND.streamData,
+      streamId,
+      seq,
+      data: encoded.data,
+      ...(encoded.compression === 'zstd'
+        ? { compression: 'zstd', uncompressedBytes: encoded.uncompressedBytes }
+        : {}),
+    })
+    return true
   }
 
   private updatePausedStreams(): void {
@@ -802,13 +875,14 @@ export class RelaySession {
   // ── Frame send helpers ──
 
   private sendPlainEnvelope(frame: InnerFrame): void {
+    const streamId = streamIdForFrame(frame)
     const env: RelayEnvelope = {
       version: RELAY_PROTOCOL_VERSION,
       roomId: this.roomId,
       seq: this.outboundSeq++,
       kind: RELAY_ENVELOPE_KIND.dataFrame,
       priority: relayPriorityForInnerFrame(frame),
-      ...(streamIdForFrame(frame) ? { streamId: streamIdForFrame(frame) } : {}),
+      ...(streamId ? { streamId } : {}),
       payload: encodeInnerFrame(frame),
     }
     this.cb.send(encodeRelayEnvelope(env))
@@ -822,13 +896,14 @@ export class RelaySession {
         message: 'Relay session keys not derived.',
       })
     }
+    const streamId = streamIdForFrame(frame)
     const env: RelayEnvelope = {
       version: RELAY_PROTOCOL_VERSION,
       roomId: this.roomId,
       seq: this.outboundSeq++,
       kind: RELAY_ENVELOPE_KIND.dataFrame,
       priority: relayPriorityForInnerFrame(frame),
-      ...(streamIdForFrame(frame) ? { streamId: streamIdForFrame(frame) } : {}),
+      ...(streamId ? { streamId } : {}),
       payload: this.sendCipher.encrypt(encodeInnerFrame(frame)),
     }
     this.cb.send(encodeRelayEnvelope(env))
@@ -867,6 +942,7 @@ export class RelaySession {
       this.cb.onStreamClose?.(streamId, 'session closed')
     }
     this.streams.clear()
+    this.connectionInFlightBytes = 0
   }
 }
 

--- a/apps/server/src/modules/relay-transport/session.ts
+++ b/apps/server/src/modules/relay-transport/session.ts
@@ -19,6 +19,7 @@ import {
   encodeInnerFrame,
   encodeRelayEnvelope,
   INNER_FRAME_KIND,
+  RELAY_CONNECTION_MAX_CREDIT_BYTES,
   RELAY_ENVELOPE_KIND,
   RELAY_MAX_STREAM_CHUNK_BYTES,
   RELAY_PROTOCOL_VERSION,
@@ -63,6 +64,8 @@ export interface RelaySessionOptions {
   initialStreamCreditBytes?: number
   /** Hard per-stream byte allowance. Defaults to 8 MiB. */
   maxStreamCreditBytes?: number
+  /** Hard aggregate byte allowance across all streams. Defaults to 16 MiB. */
+  maxConnectionCreditBytes?: number
 }
 
 export interface RelaySessionCallbacks {
@@ -170,6 +173,7 @@ export class RelaySession {
   private readonly isReconnect: boolean
   private readonly initialStreamCreditBytes: number
   private readonly maxStreamCreditBytes: number
+  private readonly maxConnectionCreditBytes: number
 
   constructor(
     role: RelaySessionRole,
@@ -196,16 +200,20 @@ export class RelaySession {
     this.initialStreamCreditBytes
       = options.initialStreamCreditBytes ?? RELAY_STREAM_MIN_CREDIT_BYTES
     this.maxStreamCreditBytes = options.maxStreamCreditBytes ?? RELAY_STREAM_MAX_CREDIT_BYTES
+    this.maxConnectionCreditBytes
+      = options.maxConnectionCreditBytes ?? RELAY_CONNECTION_MAX_CREDIT_BYTES
     if (
       !Number.isSafeInteger(this.initialStreamCreditBytes)
       || !Number.isSafeInteger(this.maxStreamCreditBytes)
+      || !Number.isSafeInteger(this.maxConnectionCreditBytes)
       || this.initialStreamCreditBytes < RELAY_STREAM_MIN_CREDIT_BYTES
       || this.maxStreamCreditBytes < this.initialStreamCreditBytes
+      || this.maxConnectionCreditBytes < this.initialStreamCreditBytes
     ) {
       throw new AppError({
         code: 'relay_credit_config_invalid',
         status: 500,
-        message: 'Relay stream credit bounds are invalid.',
+        message: 'Relay stream or connection credit bounds are invalid.',
       })
     }
   }
@@ -549,10 +557,9 @@ export class RelaySession {
    * Send data on a stream. The data is chunked to stay under the relayd frame
    * cap. The session always sends all of `data` (it does not partial-accept);
    * flow control is signaled back to the caller via onPauseStream/onResumeStream
-   * — the caller must pause reading its local source when asked. A brief
-   * overage of up to one chunk (≤ 256 KiB) past the credit window is absorbed
-   * by relayd's 4 MiB queue and the peer's receive buffer, which keeps the
-   * transport logic simple without risking a queue overrun.
+   * — the caller must pause reading its local source when asked. Per-stream
+   * and connection-wide credit bounds keep aggregate in-flight data within a
+   * fixed memory budget even when many streams are active.
    */
   writeStreamData(streamId: string, data: Uint8Array): void {
     const flow = this.streams.get(streamId)
@@ -560,7 +567,7 @@ export class RelaySession {
       return
     }
     flow.pendingData.push(data)
-    this.flushOutboundStream(streamId, flow)
+    this.flushOutboundStreams()
     if ((flow.pendingData.length > 0 || bytesInFlight(flow) >= flow.creditBytes) && !flow.paused) {
       flow.paused = true
       this.cb.onPauseStream?.(streamId)
@@ -643,6 +650,7 @@ export class RelaySession {
       streamId,
       ...(reason ? { reason } : {}),
     })
+    this.streams.delete(streamId)
   }
 
   private handleStreamOpen(streamId: string): void {
@@ -691,11 +699,8 @@ export class RelaySession {
       flow.creditBytes = Math.min(this.maxStreamCreditBytes, flow.creditBytes * 2)
       flow.ackedSinceCreditIncrease = 0
     }
-    this.flushOutboundStream(streamId, flow)
-    if (flow.paused && bytesInFlight(flow) < flow.creditBytes / 2) {
-      flow.paused = false
-      this.cb.onResumeStream?.(streamId)
-    }
+    this.flushOutboundStreams()
+    this.updatePausedStreams()
     this.cb.onStreamAck?.(streamId, ackedBytes)
   }
 
@@ -703,14 +708,41 @@ export class RelaySession {
     const flow = this.streams.get(streamId)
     if (flow) {
       flow.closed = true
+      this.streams.delete(streamId)
     }
     this.cb.onStreamClose?.(streamId, reason)
   }
 
+  private connectionBytesInFlight(): number {
+    let total = 0
+    for (const flow of this.streams.values()) {
+      if (!flow.closed) {
+        total += bytesInFlight(flow)
+      }
+    }
+    return total
+  }
+
+  private flushOutboundStreams(): void {
+    for (const [streamId, flow] of this.streams) {
+      this.flushOutboundStream(streamId, flow)
+      if (this.connectionBytesInFlight() >= this.maxConnectionCreditBytes) {
+        break
+      }
+    }
+  }
+
   private flushOutboundStream(streamId: string, flow: StreamFlowState): void {
-    while (flow.pendingData.length > 0 && bytesInFlight(flow) < flow.creditBytes) {
+    while (
+      flow.pendingData.length > 0
+      && bytesInFlight(flow) < flow.creditBytes
+      && this.connectionBytesInFlight() < this.maxConnectionCreditBytes
+    ) {
       const pending = flow.pendingData[0]
-      const capacity = flow.creditBytes - bytesInFlight(flow)
+      const capacity = Math.min(
+        flow.creditBytes - bytesInFlight(flow),
+        this.maxConnectionCreditBytes - this.connectionBytesInFlight(),
+      )
       const length = Math.min(pending.byteLength, capacity, RELAY_MAX_STREAM_CHUNK_BYTES)
       if (length <= 0) {
         break
@@ -725,6 +757,19 @@ export class RelaySession {
       const seq = flow.sentBytes
       flow.sentBytes += chunk.byteLength
       this.sendEncryptedFrame({ kind: INNER_FRAME_KIND.streamData, streamId, seq, data: chunk })
+    }
+  }
+
+  private updatePausedStreams(): void {
+    for (const [streamId, flow] of this.streams) {
+      if (
+        flow.paused
+        && flow.pendingData.length === 0
+        && bytesInFlight(flow) < flow.creditBytes / 2
+      ) {
+        flow.paused = false
+        this.cb.onResumeStream?.(streamId)
+      }
     }
   }
 

--- a/apps/server/src/modules/relay-transport/websocket-data.ts
+++ b/apps/server/src/modules/relay-transport/websocket-data.ts
@@ -1,0 +1,13 @@
+import type WebSocket from 'ws'
+
+/** Return a zero-copy view for the normal Buffer/ArrayBuffer WebSocket paths. */
+export function relayWebSocketDataView(data: WebSocket.RawData): Uint8Array {
+  if (Array.isArray(data)) {
+    const combined = Buffer.concat(data)
+    return new Uint8Array(combined.buffer, combined.byteOffset, combined.byteLength)
+  }
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data)
+  }
+  return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+}

--- a/apps/server/src/modules/remote-hosts/model.ts
+++ b/apps/server/src/modules/remote-hosts/model.ts
@@ -14,9 +14,33 @@ const sshAuth = t.Union([
 ])
 const cradleServerConnectionState = t.Union([
   t.Literal('idle'),
+  t.Literal('warming'),
   t.Literal('connected'),
   t.Literal('offline'),
 ])
+
+const relayConnectionAttempt = t.Object({
+  attempt: t.Number(),
+  startedAt: t.Number(),
+  websocketOpenedAt: nullableNumber,
+  handshakeReadyAt: nullableNumber,
+  failedAt: nullableNumber,
+}, { additionalProperties: false })
+
+const relayStreamCheckpoint = t.Object({
+  streamId: t.String(),
+  openedAt: t.Number(),
+  firstRequestByteAt: nullableNumber,
+  firstResponseByteAt: nullableNumber,
+  closedAt: nullableNumber,
+}, { additionalProperties: false })
+
+const relayPerformance = t.Object({
+  connectionAttempts: t.Array(relayConnectionAttempt),
+  localListenerReadyAt: nullableNumber,
+  activeStreams: t.Array(relayStreamCheckpoint),
+  completedStreams: t.Array(relayStreamCheckpoint),
+}, { additionalProperties: false })
 
 const relayConfig = t.Object({
   relayServerId: t.Optional(nullableString),
@@ -112,6 +136,7 @@ export const RemoteHostsModel = {
     state: cradleServerConnectionState,
     localBaseUrl: nullableString,
     lastError: nullableString,
+    relayPerformance: t.Union([relayPerformance, t.Null()]),
   }, { additionalProperties: false }),
 
   cradleServerHealth: t.Object({
@@ -119,6 +144,7 @@ export const RemoteHostsModel = {
     state: cradleServerConnectionState,
     localBaseUrl: nullableString,
     lastError: nullableString,
+    relayPerformance: t.Union([relayPerformance, t.Null()]),
     status: t.Literal('ok'),
     health: cradleServerHealthPayload,
   }, { additionalProperties: false }),

--- a/apps/server/src/modules/remote-hosts/service.ts
+++ b/apps/server/src/modules/remote-hosts/service.ts
@@ -16,6 +16,7 @@ import {
   signRelayAssertion,
 } from '../relay-servers/relay-signature-service'
 import { resolveRelayUrl as resolveRelayServerUrl } from '../relay-servers/service'
+import type { RelayControllerPerformanceSnapshot } from '../relay-transport/controller-transport'
 import {
   startRelayControllerTransport,
 } from '../relay-transport/controller-transport'
@@ -120,7 +121,7 @@ export interface SshProfileLaunchConfig {
   sshArgs: string[]
 }
 
-export type RemoteHostConnectionState = 'idle' | 'connected' | 'offline'
+export type RemoteHostConnectionState = 'idle' | 'warming' | 'connected' | 'offline'
 
 export interface RemoteHostView extends RemoteHost {
   connectionState: RemoteHostConnectionState
@@ -132,6 +133,7 @@ export interface RemoteCradleServerConnectionView {
   state: RemoteHostConnectionState
   localBaseUrl: string | null
   lastError: string | null
+  relayPerformance: RelayControllerPerformanceSnapshot | null
 }
 
 export interface RemoteCradleServerHealthView extends RemoteCradleServerConnectionView {
@@ -821,6 +823,7 @@ export async function claimRemoteHostRelay(
     state: 'idle',
     localBaseUrl: null,
     lastError: null,
+    relayPerformance: null,
   }
 }
 
@@ -1027,7 +1030,9 @@ function toHostView(host: RemoteHost): RemoteHostView {
   const record = connections.get(host.id)
   return {
     ...host,
-    connectionState: record ? connectionStateOf(record) : 'idle',
+    connectionState: record
+      ? connectionStateOf(record)
+      : connectPromises.has(host.id) ? 'warming' : 'idle',
     lastError: record?.lastError ?? null,
   }
 }
@@ -1038,7 +1043,19 @@ function toConnectionView(record: RemoteHostConnectionRecord): RemoteCradleServe
     state: connectionStateOf(record),
     localBaseUrl: record.tunnelExited ? null : record.baseUrl,
     lastError: record.lastError,
+    relayPerformance: relayPerformanceForTunnel(record.tunnel),
   }
+}
+
+function relayPerformanceForTunnel(tunnel: LocalTunnelHandle | null): RelayControllerPerformanceSnapshot | null {
+  if (!tunnel || !('getPerformanceSnapshot' in tunnel)) {
+    return null
+  }
+  const getPerformanceSnapshot = tunnel.getPerformanceSnapshot
+  if (typeof getPerformanceSnapshot !== 'function') {
+    return null
+  }
+  return getPerformanceSnapshot.call(tunnel) as RelayControllerPerformanceSnapshot
 }
 
 function connectionStateOf(record: RemoteHostConnectionRecord): RemoteHostConnectionState {

--- a/apps/server/tests/relay-transport/adverse-network-benchmark.test.ts
+++ b/apps/server/tests/relay-transport/adverse-network-benchmark.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateRelayKeyPair } from '../../src/modules/relay-transport/crypto'
+import { decodeRelayEnvelope } from '../../src/modules/relay-transport/protocol'
+import { RelaySession } from '../../src/modules/relay-transport/session'
+
+const TRANSFER_BYTES = 2 * 1024 * 1024
+
+interface LinkScenario {
+  name: 'stable' | 'mobile' | 'constrained' | 'hostile'
+  rttMs: number
+  bandwidthKbps: number
+  jitterMs: number
+  lossPercent: number
+}
+
+interface NetworkResult {
+  scenario: LinkScenario['name']
+  profile: 'compressible' | 'incompressible'
+  mode: 'V2 baseline' | 'V2 optimized'
+  completionMs: number
+  wireBytes: number
+  pauses: number
+  resumes: number
+}
+
+interface ScheduledEnvelope {
+  deliverAt: number
+  order: number
+  deliver: (data: Uint8Array) => void
+  data: Uint8Array
+}
+
+const SCENARIOS: LinkScenario[] = [
+  { name: 'stable', rttMs: 20, bandwidthKbps: 100_000, jitterMs: 2, lossPercent: 0 },
+  { name: 'mobile', rttMs: 100, bandwidthKbps: 5_000, jitterMs: 20, lossPercent: 1 },
+  { name: 'constrained', rttMs: 250, bandwidthKbps: 512, jitterMs: 50, lossPercent: 3 },
+  { name: 'hostile', rttMs: 800, bandwidthKbps: 128, jitterMs: 200, lossPercent: 10 },
+]
+
+class ShapedTcpWire {
+  now = 0
+  wireBytes = 0
+  private order = 0
+  private randomState = 0xC0FFEE
+  private readonly queue: ScheduledEnvelope[] = []
+  private readonly paths = new Map<'controller-host' | 'host-controller', { nextSendAt: number, lastArrival: number }>([
+    ['controller-host', { nextSendAt: 0, lastArrival: 0 }],
+    ['host-controller', { nextSendAt: 0, lastArrival: 0 }],
+  ])
+
+  constructor(private readonly scenario: LinkScenario) {}
+
+  send(
+    direction: 'controller-host' | 'host-controller',
+    deliver: (data: Uint8Array) => void,
+    data: Uint8Array,
+  ): void {
+    const path = this.paths.get(direction)!
+    const segmentBytes = 1_200
+    const segments = Math.max(1, Math.ceil(data.byteLength / segmentBytes))
+    let retransmittedBytes = 0
+    let retransmissionRounds = 0
+    for (let segment = 0; segment < segments; segment++) {
+      const bytes = Math.min(segmentBytes, data.byteLength - segment * segmentBytes)
+      let attempts = 0
+      while (this.nextRandom() < this.scenario.lossPercent / 100) {
+        retransmittedBytes += bytes
+        attempts++
+        if (attempts === 8) {
+          break
+        }
+      }
+      retransmissionRounds = Math.max(retransmissionRounds, attempts)
+    }
+    const transmittedBytes = data.byteLength + retransmittedBytes
+    const start = Math.max(this.now, path.nextSendAt)
+    // One kbit/s is one bit/ms, so bytes * 8 / kbit/s yields milliseconds.
+    const serializationMs = transmittedBytes * 8 / this.scenario.bandwidthKbps
+    const retransmitDelay
+      = retransmissionRounds * Math.max(200, this.scenario.rttMs * 1.5)
+    const jitter = (this.nextRandom() * 2 - 1) * this.scenario.jitterMs
+    const arrival = Math.max(
+      path.lastArrival,
+      start + serializationMs + this.scenario.rttMs / 2 + retransmitDelay + jitter,
+    )
+    path.nextSendAt = start + serializationMs
+    path.lastArrival = arrival
+    this.wireBytes += transmittedBytes
+    this.queue.push({ deliverAt: arrival, order: this.order++, deliver, data })
+  }
+
+  drainUntil(done: () => boolean, label: string): void {
+    while (!done()) {
+      const next = this.queue.shift()
+      if (!next) {
+        throw new Error(`Shaped TCP wire drained before ${label}.`)
+      }
+      this.queue.sort((left, right) => left.deliverAt - right.deliverAt || left.order - right.order)
+      this.now = next.deliverAt
+      next.deliver(next.data)
+    }
+  }
+
+  private nextRandom(): number {
+    this.randomState = (this.randomState * 1_664_525 + 1_013_904_223) >>> 0
+    return this.randomState / 0x1_0000_0000
+  }
+}
+
+function payloadFor(profile: NetworkResult['profile']): Uint8Array {
+  if (profile === 'compressible') {
+    return new Uint8Array(TRANSFER_BYTES).fill(7)
+  }
+  let state = 0xA341_316C
+  return Uint8Array.from({ length: TRANSFER_BYTES }, () => {
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    return state & 0xFF
+  })
+}
+
+function runTransfer(
+  scenario: LinkScenario,
+  profile: NetworkResult['profile'],
+  mode: NetworkResult['mode'],
+): NetworkResult {
+  const hostKeys = generateRelayKeyPair()
+  const controllerKeys = generateRelayKeyPair()
+  const wire = new ShapedTcpWire(scenario)
+  const payload = payloadFor(profile)
+  let receivedBytes = 0
+  let hostStreamOpened = false
+  let pauses = 0
+  let resumes = 0
+  let deliverToController: (data: Uint8Array) => void = () => {
+    throw new Error('Controller delivery used before setup.')
+  }
+  let deliverToHost: (data: Uint8Array) => void = () => {
+    throw new Error('Host delivery used before setup.')
+  }
+  const makeOptions = () => ({
+    roomId: 'adverse-network-benchmark',
+    pairingCode: 'ADVERSE-NETWORK',
+    optimizedCodecEnabled: mode === 'V2 optimized',
+    maxStreamCreditBytes: 8 * 1024 * 1024,
+  })
+  const host = new RelaySession('host', hostKeys.privateKeyBase64, {
+    ...makeOptions(),
+    ourPublicKeyBase64: hostKeys.publicKeyBase64,
+  }, {
+    send: data => wire.send('host-controller', deliverToController, data),
+    onStreamOpen: () => { hostStreamOpened = true },
+    onStreamData: (streamId, data) => {
+      receivedBytes += data.byteLength
+      host.reportStreamDataConsumed(streamId, data.byteLength)
+    },
+    onError: (error) => { throw error },
+  })
+  const controller = new RelaySession('controller', controllerKeys.privateKeyBase64, {
+    ...makeOptions(),
+    ourPublicKeyBase64: controllerKeys.publicKeyBase64,
+  }, {
+    send: data => wire.send('controller-host', deliverToHost, data),
+    onPauseStream: () => { pauses++ },
+    onResumeStream: () => { resumes++ },
+    onError: (error) => { throw error },
+  })
+  deliverToController = data => controller.handleEnvelope(decodeRelayEnvelope(data))
+  deliverToHost = data => host.handleEnvelope(decodeRelayEnvelope(data))
+  host.start()
+  controller.start()
+  wire.drainUntil(() => host.isReady && controller.isReady, 'handshake')
+  controller.openStream('adverse-stream')
+  wire.drainUntil(() => hostStreamOpened, 'stream open')
+  const transferStartedAt = wire.now
+  controller.writeStreamData('adverse-stream', payload)
+  wire.drainUntil(
+    () => receivedBytes === payload.byteLength && resumes > 0,
+    'stream transfer',
+  )
+  return {
+    scenario: scenario.name,
+    profile,
+    mode,
+    completionMs: wire.now - transferStartedAt,
+    wireBytes: wire.wireBytes,
+    pauses,
+    resumes,
+  }
+}
+
+describe('relay adverse-network benchmark', () => {
+  it('compares V2 before and after endpoint optimization under shaped TCP conditions', () => {
+    const results = SCENARIOS.flatMap(scenario => [
+      ...(['compressible', 'incompressible'] as const).flatMap(profile => [
+        runTransfer(scenario, profile, 'V2 baseline'),
+        runTransfer(scenario, profile, 'V2 optimized'),
+      ]),
+    ])
+    const rows = SCENARIOS.flatMap(scenario => (
+      ['compressible', 'incompressible'] as const
+    ).map((profile) => {
+      const baseline = results.find(result => result.scenario === scenario.name && result.profile === profile && result.mode === 'V2 baseline')!
+      const optimized = results.find(result => result.scenario === scenario.name && result.profile === profile && result.mode === 'V2 optimized')!
+      return {
+        scenario: scenario.name,
+        profile,
+        baselineMs: baseline.completionMs,
+        optimizedMs: optimized.completionMs,
+        baselineUsefulKbps: TRANSFER_BYTES * 8 / baseline.completionMs,
+        optimizedUsefulKbps: TRANSFER_BYTES * 8 / optimized.completionMs,
+        completionImprovementPercent: (baseline.completionMs - optimized.completionMs) / baseline.completionMs * 100,
+        baselineWireBytes: baseline.wireBytes,
+        optimizedWireBytes: optimized.wireBytes,
+        wireReductionPercent: (baseline.wireBytes - optimized.wireBytes) / baseline.wireBytes * 100,
+      }
+    }))
+    console.info('# Relay adverse-network matrix')
+    console.info('| Scenario | Profile | V2 baseline | V2 optimized | Improvement | Wire reduction |')
+    console.info('| --- | --- | ---: | ---: | ---: | ---: |')
+    for (const row of rows) {
+      console.info(`| ${row.scenario} | ${row.profile} | ${row.baselineMs.toFixed(1)} ms / ${row.baselineWireBytes} B | ${row.optimizedMs.toFixed(1)} ms / ${row.optimizedWireBytes} B | ${row.completionImprovementPercent.toFixed(1)}% | ${row.wireReductionPercent.toFixed(1)}% |`)
+    }
+    console.info(JSON.stringify({
+      kind: 'relay-adverse-network-matrix',
+      conditions: {
+        transferBytes: TRANSFER_BYTES,
+        linkModel: 'ordered TCP serialization with deterministic jitter, bandwidth, segment loss, and retransmission timeout',
+        scenarios: SCENARIOS,
+      },
+      rows,
+    }))
+    for (const row of rows) {
+      expect(row.optimizedWireBytes).toBeLessThanOrEqual(row.baselineWireBytes)
+      if (row.profile === 'compressible') {
+        expect(row.optimizedMs).toBeLessThan(row.baselineMs)
+        expect(row.optimizedWireBytes).toBeLessThan(row.baselineWireBytes * 0.1)
+      }
+      else {
+        expect(Math.abs(row.completionImprovementPercent)).toBeLessThan(1)
+      }
+    }
+  })
+})

--- a/apps/server/tests/relay-transport/codec-throughput-benchmark.test.ts
+++ b/apps/server/tests/relay-transport/codec-throughput-benchmark.test.ts
@@ -1,0 +1,199 @@
+import { performance } from 'node:perf_hooks'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  decodeRelayChunk,
+  encodeRelayChunk,
+  RELAY_MIN_COMPRESSION_INPUT_BYTES,
+} from '../../src/modules/relay-transport/compression'
+import { RelayCipher } from '../../src/modules/relay-transport/crypto'
+import { decodeInnerFrame, encodeInnerFrame } from '../../src/modules/relay-transport/protocol'
+
+type PayloadProfile = 'compressible' | 'incompressible'
+
+interface CodecResult {
+  profile: PayloadProfile
+  payloadBytes: number
+  baselineWireBytes: number
+  optimizedWireBytes: number
+  baselineMiBps: number
+  optimizedMiBps: number
+  throughputImprovementPercent: number
+  wireReductionPercent: number
+}
+
+const KEY = new Uint8Array(32).fill(7)
+const BASELINE_CIPHER = new RelayCipher(KEY, false)
+const OPTIMIZED_CIPHER = new RelayCipher(KEY)
+
+function payloadFor(profile: PayloadProfile, length: number): Uint8Array {
+  if (profile === 'compressible') {
+    const record = Buffer.from('{"type":"delta","content":"relay benchmark payload"}\n')
+    return Uint8Array.from({ length }, (_, index) => record[index % record.length])
+  }
+  let state = 0xA341_316C
+  return Uint8Array.from({ length }, () => {
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    return state & 0xFF
+  })
+}
+
+function baselineRoundTrip(data: Uint8Array): { data: Uint8Array, wireBytes: number } {
+  const plaintext = encodeInnerFrame({
+    kind: 'stream_data',
+    streamId: 'benchmark',
+    seq: 0,
+    data,
+  })
+  const sealed = BASELINE_CIPHER.encrypt(plaintext)
+  const decoded = decodeInnerFrame(BASELINE_CIPHER.decrypt(sealed))
+  if (decoded.kind !== 'stream_data') {
+    throw new Error('Baseline codec returned a non-data frame.')
+  }
+  return {
+    data: decoded.data,
+    wireBytes: sealed.byteLength,
+  }
+}
+
+function optimizedRoundTrip(data: Uint8Array): { data: Uint8Array, wireBytes: number } {
+  const plaintext = data.byteLength < RELAY_MIN_COMPRESSION_INPUT_BYTES
+    ? encodeInnerFrame({ kind: 'stream_data', streamId: 'benchmark', seq: 0, data })
+    : (() => {
+        const compressed = encodeRelayChunk(data)
+        return encodeInnerFrame({
+          kind: 'stream_data',
+          streamId: 'benchmark',
+          seq: 0,
+          data: compressed.data,
+          ...(compressed.compression === 'zstd'
+            ? { compression: 'zstd' as const, uncompressedBytes: compressed.uncompressedBytes }
+            : {}),
+        })
+      })()
+  const sealed = OPTIMIZED_CIPHER.encrypt(plaintext)
+  const decoded = decodeInnerFrame(OPTIMIZED_CIPHER.decrypt(sealed))
+  if (decoded.kind !== 'stream_data') {
+    throw new Error('Optimized codec returned a non-data frame.')
+  }
+  return {
+    data: decodeRelayChunk({
+      data: decoded.data,
+      compression: decoded.compression ?? 'none',
+      uncompressedBytes: decoded.uncompressedBytes ?? decoded.data.byteLength,
+    }),
+    wireBytes: sealed.byteLength,
+  }
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right)
+  return sorted[Math.floor(sorted.length / 2)]
+}
+
+function timeOperation(
+  operation: (data: Uint8Array) => { data: Uint8Array, wireBytes: number },
+  payload: Uint8Array,
+  iterations: number,
+): number {
+  const startedAt = performance.now()
+  for (let index = 0; index < iterations; index++) {
+    operation(payload)
+  }
+  const elapsedMs = performance.now() - startedAt
+  return payload.byteLength * iterations / (1024 * 1024) / (elapsedMs / 1_000)
+}
+
+function measureComparison(
+  payload: Uint8Array,
+  iterations: number,
+): {
+    baselineWireBytes: number
+    optimizedWireBytes: number
+    baselineMiBps: number
+    optimizedMiBps: number
+  } {
+  const warmupIterations = Math.max(10, iterations / 20)
+  timeOperation(baselineRoundTrip, payload, warmupIterations)
+  timeOperation(optimizedRoundTrip, payload, warmupIterations)
+
+  const baselineSamples: number[] = []
+  const optimizedSamples: number[] = []
+  for (let sample = 0; sample < 5; sample++) {
+    if (sample % 2 === 0) {
+      baselineSamples.push(timeOperation(baselineRoundTrip, payload, iterations))
+      optimizedSamples.push(timeOperation(optimizedRoundTrip, payload, iterations))
+    }
+    else {
+      optimizedSamples.push(timeOperation(optimizedRoundTrip, payload, iterations))
+      baselineSamples.push(timeOperation(baselineRoundTrip, payload, iterations))
+    }
+  }
+
+  const baseline = baselineRoundTrip(payload)
+  const optimized = optimizedRoundTrip(payload)
+  expect(baseline.data).toEqual(payload)
+  expect(optimized.data).toEqual(payload)
+  return {
+    baselineWireBytes: baseline.wireBytes,
+    optimizedWireBytes: optimized.wireBytes,
+    baselineMiBps: median(baselineSamples),
+    optimizedMiBps: median(optimizedSamples),
+  }
+}
+
+describe('relay endpoint codec throughput benchmark', () => {
+  it('compares the V2 baseline and optimized codec on interactive and bulk payloads', () => {
+    const rows = (['compressible', 'incompressible'] as const).flatMap(profile => (
+      [512, 64 * 1024].map((payloadBytes): CodecResult => {
+        const payload = payloadFor(profile, payloadBytes)
+        const iterations = payloadBytes < 1024 ? 10_000 : 100
+        const comparison = measureComparison(payload, iterations)
+        return {
+          profile,
+          payloadBytes,
+          baselineWireBytes: comparison.baselineWireBytes,
+          optimizedWireBytes: comparison.optimizedWireBytes,
+          baselineMiBps: comparison.baselineMiBps,
+          optimizedMiBps: comparison.optimizedMiBps,
+          throughputImprovementPercent:
+            (comparison.optimizedMiBps - comparison.baselineMiBps)
+            / comparison.baselineMiBps * 100,
+          wireReductionPercent:
+            (comparison.baselineWireBytes - comparison.optimizedWireBytes)
+            / comparison.baselineWireBytes * 100,
+        }
+      })
+    ))
+
+    console.info('# Relay endpoint codec CPU matrix')
+    console.info('| Profile | Payload | V2 baseline | V2 optimized | Throughput improvement | Wire reduction |')
+    console.info('| --- | ---: | ---: | ---: | ---: | ---: |')
+    for (const row of rows) {
+      console.info(`| ${row.profile} | ${row.payloadBytes} B | ${row.baselineMiBps.toFixed(1)} MiB/s / ${row.baselineWireBytes} B | ${row.optimizedMiBps.toFixed(1)} MiB/s / ${row.optimizedWireBytes} B | ${row.throughputImprovementPercent.toFixed(1)}% | ${row.wireReductionPercent.toFixed(1)}% |`)
+    }
+    console.info(JSON.stringify({
+      kind: 'relay-endpoint-codec-cpu-matrix',
+      conditions: {
+        samples: 5,
+        statistic: 'median',
+        baseline: 'binary inner frame + XChaCha20-Poly1305',
+        optimized: 'adaptive Zstandard + binary inner frame + size-adaptive AEAD',
+      },
+      rows,
+    }))
+
+    for (const row of rows) {
+      expect(row.optimizedWireBytes).toBeLessThanOrEqual(row.baselineWireBytes)
+      if (row.payloadBytes >= 64 * 1024) {
+        expect(row.optimizedMiBps).toBeGreaterThan(row.baselineMiBps)
+      }
+      else {
+        expect(row.optimizedMiBps).toBeGreaterThan(row.baselineMiBps * 0.85)
+      }
+    }
+  }, 15_000)
+})

--- a/apps/server/tests/relay-transport/compression.test.ts
+++ b/apps/server/tests/relay-transport/compression.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  decodeRelayChunk,
+  encodeRelayChunk,
+  RELAY_COMPRESSION_KIND,
+} from '../../src/modules/relay-transport/compression'
+import { decodeInnerFrame, encodeInnerFrame } from '../../src/modules/relay-transport/protocol'
+
+function incompressibleBytes(length: number): Uint8Array {
+  let state = 0xA341_316C
+  return Uint8Array.from({ length }, () => {
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    return state & 0xFF
+  })
+}
+
+describe('relay chunk compression', () => {
+  it('compresses repetitive endpoint data and round-trips the exact plaintext', () => {
+    const plaintext = new Uint8Array(64 * 1024).fill(7)
+    const encoded = encodeRelayChunk(plaintext)
+
+    expect(encoded.compression).toBe(RELAY_COMPRESSION_KIND.zstd)
+    expect(encoded.data.byteLength).toBeLessThan(plaintext.byteLength)
+    expect(decodeRelayChunk(encoded)).toEqual(plaintext)
+  })
+
+  it('keeps incompressible data raw and never expands the wire', () => {
+    const plaintext = incompressibleBytes(64 * 1024)
+    const encoded = encodeRelayChunk(plaintext)
+
+    expect(encoded.compression).toBe(RELAY_COMPRESSION_KIND.none)
+    expect(encoded.data).toBe(plaintext)
+    expect(decodeRelayChunk(encoded)).toBe(plaintext)
+  })
+
+  it('skips tiny chunks to preserve interactive latency', () => {
+    const plaintext = new Uint8Array(512).fill(7)
+    const encoded = encodeRelayChunk(plaintext)
+
+    expect(encoded.compression).toBe(RELAY_COMPRESSION_KIND.none)
+    expect(encoded.data).toBe(plaintext)
+  })
+
+  it('rejects a forged decompressed length before allocating output', () => {
+    const encoded = encodeRelayChunk(new Uint8Array(64 * 1024).fill(7))
+
+    expect(() => decodeRelayChunk({
+      ...encoded,
+      uncompressedBytes: 64 * 1024 + 1,
+    })).toThrow('invalid output length')
+  })
+
+  it('rejects corrupted compressed bytes', () => {
+    const encoded = encodeRelayChunk(new Uint8Array(64 * 1024).fill(7))
+    const corrupted = encoded.data.slice()
+    corrupted[Math.floor(corrupted.byteLength / 2)] ^= 0xFF
+
+    expect(() => decodeRelayChunk({ ...encoded, data: corrupted })).toThrow()
+  })
+
+  it('preserves the compact raw frame and round-trips the compressed frame code', () => {
+    const rawData = incompressibleBytes(4 * 1024)
+    const raw = encodeInnerFrame({
+      kind: 'stream_data',
+      streamId: 's1',
+      seq: 10,
+      data: rawData,
+    })
+    expect(raw[0]).toBe(4)
+    expect(raw.byteLength).toBe(7 + 2 + rawData.byteLength)
+    expect(decodeInnerFrame(raw)).toEqual({
+      kind: 'stream_data',
+      streamId: 's1',
+      seq: 10,
+      data: rawData,
+    })
+
+    const compressed = encodeRelayChunk(new Uint8Array(4 * 1024).fill(7))
+    const encoded = encodeInnerFrame({
+      kind: 'stream_data',
+      streamId: 's1',
+      seq: 10,
+      data: compressed.data,
+      compression: 'zstd',
+      uncompressedBytes: compressed.uncompressedBytes,
+    })
+    expect(encoded[0]).toBe(7)
+    expect(decodeInnerFrame(encoded)).toEqual({
+      kind: 'stream_data',
+      streamId: 's1',
+      seq: 10,
+      data: compressed.data,
+      compression: 'zstd',
+      uncompressedBytes: compressed.uncompressedBytes,
+    })
+  })
+})

--- a/apps/server/tests/relay-transport/crypto.test.ts
+++ b/apps/server/tests/relay-transport/crypto.test.ts
@@ -109,6 +109,16 @@ describe('relay crypto', () => {
     expect(cipher.decrypt(b)).toEqual(plaintext)
   })
 
+  it('keeps the benchmark baseline on XChaCha for bulk frames', () => {
+    const cipher = new RelayCipher(new Uint8Array(32).fill(7), false)
+    const plaintext = new Uint8Array(64 * 1024)
+    const sealed = cipher.encrypt(plaintext)
+
+    expect(sealed.byteLength).toBe(plaintext.byteLength + 40)
+    expect(sealed[0] & 0x80).toBe(0x80)
+    expect(cipher.decrypt(sealed)).toEqual(plaintext)
+  })
+
   it('rejects tampered ciphertext (auth tag verification)', () => {
     const keys = deriveRelayKeys(new Uint8Array(32).fill(1), 'CODE')
     const cipher = new RelayCipher(sendKeyForRole(keys, 'host'))

--- a/apps/server/tests/relay-transport/e2e.test.ts
+++ b/apps/server/tests/relay-transport/e2e.test.ts
@@ -20,8 +20,11 @@ import {
   signRelayAssertion,
 } from '../../src/modules/relay-servers/relay-signature-service'
 import { startRelayControllerTransport } from '../../src/modules/relay-transport/controller-transport'
-import { generateRelayKeyPair, relayPublicKeyFingerprint } from '../../src/modules/relay-transport/crypto'
-import { relayEnvelopeSchema } from '../../src/modules/relay-transport/protocol'
+import {
+  generateRelayKeyPair,
+  relayPublicKeyFingerprint,
+} from '../../src/modules/relay-transport/crypto'
+import { decodeRelayEnvelope } from '../../src/modules/relay-transport/protocol'
 import { RelaySession } from '../../src/modules/relay-transport/session'
 
 /**
@@ -47,7 +50,10 @@ function resolveRelaydSourceDir(): string | null {
     resolve(moduleDir, '../../../../relayd'),
   ]
   for (const candidate of candidates) {
-    if (existsSyncSafe(join(candidate, 'go.mod')) && existsSyncSafe(join(candidate, 'cmd/relayd/main.go'))) {
+    if (
+      existsSyncSafe(join(candidate, 'go.mod'))
+      && existsSyncSafe(join(candidate, 'cmd/relayd/main.go'))
+    ) {
       return candidate
     }
   }
@@ -58,7 +64,7 @@ function existsSyncSafe(path: string): boolean {
   try {
     return existsSync(path)
   }
-  catch {
+ catch {
     return false
   }
 }
@@ -111,13 +117,15 @@ async function waitForReady(relayUrl: string): Promise<void> {
   let lastError: unknown
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(new URL('/readyz', `${relayUrl}/`), { signal: AbortSignal.timeout(500) })
+      const response = await fetch(new URL('/readyz', `${relayUrl}/`), {
+        signal: AbortSignal.timeout(500),
+      })
       if (response.ok) {
         return
       }
       lastError = new Error(`relayd ready check returned HTTP ${response.status}`)
     }
-    catch (error) {
+ catch (error) {
       lastError = error
     }
     await new Promise(r => setTimeout(r, 200))
@@ -165,8 +173,13 @@ function signalRelayd(child: ChildProcess, signal: NodeJS.Signals): boolean {
       process.kill(-child.pid, signal)
       return true
     }
-    catch (error) {
-      if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ESRCH') {
+ catch (error) {
+      if (
+        typeof error === 'object'
+        && error !== null
+        && 'code' in error
+        && error.code === 'ESRCH'
+      ) {
         return false
       }
       throw error
@@ -186,7 +199,7 @@ function closeRelaydOwnerPipe(child: ChildProcess): void {
     }
     stdin.destroy()
   }
-  catch {
+ catch {
     // Best-effort cleanup; process signals still handle termination.
   }
 }
@@ -226,9 +239,16 @@ async function startHostBridge(opts: {
       onStreamOpen: (streamId) => {
         const socket = connect({ host: opts.targetHost, port: opts.targetPort })
         streams.set(streamId, socket)
-        socket.on('data', (chunk: Buffer) => session.writeStreamData(streamId, new Uint8Array(chunk)))
-        socket.on('close', () => { session.closeStream(streamId, 'target closed'); streams.delete(streamId) })
-        socket.on('error', () => { session.closeStream(streamId, 'target error'); streams.delete(streamId) })
+        socket.on('data', (chunk: Buffer) =>
+          session.writeStreamData(streamId, new Uint8Array(chunk)))
+        socket.on('close', () => {
+          session.closeStream(streamId, 'target closed')
+          streams.delete(streamId)
+        })
+        socket.on('error', () => {
+          session.closeStream(streamId, 'target error')
+          streams.delete(streamId)
+        })
       },
       onStreamData: (streamId, data) => {
         const socket = streams.get(streamId)
@@ -247,8 +267,7 @@ async function startHostBridge(opts: {
     },
   )
   ws.on('message', (data: WebSocket.RawData) => {
-    const env = relayEnvelopeSchema.parse(JSON.parse(data.toString('utf8')))
-    session.handleEnvelope(env)
+    session.handleEnvelope(decodeRelayEnvelope(new Uint8Array(data as Buffer)))
   })
 
   await new Promise<void>((resolve, reject) => {
@@ -280,13 +299,16 @@ function toWsUrl(relayUrl: string, path: string): string {
   if (url.protocol === 'http:') {
     url.protocol = 'ws:'
   }
-  else if (url.protocol === 'https:') {
+ else if (url.protocol === 'https:') {
     url.protocol = 'wss:'
   }
   return url.toString()
 }
 
-async function callPairingStart(relayUrl: string, assertion: SignedRelayAssertion): Promise<{ pairingCode: string, roomId: string }> {
+async function callPairingStart(
+  relayUrl: string,
+  assertion: SignedRelayAssertion,
+): Promise<{ pairingCode: string, roomId: string }> {
   const response = await fetch(new URL('/pairing/start', `${relayUrl}/`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -295,10 +317,13 @@ async function callPairingStart(relayUrl: string, assertion: SignedRelayAssertio
   if (!response.ok) {
     throw new Error(`/pairing/start returned ${response.status}: ${await response.text()}`)
   }
-  return await response.json() as { pairingCode: string, roomId: string }
+  return (await response.json()) as { pairingCode: string, roomId: string }
 }
 
-async function callPairingClaim(relayUrl: string, assertion: SignedRelayAssertion): Promise<{ roomId: string }> {
+async function callPairingClaim(
+  relayUrl: string,
+  assertion: SignedRelayAssertion,
+): Promise<{ roomId: string }> {
   const response = await fetch(new URL('/pairing/claim', `${relayUrl}/`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -307,14 +332,16 @@ async function callPairingClaim(relayUrl: string, assertion: SignedRelayAssertio
   if (!response.ok) {
     throw new Error(`/pairing/claim returned ${response.status}: ${await response.text()}`)
   }
-  return await response.json() as { roomId: string }
+  return (await response.json()) as { roomId: string }
 }
 
 function startFakeHostServer(): Promise<{ baseUrl: string, server: Server, requests: string[] }> {
   const requests: string[] = []
   const server = createServer((req, res) => {
     let body = ''
-    req.on('data', (chunk) => { body += chunk.toString() })
+    req.on('data', (chunk) => {
+      body += chunk.toString()
+    })
     req.on('end', () => {
       requests.push(`${req.method} ${req.url} ${body}`)
       res.writeHead(200, { 'content-type': 'application/json' })
@@ -357,8 +384,16 @@ describe.skipIf(!relaydSourceDir)('relay transport e2e (real relayd)', () => {
     const roomId = createRelayRoomId()
     const hostFingerprint = relayPublicKeyFingerprint(hostKeys.publicKeyBase64)
 
-    const pairingStart = signRelayAssertion(hostSigningKeys.privateKeyBase64, { role: 'host', purpose: 'create_room', roomId })
-    const hostWs = signRelayAssertion(hostSigningKeys.privateKeyBase64, { role: 'host', purpose: 'ws', roomId })
+    const pairingStart = signRelayAssertion(hostSigningKeys.privateKeyBase64, {
+      role: 'host',
+      purpose: 'create_room',
+      roomId,
+    })
+    const hostWs = signRelayAssertion(hostSigningKeys.privateKeyBase64, {
+      role: 'host',
+      purpose: 'ws',
+      roomId,
+    })
     const { pairingCode } = await callPairingStart(relayd.relayUrl, pairingStart)
 
     // ── Host: start the bridge (WS + session + TCP target = fake host server).
@@ -378,10 +413,19 @@ describe.skipIf(!relaydSourceDir)('relay transport e2e (real relayd)', () => {
     })
 
     // ── Controller: claim the pairing ──
-    const claimAssertion = signRelayAssertion(controllerSigningKeys.privateKeyBase64, { role: 'controller', purpose: 'claim', roomId, pairingCode })
+    const claimAssertion = signRelayAssertion(controllerSigningKeys.privateKeyBase64, {
+      role: 'controller',
+      purpose: 'claim',
+      roomId,
+      pairingCode,
+    })
     const lookup = await callPairingClaim(relayd.relayUrl, claimAssertion)
     expect(lookup.roomId).toBe(roomId)
-    const controllerWs = signRelayAssertion(controllerSigningKeys.privateKeyBase64, { role: 'controller', purpose: 'ws', roomId })
+    const controllerWs = signRelayAssertion(controllerSigningKeys.privateKeyBase64, {
+      role: 'controller',
+      purpose: 'ws',
+      roomId,
+    })
 
     // ── Controller: start the relay transport (first pairing) ──
     const handle = await startRelayControllerTransport({
@@ -405,7 +449,7 @@ describe.skipIf(!relaydSourceDir)('relay transport e2e (real relayd)', () => {
       body: 'ping',
     })
     expect(response.status).toBe(200)
-    const json = await response.json() as { ok: boolean, echo: string, path: string }
+    const json = (await response.json()) as { ok: boolean, echo: string, path: string }
     expect(json.ok).toBe(true)
     expect(json.echo).toBe('ping')
     expect(json.path).toBe('/hello')
@@ -422,7 +466,11 @@ describe.skipIf(!relaydSourceDir)('relay transport e2e (real relayd)', () => {
       roomId,
       controllerPubkey: controllerSigningKeys.publicKeyBase64,
     })
-    const hostWs2 = signRelayAssertion(hostSigningKeys.privateKeyBase64, { role: 'host', purpose: 'ws', roomId })
+    const hostWs2 = signRelayAssertion(hostSigningKeys.privateKeyBase64, {
+      role: 'host',
+      purpose: 'ws',
+      roomId,
+    })
     const renewResponse = await fetch(new URL('/rooms/host-session', `${relayd.relayUrl}/`), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -441,7 +489,11 @@ describe.skipIf(!relaydSourceDir)('relay transport e2e (real relayd)', () => {
       targetPort: fakeHostPort,
     })
 
-    const controllerWs2 = signRelayAssertion(controllerSigningKeys.privateKeyBase64, { role: 'controller', purpose: 'ws', roomId })
+    const controllerWs2 = signRelayAssertion(controllerSigningKeys.privateKeyBase64, {
+      role: 'controller',
+      purpose: 'ws',
+      roomId,
+    })
     const handle2 = await startRelayControllerTransport({
       hostId: 'e2e-host',
       relayUrl: relayd.relayUrl,
@@ -455,7 +507,7 @@ describe.skipIf(!relaydSourceDir)('relay transport e2e (real relayd)', () => {
 
     const response2 = await fetch(`${handle2.localBaseUrl}/again`, { method: 'GET' })
     expect(response2.status).toBe(200)
-    const json2 = await response2.json() as { ok: boolean, path: string }
+    const json2 = (await response2.json()) as { ok: boolean, path: string }
     expect(json2.ok).toBe(true)
     expect(json2.path).toBe('/again')
 
@@ -482,7 +534,11 @@ async function startHostBridgePinned(opts: {
   const session = new RelaySession(
     'host',
     opts.hostPrivateKey,
-    { roomId: opts.roomId, ourPublicKeyBase64: opts.hostPublicKey, pinnedPeerPubkey: opts.pinnedControllerPubkey },
+    {
+      roomId: opts.roomId,
+      ourPublicKeyBase64: opts.hostPublicKey,
+      pinnedPeerPubkey: opts.pinnedControllerPubkey,
+    },
     {
       send: (data) => {
         if (ws.readyState === WebSocket.OPEN) {
@@ -492,9 +548,16 @@ async function startHostBridgePinned(opts: {
       onStreamOpen: (streamId) => {
         const socket = connect({ host: opts.targetHost, port: opts.targetPort })
         streams.set(streamId, socket)
-        socket.on('data', (chunk: Buffer) => session.writeStreamData(streamId, new Uint8Array(chunk)))
-        socket.on('close', () => { session.closeStream(streamId, 'target closed'); streams.delete(streamId) })
-        socket.on('error', () => { session.closeStream(streamId, 'target error'); streams.delete(streamId) })
+        socket.on('data', (chunk: Buffer) =>
+          session.writeStreamData(streamId, new Uint8Array(chunk)))
+        socket.on('close', () => {
+          session.closeStream(streamId, 'target closed')
+          streams.delete(streamId)
+        })
+        socket.on('error', () => {
+          session.closeStream(streamId, 'target error')
+          streams.delete(streamId)
+        })
       },
       onStreamData: (streamId, data) => {
         streams.get(streamId)?.write(Buffer.from(data))
@@ -510,8 +573,7 @@ async function startHostBridgePinned(opts: {
     },
   )
   ws.on('message', (data: WebSocket.RawData) => {
-    const env = relayEnvelopeSchema.parse(JSON.parse(data.toString('utf8')))
-    session.handleEnvelope(env)
+    session.handleEnvelope(decodeRelayEnvelope(new Uint8Array(data as Buffer)))
   })
 
   await new Promise<void>((resolve, reject) => {

--- a/apps/server/tests/relay-transport/e2e.test.ts
+++ b/apps/server/tests/relay-transport/e2e.test.ts
@@ -7,6 +7,7 @@ import type { AddressInfo, Socket } from 'node:net'
 import { connect, createServer as createNetServer } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
 import { fileURLToPath } from 'node:url'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -483,6 +484,57 @@ describe.skipIf(!relaydSourceDir)('relay transport e2e (real relayd)', () => {
     expect(warmStream?.firstRequestByteAt).not.toBeNull()
     expect(warmStream?.firstResponseByteAt).not.toBeNull()
 
+    const concurrentBody = 'x'.repeat(64 * 1024)
+    const concurrencyRows = []
+    for (const concurrency of [1, 8]) {
+      const batchStartedAt = performance.now()
+      const durations = await Promise.all(Array.from({ length: concurrency }, async (_, index) => {
+        const startedAt = performance.now()
+        const concurrentResponse = await fetch(`${handle.localBaseUrl}/benchmark/${concurrency}/${index}`, {
+          method: 'POST',
+          headers: { 'content-type': 'text/plain' },
+          body: concurrentBody,
+        })
+        expect(concurrentResponse.status).toBe(200)
+        const body = (await concurrentResponse.json()) as { ok: boolean, echo: string }
+        expect(body.ok).toBe(true)
+        expect(body.echo).toBe(concurrentBody)
+        return performance.now() - startedAt
+      }))
+      const batchElapsedMs = performance.now() - batchStartedAt
+      concurrencyRows.push({
+        concurrency,
+        requestBodyBytes: Buffer.byteLength(concurrentBody),
+        p50Ms: percentile(durations, 0.5),
+        p95Ms: percentile(durations, 0.95),
+        maxMs: Math.max(...durations),
+        aggregateUsefulMiBps:
+          (concurrency * Buffer.byteLength(concurrentBody) * 2) / (1024 * 1024) / (batchElapsedMs / 1_000),
+      })
+    }
+    expect(handle.getPerformanceSnapshot().connectionAttempts).toHaveLength(attemptsBeforeWarmRequest)
+    console.info([
+      '# Relay local-relayd concurrent-stream matrix',
+      '',
+      'This exercises real loopback WebSocket, relayd scheduler, E2EE session, TCP bridge, and HTTP streams. It is not a WAN, Tailscale, or injected-RTT measurement.',
+      '',
+      '| Concurrent streams | Request body | p50 complete | p95 complete | max complete | Aggregate useful throughput |',
+      '| ---: | ---: | ---: | ---: | ---: | ---: |',
+      ...concurrencyRows.map(row =>
+        `| ${row.concurrency} | ${row.requestBodyBytes} B | ${row.p50Ms.toFixed(2)} ms | ${row.p95Ms.toFixed(2)} ms | ${row.maxMs.toFixed(2)} ms | ${row.aggregateUsefulMiBps.toFixed(2)} MiB/s |`),
+    ].join('\n'))
+    console.info(JSON.stringify({
+      kind: 'relay-local-e2e-concurrency',
+      conditions: {
+        relayd: 'local subprocess',
+        transport: 'binary-v2',
+        logicalUsefulBytesPerRequest: Buffer.byteLength(concurrentBody) * 2,
+        connectionAttemptsBeforeMatrix: attemptsBeforeWarmRequest,
+        connectionAttemptsAfterMatrix: handle.getPerformanceSnapshot().connectionAttempts.length,
+      },
+      rows: concurrencyRows,
+    }))
+
     if (coldAttempt && coldSnapshot.localListenerReadyAt !== null && coldStream && warmStream) {
       console.info(JSON.stringify({
         kind: 'relay-cold-warm-checkpoints',
@@ -570,6 +622,12 @@ function latestRelayStream(snapshot: RelayControllerPerformanceSnapshot): RelayS
 
 function nonNegativeDuration(end: number | null, start: number): number | null {
   return end === null ? null : Math.max(0, end - start)
+}
+
+function percentile(samples: number[], percentileValue: number): number {
+  const ordered = [...samples].sort((left, right) => left - right)
+  const index = Math.min(ordered.length - 1, Math.ceil(ordered.length * percentileValue) - 1)
+  return ordered[index]!
 }
 
 // Pinned-pubkey variant of startHostBridge for the reconnect phase.

--- a/apps/server/tests/relay-transport/e2e.test.ts
+++ b/apps/server/tests/relay-transport/e2e.test.ts
@@ -19,7 +19,13 @@ import {
   relayAssertionHeaders,
   signRelayAssertion,
 } from '../../src/modules/relay-servers/relay-signature-service'
-import { startRelayControllerTransport } from '../../src/modules/relay-transport/controller-transport'
+import type {
+  RelayControllerPerformanceSnapshot,
+  RelayStreamCheckpoint,
+} from '../../src/modules/relay-transport/controller-transport'
+import {
+  startRelayControllerTransport,
+} from '../../src/modules/relay-transport/controller-transport'
 import {
   generateRelayKeyPair,
   relayPublicKeyFingerprint,
@@ -455,6 +461,47 @@ describe.skipIf(!relaydSourceDir)('relay transport e2e (real relayd)', () => {
     expect(json.path).toBe('/hello')
     expect(fakeHost.requests).toContain('POST /hello ping')
 
+    const coldSnapshot = handle.getPerformanceSnapshot()
+    const coldAttempt = coldSnapshot.connectionAttempts.at(-1)
+    const coldStream = latestRelayStream(coldSnapshot)
+    expect(coldAttempt?.websocketOpenedAt).not.toBeNull()
+    expect(coldAttempt?.handshakeReadyAt).not.toBeNull()
+    expect(coldSnapshot.localListenerReadyAt).not.toBeNull()
+    expect(coldStream?.firstRequestByteAt).not.toBeNull()
+    expect(coldStream?.firstResponseByteAt).not.toBeNull()
+
+    // This request reuses the listener/session above: it must not open another
+    // WebSocket or perform a second relay handshake before proxying bytes.
+    const attemptsBeforeWarmRequest = coldSnapshot.connectionAttempts.length
+    const warmResponse = await fetch(`${handle.localBaseUrl}/warm`, { method: 'GET' })
+    expect(warmResponse.status).toBe(200)
+    await warmResponse.json()
+    const warmSnapshot = handle.getPerformanceSnapshot()
+    const warmStream = latestRelayStream(warmSnapshot)
+    expect(warmSnapshot.connectionAttempts).toHaveLength(attemptsBeforeWarmRequest)
+    expect(warmStream?.streamId).not.toBe(coldStream?.streamId)
+    expect(warmStream?.firstRequestByteAt).not.toBeNull()
+    expect(warmStream?.firstResponseByteAt).not.toBeNull()
+
+    if (coldAttempt && coldSnapshot.localListenerReadyAt !== null && coldStream && warmStream) {
+      console.info(JSON.stringify({
+        kind: 'relay-cold-warm-checkpoints',
+        conditions: { relayd: 'local subprocess', transport: 'binary-v2' },
+        cold: {
+          connectToWebSocketOpenMs: nonNegativeDuration(coldAttempt.websocketOpenedAt, coldAttempt.startedAt),
+          connectToHandshakeReadyMs: nonNegativeDuration(coldAttempt.handshakeReadyAt, coldAttempt.startedAt),
+          connectToLocalListenerReadyMs: nonNegativeDuration(coldSnapshot.localListenerReadyAt, coldAttempt.startedAt),
+          streamToFirstResponseByteMs: nonNegativeDuration(coldStream.firstResponseByteAt, coldStream.openedAt),
+        },
+        warm: {
+          connectionAttemptsBeforeRequest: attemptsBeforeWarmRequest,
+          connectionAttemptsAfterRequest: warmSnapshot.connectionAttempts.length,
+          additionalWebSocketOrHandshake: 0,
+          streamToFirstResponseByteMs: nonNegativeDuration(warmStream.firstResponseByteAt, warmStream.openedAt),
+        },
+      }))
+    }
+
     await handle.close()
     await hostBridge.stop()
 
@@ -515,6 +562,15 @@ describe.skipIf(!relaydSourceDir)('relay transport e2e (real relayd)', () => {
     await hostBridgeReconnect.stop()
   }, 60_000)
 })
+
+function latestRelayStream(snapshot: RelayControllerPerformanceSnapshot): RelayStreamCheckpoint | undefined {
+  return [...snapshot.activeStreams, ...snapshot.completedStreams]
+    .sort((left, right) => right.openedAt - left.openedAt)[0]
+}
+
+function nonNegativeDuration(end: number | null, start: number): number | null {
+  return end === null ? null : Math.max(0, end - start)
+}
 
 // Pinned-pubkey variant of startHostBridge for the reconnect phase.
 async function startHostBridgePinned(opts: {

--- a/apps/server/tests/relay-transport/latency-window-benchmark.test.ts
+++ b/apps/server/tests/relay-transport/latency-window-benchmark.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateRelayKeyPair } from '../../src/modules/relay-transport/crypto'
+import { decodeRelayEnvelope } from '../../src/modules/relay-transport/protocol'
+import { RelaySession } from '../../src/modules/relay-transport/session'
+
+const TRANSFER_BYTES = 8 * 1024 * 1024
+const INITIAL_CREDIT_BYTES = 512 * 1024
+const ADAPTIVE_MAX_CREDIT_BYTES = 8 * 1024 * 1024
+
+interface VirtualTransferResult {
+  rttMs: number
+  mode: 'fixed-512KiB' | 'adaptive-8MiB'
+  completionMs: number
+  usefulMiBps: number
+  pauses: number
+  resumes: number
+}
+
+interface ScheduledEnvelope {
+  deliverAt: number
+  order: number
+  data: Uint8Array
+  deliver: (data: Uint8Array) => void
+}
+
+/**
+ * Test-only, deterministic one-way-delay wire. It delivers real encrypted
+ * RelaySession envelopes in virtual timestamp order without using wall-clock
+ * sleeps or claiming to emulate WebSocket, relayd, packet loss, or the WAN.
+ */
+class VirtualDelayedWire {
+  now = 0
+  private nextOrder = 0
+  private readonly queue: ScheduledEnvelope[] = []
+
+  constructor(private readonly oneWayDelayMs: number) {}
+
+  send(deliver: (data: Uint8Array) => void, data: Uint8Array): void {
+    this.queue.push({
+      deliverAt: this.now + this.oneWayDelayMs,
+      order: this.nextOrder++,
+      data,
+      deliver,
+    })
+  }
+
+  drainUntil(done: () => boolean, label: string): void {
+    while (!done()) {
+      const next = this.takeNext()
+      if (!next) {
+        throw new Error(`Virtual delayed wire drained before ${label}.`)
+      }
+      this.now = next.deliverAt
+      next.deliver(next.data)
+    }
+  }
+
+  private takeNext(): ScheduledEnvelope | undefined {
+    if (this.queue.length === 0) {
+      return undefined
+    }
+    this.queue.sort((left, right) => left.deliverAt - right.deliverAt || left.order - right.order)
+    return this.queue.shift()
+  }
+}
+
+function runVirtualTransfer(
+  rttMs: number,
+  mode: VirtualTransferResult['mode'],
+): VirtualTransferResult {
+  const hostKeys = generateRelayKeyPair()
+  const controllerKeys = generateRelayKeyPair()
+  const wire = new VirtualDelayedWire(rttMs / 2)
+  const payload = new Uint8Array(TRANSFER_BYTES).fill(7)
+  const maxStreamCreditBytes = mode === 'fixed-512KiB'
+    ? INITIAL_CREDIT_BYTES
+    : ADAPTIVE_MAX_CREDIT_BYTES
+  let receivedBytes = 0
+  let hostStreamOpened = false
+  let pauses = 0
+  let resumes = 0
+  let deliverToController: (envelope: Uint8Array) => void = () => {
+    throw new Error('Controller delivery was used before session setup.')
+  }
+  let deliverToHost: (envelope: Uint8Array) => void = () => {
+    throw new Error('Host delivery was used before session setup.')
+  }
+
+  const host = new RelaySession(
+    'host',
+    hostKeys.privateKeyBase64,
+    {
+      roomId: 'virtual_rtt_benchmark',
+      pairingCode: 'VIRTUAL-RTT',
+      ourPublicKeyBase64: hostKeys.publicKeyBase64,
+      maxStreamCreditBytes,
+    },
+    {
+      send: data => wire.send(deliverToController, data),
+      onStreamOpen: () => {
+        hostStreamOpened = true
+      },
+      onStreamData: (streamId, data) => {
+        receivedBytes += data.byteLength
+        // This models a local target that has accepted the bytes immediately.
+        // The ACK still crosses the virtual delayed wire through the real
+        // RelaySession encryption, framing, and cumulative-ack code paths.
+        host.reportStreamDataConsumed(streamId, data.byteLength)
+      },
+      onError: (error) => {
+        throw error
+      },
+    },
+  )
+  const controller = new RelaySession(
+    'controller',
+    controllerKeys.privateKeyBase64,
+    {
+      roomId: 'virtual_rtt_benchmark',
+      pairingCode: 'VIRTUAL-RTT',
+      ourPublicKeyBase64: controllerKeys.publicKeyBase64,
+      maxStreamCreditBytes,
+    },
+    {
+      send: data => wire.send(deliverToHost, data),
+      onPauseStream: () => {
+        pauses++
+      },
+      onResumeStream: () => {
+        resumes++
+      },
+      onError: (error) => {
+        throw error
+      },
+    },
+  )
+  deliverToController = envelope => controller.handleEnvelope(decodeRelayEnvelope(envelope))
+  deliverToHost = envelope => host.handleEnvelope(decodeRelayEnvelope(envelope))
+
+  host.start()
+  controller.start()
+  wire.drainUntil(() => host.isReady && controller.isReady, 'the relay handshake')
+
+  controller.openStream('virtual-stream')
+  wire.drainUntil(() => hostStreamOpened, 'stream open')
+  const transferStartedAt = wire.now
+  controller.writeStreamData('virtual-stream', payload)
+  wire.drainUntil(() => receivedBytes === payload.byteLength && resumes > 0, 'stream delivery and resume')
+  const completionMs = wire.now - transferStartedAt
+
+  return {
+    rttMs,
+    mode,
+    completionMs,
+    usefulMiBps: TRANSFER_BYTES / (1024 * 1024) / (completionMs / 1_000),
+    pauses,
+    resumes,
+  }
+}
+
+function printVirtualResults(results: VirtualTransferResult[]): void {
+  const rows = [20, 100, 200, 400].map(rttMs => ({
+    rttMs,
+    fixed: results.find(result => result.rttMs === rttMs && result.mode === 'fixed-512KiB')!,
+    adaptive: results.find(result => result.rttMs === rttMs && result.mode === 'adaptive-8MiB')!,
+  }))
+  const markdown = [
+    '# Relay session virtual-time RTT matrix',
+    '',
+    'This is a deterministic RelaySession simulation: real handshake, binary codec, XChaCha frames, ACKs, pause/resume, and credit state; it is not a real relayd, WebSocket, Tailscale, or WAN measurement.',
+    '',
+    '| RTT | V2 fixed 512 KiB completion / useful rate / pause-resume | V2 adaptive 8 MiB completion / useful rate / pause-resume | Adaptive improvement |',
+    '| ---: | --- | --- | ---: |',
+    ...rows.map(({ rttMs, fixed, adaptive }) => {
+      const fixedCell = `${fixed.completionMs} ms / ${fixed.usefulMiBps.toFixed(2)} MiB/s / ${fixed.pauses}-${fixed.resumes}`
+      const adaptiveCell = `${adaptive.completionMs} ms / ${adaptive.usefulMiBps.toFixed(2)} MiB/s / ${adaptive.pauses}-${adaptive.resumes}`
+      const improvement = ((fixed.completionMs - adaptive.completionMs) / fixed.completionMs) * 100
+      return `| ${rttMs} ms | ${fixedCell} | ${adaptiveCell} | ${improvement.toFixed(1)}% faster |`
+    }),
+  ].join('\n')
+  console.info(markdown)
+  console.info(JSON.stringify({
+    kind: 'relay-session-virtual-rtt-matrix',
+    conditions: {
+      transferBytes: TRANSFER_BYTES,
+      initialCreditBytes: INITIAL_CREDIT_BYTES,
+      fixedMaxCreditBytes: INITIAL_CREDIT_BYTES,
+      adaptiveMaxCreditBytes: ADAPTIVE_MAX_CREDIT_BYTES,
+      transport: 'virtual-time RelaySession wire',
+    },
+    rows,
+  }))
+}
+
+describe('relay session controlled RTT benchmark', () => {
+  it('compares fixed and adaptive V2 credit using real session frames', () => {
+    const results = [20, 100, 200, 400].flatMap(rttMs => [
+      runVirtualTransfer(rttMs, 'fixed-512KiB'),
+      runVirtualTransfer(rttMs, 'adaptive-8MiB'),
+    ])
+    printVirtualResults(results)
+
+    for (const result of results) {
+      expect(result.completionMs).toBeGreaterThan(0)
+      expect(result.pauses).toBeGreaterThan(0)
+      expect(result.resumes).toBeGreaterThan(0)
+    }
+    for (const rttMs of [200, 400]) {
+      const fixed = results.find(result => result.rttMs === rttMs && result.mode === 'fixed-512KiB')!
+      const adaptive = results.find(result => result.rttMs === rttMs && result.mode === 'adaptive-8MiB')!
+      expect(adaptive.completionMs).toBeLessThan(fixed.completionMs)
+    }
+  })
+})

--- a/apps/server/tests/relay-transport/latency-window-benchmark.test.ts
+++ b/apps/server/tests/relay-transport/latency-window-benchmark.test.ts
@@ -168,7 +168,7 @@ function printVirtualResults(results: VirtualTransferResult[]): void {
   const markdown = [
     '# Relay session virtual-time RTT matrix',
     '',
-    'This is a deterministic RelaySession simulation: real handshake, binary codec, XChaCha frames, ACKs, pause/resume, and credit state; it is not a real relayd, WebSocket, Tailscale, or WAN measurement.',
+    'This is a deterministic RelaySession simulation: real handshake, binary codec, adaptive AEAD frames, ACKs, pause/resume, and credit state; it is not a real relayd, WebSocket, Tailscale, or WAN measurement.',
     '',
     '| RTT | V2 fixed 512 KiB completion / useful rate / pause-resume | V2 adaptive 8 MiB completion / useful rate / pause-resume | Adaptive improvement |',
     '| ---: | --- | --- | ---: |',

--- a/apps/server/tests/relay-transport/performance-compare.test.ts
+++ b/apps/server/tests/relay-transport/performance-compare.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import { RelayCipher } from '../../src/modules/relay-transport/crypto'
+import {
+  decodeInnerFrame,
+  decodeRelayEnvelope,
+  encodeInnerFrame,
+  encodeRelayEnvelope,
+  legacyV1WireBytesForStreamData,
+  RELAY_ENVELOPE_KIND,
+  RELAY_PROTOCOL_VERSION,
+} from '../../src/modules/relay-transport/protocol'
+
+interface ComparisonCheckpoint {
+  checkpoint: string
+  old: number
+  new: number
+  unit: string
+  interpretation: string
+}
+
+function printComparison(checkpoints: ComparisonCheckpoint[]): void {
+  console.info(
+    JSON.stringify({
+      kind: 'relay-latency-compare',
+      protocol: { old: 1, new: RELAY_PROTOCOL_VERSION },
+      conditions: {
+        payloadBytes: 64 * 1024,
+        oldCreditBytes: 512 * 1024,
+        newCreditRangeBytes: [512 * 1024, 8 * 1024 * 1024],
+        syntheticRttMs: 200,
+      },
+      checkpoints,
+    }),
+  )
+}
+
+describe('relay Old/New performance comparison', () => {
+  it('reports deterministic wire, round-trip, queue, and BDP checkpoints', () => {
+    const payload = new Uint8Array(64 * 1024)
+    payload.forEach((_, index) => {
+      payload[index] = index & 0xFF
+    })
+    const frame = { kind: 'stream_data' as const, streamId: 'c1', seq: 0, data: payload }
+    const cipher = new RelayCipher(new Uint8Array(32).fill(7))
+    const encoded = encodeRelayEnvelope({
+      version: RELAY_PROTOCOL_VERSION,
+      roomId: 'room_compare',
+      seq: 0,
+      kind: RELAY_ENVELOPE_KIND.dataFrame,
+      priority: 'data',
+      streamId: frame.streamId,
+      payload: cipher.encrypt(encodeInnerFrame(frame)),
+    })
+    const decoded = decodeRelayEnvelope(encoded)
+    const decodedFrame = decodeInnerFrame(cipher.decrypt(decoded.payload))
+    expect(decodedFrame.kind).toBe('stream_data')
+    if (decodedFrame.kind === 'stream_data') {
+      expect(decodedFrame.data).toEqual(payload)
+    }
+
+    const oldWireBytes = legacyV1WireBytesForStreamData(payload)
+    const newWireBytes = encoded.byteLength
+    const checkpoints: ComparisonCheckpoint[] = [
+      {
+        checkpoint: 'wireBytes.streamData.64KiB',
+        old: oldWireBytes,
+        new: newWireBytes,
+        unit: 'bytes',
+        interpretation: 'V2 carries raw encrypted bytes instead of nested Base64 and JSON.',
+      },
+      {
+        checkpoint: 'readyRoundTrips.reconnect',
+        old: 1,
+        new: 1,
+        unit: 'round trips',
+        interpretation:
+          'Protocol encoding does not add a reconnect handshake round trip; warming removes it from a user request.',
+      },
+      {
+        checkpoint: 'controlQueuePosition.behindBulk',
+        old: 65,
+        new: 0,
+        unit: 'bulk frames ahead',
+        interpretation:
+          'The legacy FIFO can place a control frame behind the full queue; V2 reserves control priority.',
+      },
+      {
+        checkpoint: 'creditThroughputCap.200msRtt',
+        old: 2.5,
+        new: 40,
+        unit: 'MiB/s theoretical window cap',
+        interpretation:
+          'Old is 512 KiB / 200 ms; new may grow to 8 MiB after successful application acknowledgements.',
+      },
+    ]
+    printComparison(checkpoints)
+    expect(newWireBytes).toBeLessThan(oldWireBytes * 0.7)
+  })
+})

--- a/apps/server/tests/relay-transport/performance-compare.test.ts
+++ b/apps/server/tests/relay-transport/performance-compare.test.ts
@@ -31,7 +31,9 @@ interface CodecSample {
 
 const OLD_CREDIT_BYTES = 512 * 1024
 const NEW_MAX_CREDIT_BYTES = 8 * 1024 * 1024
+const NEW_MAX_CONNECTION_CREDIT_BYTES = 16 * 1024 * 1024
 const BULK_FRAMES_AHEAD_OF_CONTROL = 65
+const RESERVED_MAX_CONTROL_FRAMES = 1
 
 interface SchedulingFrame {
   priority: 'control' | 'data'
@@ -125,6 +127,9 @@ function priorityRoundRobinOrder(queue: SchedulingFrame[]): SchedulingFrame[] {
 }
 
 function deltaPercent(old: number, next: number): string {
+  if (old === 0) {
+    return next === 0 ? '0.0%' : 'new guarantee'
+  }
   const delta = ((next - old) / old) * 100
   return `${delta >= 0 ? '+' : ''}${delta.toFixed(1)}%`
 }
@@ -145,7 +150,9 @@ function printBenchmark(codecSamples: CodecSample[], rows: BenchmarkRow[]): void
       newMaxStreamChunkBytes: RELAY_MAX_STREAM_CHUNK_BYTES,
       oldCreditBytes: OLD_CREDIT_BYTES,
       newCreditRangeBytes: [OLD_CREDIT_BYTES, NEW_MAX_CREDIT_BYTES],
+      newConnectionCreditBytes: NEW_MAX_CONNECTION_CREDIT_BYTES,
       bulkFramesAheadOfControl: BULK_FRAMES_AHEAD_OF_CONTROL,
+      reservedMaximumControlFrames: RESERVED_MAX_CONTROL_FRAMES,
     },
     codecSamples: codecSamples.map(sample => ({
       ...sample,
@@ -209,6 +216,14 @@ describe('relay Old/New performance comparison', () => {
         unit: 'bulk frames',
         evidence: 'exact scheduler model',
         conclusion: 'V2 control priority bypasses queued bulk transfer frames.',
+      },
+      {
+        checkpoint: 'maximum-size control frames admitted after bulk saturation',
+        old: 0,
+        new: RESERVED_MAX_CONTROL_FRAMES,
+        unit: 'frames',
+        evidence: 'exact scheduler model',
+        conclusion: 'V2 keeps a maximum-frame byte reserve for ACK, close, and peer-notification traffic.',
       },
       {
         checkpoint: 'window cap at 20 ms RTT',

--- a/apps/server/tests/relay-transport/performance-compare.test.ts
+++ b/apps/server/tests/relay-transport/performance-compare.test.ts
@@ -169,7 +169,7 @@ function printBenchmark(codecSamples: CodecSample[], rows: BenchmarkRow[]): void
       ),
     })),
     rows,
-    caveat: 'Wire and scheduler rows are exact under the stated inputs. Throughput rows are window bounds, not Internet throughput measurements. Run benchmark:relay:runtime for a local real-relayd cold/warm timestamp sample.',
+    caveat: 'Wire and scheduler rows are exact under the stated inputs. Throughput rows are window bounds, not Internet throughput measurements. Run benchmark:relay:runtime for virtual-session RTT and local real-relayd cold/warm/concurrency samples.',
   }
   const markdown = [
     `# Relay three-generation benchmark — ${report.run.id}`,

--- a/apps/server/tests/relay-transport/performance-compare.test.ts
+++ b/apps/server/tests/relay-transport/performance-compare.test.ts
@@ -23,10 +23,12 @@ interface BenchmarkRow {
 
 interface CodecSample {
   payloadBytes: number
-  oldWireBytes: number
-  newWireBytes: number
-  oldFrames: number
-  newFrames: number
+  v1WireBytes: number
+  previousV2WireBytes: number
+  currentV2WireBytes: number
+  v1Frames: number
+  previousV2Frames: number
+  currentV2Frames: number
 }
 
 const OLD_CREDIT_BYTES = 512 * 1024
@@ -75,13 +77,17 @@ function encodeV2Payload(payload: Uint8Array): { wireBytes: number, frames: numb
 
 function measureCodec(payloadBytes: number): CodecSample {
   const payload = makePayload(payloadBytes)
-  const current = encodeV2Payload(payload)
+  const v2 = encodeV2Payload(payload)
   return {
     payloadBytes,
-    oldWireBytes: legacyV1WireBytesForStreamData(payload),
-    newWireBytes: current.wireBytes,
-    oldFrames: 1,
-    newFrames: current.frames,
+    v1WireBytes: legacyV1WireBytesForStreamData(payload),
+    // Commit 01c39cd8 changes only relayd's forwarding ownership. The V2
+    // codec is deliberately identical before and after that change.
+    previousV2WireBytes: v2.wireBytes,
+    currentV2WireBytes: v2.wireBytes,
+    v1Frames: 1,
+    previousV2Frames: v2.frames,
+    currentV2Frames: v2.frames,
   }
 }
 
@@ -136,10 +142,10 @@ function deltaPercent(old: number, next: number): string {
 
 function printBenchmark(codecSamples: CodecSample[], rows: BenchmarkRow[]): void {
   const report = {
-    kind: 'relay-old-new-benchmark',
+    kind: 'relay-three-generation-benchmark',
     run: {
-      id: 'relay-v2-deterministic-compare',
-      protocol: { old: 1, new: RELAY_PROTOCOL_VERSION },
+      id: 'relay-v1-v2-before-current-compare',
+      protocol: { v1: 1, previousV2: RELAY_PROTOCOL_VERSION, currentV2: RELAY_PROTOCOL_VERSION },
       measurementBoundary: 'same-process codec and scheduler model',
       payloadPattern: 'payload[index] = index & 0xff',
       loss: 'none',
@@ -156,20 +162,24 @@ function printBenchmark(codecSamples: CodecSample[], rows: BenchmarkRow[]): void
     },
     codecSamples: codecSamples.map(sample => ({
       ...sample,
-      wireByteDeltaPercent: deltaPercent(sample.oldWireBytes, sample.newWireBytes),
+      v1ToV2WireByteDeltaPercent: deltaPercent(sample.v1WireBytes, sample.currentV2WireBytes),
+      previousV2ToCurrentV2WireByteDeltaPercent: deltaPercent(
+        sample.previousV2WireBytes,
+        sample.currentV2WireBytes,
+      ),
     })),
     rows,
     caveat: 'Wire and scheduler rows are exact under the stated inputs. Throughput rows are window bounds, not Internet throughput measurements. Run benchmark:relay:runtime for a local real-relayd cold/warm timestamp sample.',
   }
   const markdown = [
-    `# Relay Old/New Benchmark — ${report.run.id}`,
+    `# Relay three-generation benchmark — ${report.run.id}`,
     '',
     '## Codec: exact byte measurements',
     '',
-    '| Logical payload | V1 wire bytes | V2 wire bytes | Delta | V1 frames | V2 frames |',
-    '| ---: | ---: | ---: | ---: | ---: | ---: |',
+    '| Logical payload | V1 wire bytes | V2 before pass-through | V2 current | V1 → current | V2 before → current | V1 frames | V2 before/current frames |',
+    '| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
     ...report.codecSamples.map(sample =>
-      `| ${sample.payloadBytes} B | ${sample.oldWireBytes} | ${sample.newWireBytes} | ${sample.wireByteDeltaPercent} | ${sample.oldFrames} | ${sample.newFrames} |`),
+      `| ${sample.payloadBytes} B | ${sample.v1WireBytes} | ${sample.previousV2WireBytes} | ${sample.currentV2WireBytes} | ${sample.v1ToV2WireByteDeltaPercent} | ${sample.previousV2ToCurrentV2WireByteDeltaPercent} | ${sample.v1Frames} | ${sample.previousV2Frames}/${sample.currentV2Frames} |`),
     '',
     '## Checkpoints',
     '',
@@ -178,14 +188,14 @@ function printBenchmark(codecSamples: CodecSample[], rows: BenchmarkRow[]): void
     ...rows.map(row =>
       `| ${row.checkpoint} | ${row.old} ${row.unit} | ${row.new} ${row.unit} | ${deltaPercent(row.old, row.new)} | ${row.evidence} |`),
     '',
-    'The 8 MiB value is the bounded adaptive maximum after successful acknowledgements; new streams start at the same 512 KiB as V1.',
+    'V2-before and V2-current have identical wire bytes by design: pass-through removes Relay process work, not bytes on the network. The 8 MiB value is the bounded adaptive maximum after successful acknowledgements; new streams start at the same 512 KiB as V1.',
   ].join('\n')
   console.info(markdown)
   console.info(JSON.stringify(report))
 }
 
-describe('relay Old/New performance comparison', () => {
-  it('emits a reproducible before/after report and guards the material gains', () => {
+describe('relay three-generation performance comparison', () => {
+  it('emits a reproducible V1/V2-before/V2-current report and guards the gains', () => {
     const codecSamples = [
       measureCodec(1 * 1024),
       measureCodec(64 * 1024),
@@ -269,7 +279,8 @@ describe('relay Old/New performance comparison', () => {
     printBenchmark(codecSamples, rows)
 
     for (const sample of codecSamples) {
-      expect(sample.newWireBytes).toBeLessThan(sample.oldWireBytes * 0.7)
+      expect(sample.currentV2WireBytes).toBeLessThan(sample.v1WireBytes * 0.7)
+      expect(sample.previousV2WireBytes).toBe(sample.currentV2WireBytes)
     }
     expect(rows.find(row => row.checkpoint === 'control frames ahead of an interactive control frame')?.new).toBe(0)
     expect(rows.find(row => row.checkpoint === 'window cap at 200 ms RTT')?.new).toBe(40)

--- a/apps/server/tests/relay-transport/performance-compare.test.ts
+++ b/apps/server/tests/relay-transport/performance-compare.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { decodeRelayChunk, encodeRelayChunk } from '../../src/modules/relay-transport/compression'
 import { RelayCipher } from '../../src/modules/relay-transport/crypto'
 import {
   decodeInnerFrame,
@@ -22,13 +23,14 @@ interface BenchmarkRow {
 }
 
 interface CodecSample {
+  profile: 'compressible-json' | 'incompressible'
   payloadBytes: number
   v1WireBytes: number
-  previousV2WireBytes: number
-  currentV2WireBytes: number
+  baselineV2WireBytes: number
+  optimizedV2WireBytes: number
   v1Frames: number
-  previousV2Frames: number
-  currentV2Frames: number
+  baselineV2Frames: number
+  optimizedV2Frames: number
 }
 
 const OLD_CREDIT_BYTES = 512 * 1024
@@ -43,17 +45,51 @@ interface SchedulingFrame {
   sequence: number
 }
 
-function makePayload(length: number): Uint8Array {
-  return Uint8Array.from({ length }, (_, index) => index & 0xFF)
+function makePayload(length: number, profile: CodecSample['profile']): Uint8Array {
+  if (profile === 'compressible-json') {
+    const record = Buffer.from('{"type":"relay_event","status":"streaming","content":"hello from Cradle"}\n')
+    return Uint8Array.from({ length }, (_, index) => record[index % record.length])
+  }
+  let state = 0xA341_316C
+  return Uint8Array.from({ length }, () => {
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    return state & 0xFF
+  })
 }
 
-function encodeV2Payload(payload: Uint8Array): { wireBytes: number, frames: number } {
+function baselineV2Wire(payload: Uint8Array): { wireBytes: number, frames: number } {
+  const roomBytes = Buffer.byteLength('room_benchmark')
+  const streamBytes = Buffer.byteLength('benchmark')
+  let wireBytes = 0
+  let frames = 0
+  for (let offset = 0; offset < payload.byteLength; offset += RELAY_MAX_STREAM_CHUNK_BYTES) {
+    const chunkBytes = Math.min(RELAY_MAX_STREAM_CHUNK_BYTES, payload.byteLength - offset)
+    // V2: outer header + room + outer stream id + encrypted(inner header +
+    // inner stream id + data). XChaCha added nonce(24) + tag(16).
+    wireBytes += 16 + roomBytes + streamBytes + 7 + streamBytes + chunkBytes + 40
+    frames++
+  }
+  return { wireBytes, frames }
+}
+
+function encodeOptimizedV2Payload(payload: Uint8Array): { wireBytes: number, frames: number } {
   const cipher = new RelayCipher(new Uint8Array(32).fill(7))
   let wireBytes = 0
   let frames = 0
   for (let offset = 0; offset < payload.byteLength; offset += RELAY_MAX_STREAM_CHUNK_BYTES) {
     const chunk = payload.slice(offset, offset + RELAY_MAX_STREAM_CHUNK_BYTES)
-    const frame = { kind: 'stream_data' as const, streamId: 'benchmark', seq: offset, data: chunk }
+    const compressed = encodeRelayChunk(chunk)
+    const frame = {
+      kind: 'stream_data' as const,
+      streamId: 'benchmark',
+      seq: offset,
+      data: compressed.data,
+      ...(compressed.compression === 'zstd'
+        ? { compression: 'zstd' as const, uncompressedBytes: compressed.uncompressedBytes }
+        : {}),
+    }
     const encoded = encodeRelayEnvelope({
       version: RELAY_PROTOCOL_VERSION,
       roomId: 'room_benchmark',
@@ -67,7 +103,11 @@ function encodeV2Payload(payload: Uint8Array): { wireBytes: number, frames: numb
     const decodedFrame = decodeInnerFrame(cipher.decrypt(decoded.payload))
     expect(decodedFrame).toMatchObject({ kind: 'stream_data', streamId: frame.streamId, seq: offset })
     if (decodedFrame.kind === 'stream_data') {
-      expect(decodedFrame.data).toEqual(chunk)
+      expect(decodeRelayChunk({
+        data: decodedFrame.data,
+        compression: decodedFrame.compression ?? 'none',
+        uncompressedBytes: decodedFrame.uncompressedBytes ?? decodedFrame.data.byteLength,
+      })).toEqual(chunk)
     }
     wireBytes += encoded.byteLength
     frames += 1
@@ -75,19 +115,19 @@ function encodeV2Payload(payload: Uint8Array): { wireBytes: number, frames: numb
   return { wireBytes, frames }
 }
 
-function measureCodec(payloadBytes: number): CodecSample {
-  const payload = makePayload(payloadBytes)
-  const v2 = encodeV2Payload(payload)
+function measureCodec(profile: CodecSample['profile'], payloadBytes: number): CodecSample {
+  const payload = makePayload(payloadBytes, profile)
+  const baselineV2 = baselineV2Wire(payload)
+  const optimizedV2 = encodeOptimizedV2Payload(payload)
   return {
+    profile,
     payloadBytes,
     v1WireBytes: legacyV1WireBytesForStreamData(payload),
-    // Commit 01c39cd8 changes only relayd's forwarding ownership. The V2
-    // codec is deliberately identical before and after that change.
-    previousV2WireBytes: v2.wireBytes,
-    currentV2WireBytes: v2.wireBytes,
+    baselineV2WireBytes: baselineV2.wireBytes,
+    optimizedV2WireBytes: optimizedV2.wireBytes,
     v1Frames: 1,
-    previousV2Frames: v2.frames,
-    currentV2Frames: v2.frames,
+    baselineV2Frames: baselineV2.frames,
+    optimizedV2Frames: optimizedV2.frames,
   }
 }
 
@@ -142,44 +182,44 @@ function deltaPercent(old: number, next: number): string {
 
 function printBenchmark(codecSamples: CodecSample[], rows: BenchmarkRow[]): void {
   const report = {
-    kind: 'relay-three-generation-benchmark',
+    kind: 'relay-v2-performance-benchmark',
     run: {
-      id: 'relay-v1-v2-before-current-compare',
-      protocol: { v1: 1, previousV2: RELAY_PROTOCOL_VERSION, currentV2: RELAY_PROTOCOL_VERSION },
+      id: 'relay-v1-v2-baseline-optimized-compare',
+      protocol: { v1: 1, baselineV2: RELAY_PROTOCOL_VERSION, optimizedV2: RELAY_PROTOCOL_VERSION },
       measurementBoundary: 'same-process codec and scheduler model',
-      payloadPattern: 'payload[index] = index & 0xff',
+      payloadPatterns: ['compressible JSON-like stream', 'deterministic incompressible stream'],
       loss: 'none',
       randomSeed: 'not applicable',
     },
     conditions: {
       oldMaxStreamChunkBytes: 256 * 1024,
-      newMaxStreamChunkBytes: RELAY_MAX_STREAM_CHUNK_BYTES,
+      maxStreamChunkBytes: RELAY_MAX_STREAM_CHUNK_BYTES,
       oldCreditBytes: OLD_CREDIT_BYTES,
-      newCreditRangeBytes: [OLD_CREDIT_BYTES, NEW_MAX_CREDIT_BYTES],
-      newConnectionCreditBytes: NEW_MAX_CONNECTION_CREDIT_BYTES,
+      optimizedCreditRangeBytes: [OLD_CREDIT_BYTES, NEW_MAX_CREDIT_BYTES],
+      optimizedConnectionCreditBytes: NEW_MAX_CONNECTION_CREDIT_BYTES,
       bulkFramesAheadOfControl: BULK_FRAMES_AHEAD_OF_CONTROL,
       reservedMaximumControlFrames: RESERVED_MAX_CONTROL_FRAMES,
     },
     codecSamples: codecSamples.map(sample => ({
       ...sample,
-      v1ToV2WireByteDeltaPercent: deltaPercent(sample.v1WireBytes, sample.currentV2WireBytes),
-      previousV2ToCurrentV2WireByteDeltaPercent: deltaPercent(
-        sample.previousV2WireBytes,
-        sample.currentV2WireBytes,
+      v1ToV2WireByteDeltaPercent: deltaPercent(sample.v1WireBytes, sample.optimizedV2WireBytes),
+      baselineV2ToOptimizedV2WireDeltaPercent: deltaPercent(
+        sample.baselineV2WireBytes,
+        sample.optimizedV2WireBytes,
       ),
     })),
     rows,
     caveat: 'Wire and scheduler rows are exact under the stated inputs. Throughput rows are window bounds, not Internet throughput measurements. Run benchmark:relay:runtime for virtual-session RTT and local real-relayd cold/warm/concurrency samples.',
   }
   const markdown = [
-    `# Relay three-generation benchmark — ${report.run.id}`,
+    `# Relay V2 benchmark — ${report.run.id}`,
     '',
     '## Codec: exact byte measurements',
     '',
-    '| Logical payload | V1 wire bytes | V2 before pass-through | V2 current | V1 → current | V2 before → current | V1 frames | V2 before/current frames |',
-    '| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    '| Profile | Logical payload | V1 wire bytes | V2 baseline | V2 optimized | V1 → V2 | Baseline → optimized | V2 frames |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
     ...report.codecSamples.map(sample =>
-      `| ${sample.payloadBytes} B | ${sample.v1WireBytes} | ${sample.previousV2WireBytes} | ${sample.currentV2WireBytes} | ${sample.v1ToV2WireByteDeltaPercent} | ${sample.previousV2ToCurrentV2WireByteDeltaPercent} | ${sample.v1Frames} | ${sample.previousV2Frames}/${sample.currentV2Frames} |`),
+      `| ${sample.profile} | ${sample.payloadBytes} B | ${sample.v1WireBytes} | ${sample.baselineV2WireBytes} | ${sample.optimizedV2WireBytes} | ${sample.v1ToV2WireByteDeltaPercent} | ${sample.baselineV2ToOptimizedV2WireDeltaPercent} | ${sample.baselineV2Frames}/${sample.optimizedV2Frames} |`),
     '',
     '## Checkpoints',
     '',
@@ -188,18 +228,20 @@ function printBenchmark(codecSamples: CodecSample[], rows: BenchmarkRow[]): void
     ...rows.map(row =>
       `| ${row.checkpoint} | ${row.old} ${row.unit} | ${row.new} ${row.unit} | ${deltaPercent(row.old, row.new)} | ${row.evidence} |`),
     '',
-    'V2-before and V2-current have identical wire bytes by design: pass-through removes Relay process work, not bytes on the network. The 8 MiB value is the bounded adaptive maximum after successful acknowledgements; new streams start at the same 512 KiB as V1.',
+    'V2 baseline is the PR wire format before endpoint compression/adaptive AEAD. Optimized V2 keeps the relay envelope version, adds independently decodable Zstandard chunks, keeps low-latency XChaCha for small frames, and uses native AES-GCM for bulk frames. Incompressible chunks are sent raw, so compression never expands the wire.',
   ].join('\n')
   console.info(markdown)
   console.info(JSON.stringify(report))
 }
 
 describe('relay three-generation performance comparison', () => {
-  it('emits a reproducible V1/V2-before/V2-current report and guards the gains', () => {
+  it('emits a reproducible V1/V2 baseline-versus-optimized report and guards the gains', () => {
     const codecSamples = [
-      measureCodec(1 * 1024),
-      measureCodec(64 * 1024),
-      measureCodec(256 * 1024),
+      ...(['compressible-json', 'incompressible'] as const).flatMap(profile => [
+        measureCodec(profile, 1 * 1024),
+        measureCodec(profile, 64 * 1024),
+        measureCodec(profile, 256 * 1024),
+      ]),
     ]
     const oldControlPosition = legacyFifoControlPosition(BULK_FRAMES_AHEAD_OF_CONTROL)
     const newSchedule = priorityRoundRobinOrder([
@@ -279,8 +321,10 @@ describe('relay three-generation performance comparison', () => {
     printBenchmark(codecSamples, rows)
 
     for (const sample of codecSamples) {
-      expect(sample.currentV2WireBytes).toBeLessThan(sample.v1WireBytes * 0.7)
-      expect(sample.previousV2WireBytes).toBe(sample.currentV2WireBytes)
+      expect(sample.optimizedV2WireBytes).toBeLessThanOrEqual(sample.baselineV2WireBytes)
+      if (sample.profile === 'compressible-json') {
+        expect(sample.optimizedV2WireBytes).toBeLessThan(sample.baselineV2WireBytes * 0.2)
+      }
     }
     expect(rows.find(row => row.checkpoint === 'control frames ahead of an interactive control frame')?.new).toBe(0)
     expect(rows.find(row => row.checkpoint === 'window cap at 200 ms RTT')?.new).toBe(40)

--- a/apps/server/tests/relay-transport/performance-compare.test.ts
+++ b/apps/server/tests/relay-transport/performance-compare.test.ts
@@ -8,45 +8,52 @@ import {
   encodeRelayEnvelope,
   legacyV1WireBytesForStreamData,
   RELAY_ENVELOPE_KIND,
+  RELAY_MAX_STREAM_CHUNK_BYTES,
   RELAY_PROTOCOL_VERSION,
 } from '../../src/modules/relay-transport/protocol'
 
-interface ComparisonCheckpoint {
+interface BenchmarkRow {
   checkpoint: string
   old: number
   new: number
   unit: string
-  interpretation: string
+  evidence: 'exact codec measurement' | 'exact scheduler model' | 'bounded-window model'
+  conclusion: string
 }
 
-function printComparison(checkpoints: ComparisonCheckpoint[]): void {
-  console.info(
-    JSON.stringify({
-      kind: 'relay-latency-compare',
-      protocol: { old: 1, new: RELAY_PROTOCOL_VERSION },
-      conditions: {
-        payloadBytes: 64 * 1024,
-        oldCreditBytes: 512 * 1024,
-        newCreditRangeBytes: [512 * 1024, 8 * 1024 * 1024],
-        syntheticRttMs: 200,
-      },
-      checkpoints,
-    }),
-  )
+interface CodecSample {
+  payloadBytes: number
+  oldWireBytes: number
+  newWireBytes: number
+  oldFrames: number
+  newFrames: number
 }
 
-describe('relay Old/New performance comparison', () => {
-  it('reports deterministic wire, round-trip, queue, and BDP checkpoints', () => {
-    const payload = new Uint8Array(64 * 1024)
-    payload.forEach((_, index) => {
-      payload[index] = index & 0xFF
-    })
-    const frame = { kind: 'stream_data' as const, streamId: 'c1', seq: 0, data: payload }
-    const cipher = new RelayCipher(new Uint8Array(32).fill(7))
+const OLD_CREDIT_BYTES = 512 * 1024
+const NEW_MAX_CREDIT_BYTES = 8 * 1024 * 1024
+const BULK_FRAMES_AHEAD_OF_CONTROL = 65
+
+interface SchedulingFrame {
+  priority: 'control' | 'data'
+  streamId: string
+  sequence: number
+}
+
+function makePayload(length: number): Uint8Array {
+  return Uint8Array.from({ length }, (_, index) => index & 0xFF)
+}
+
+function encodeV2Payload(payload: Uint8Array): { wireBytes: number, frames: number } {
+  const cipher = new RelayCipher(new Uint8Array(32).fill(7))
+  let wireBytes = 0
+  let frames = 0
+  for (let offset = 0; offset < payload.byteLength; offset += RELAY_MAX_STREAM_CHUNK_BYTES) {
+    const chunk = payload.slice(offset, offset + RELAY_MAX_STREAM_CHUNK_BYTES)
+    const frame = { kind: 'stream_data' as const, streamId: 'benchmark', seq: offset, data: chunk }
     const encoded = encodeRelayEnvelope({
       version: RELAY_PROTOCOL_VERSION,
-      roomId: 'room_compare',
-      seq: 0,
+      roomId: 'room_benchmark',
+      seq: frames,
       kind: RELAY_ENVELOPE_KIND.dataFrame,
       priority: 'data',
       streamId: frame.streamId,
@@ -54,47 +61,202 @@ describe('relay Old/New performance comparison', () => {
     })
     const decoded = decodeRelayEnvelope(encoded)
     const decodedFrame = decodeInnerFrame(cipher.decrypt(decoded.payload))
-    expect(decodedFrame.kind).toBe('stream_data')
+    expect(decodedFrame).toMatchObject({ kind: 'stream_data', streamId: frame.streamId, seq: offset })
     if (decodedFrame.kind === 'stream_data') {
-      expect(decodedFrame.data).toEqual(payload)
+      expect(decodedFrame.data).toEqual(chunk)
     }
+    wireBytes += encoded.byteLength
+    frames += 1
+  }
+  return { wireBytes, frames }
+}
 
-    const oldWireBytes = legacyV1WireBytesForStreamData(payload)
-    const newWireBytes = encoded.byteLength
-    const checkpoints: ComparisonCheckpoint[] = [
+function measureCodec(payloadBytes: number): CodecSample {
+  const payload = makePayload(payloadBytes)
+  const current = encodeV2Payload(payload)
+  return {
+    payloadBytes,
+    oldWireBytes: legacyV1WireBytesForStreamData(payload),
+    newWireBytes: current.wireBytes,
+    oldFrames: 1,
+    newFrames: current.frames,
+  }
+}
+
+function windowCapMiBps(windowBytes: number, rttMs: number): number {
+  return windowBytes / (1024 * 1024) / (rttMs / 1_000)
+}
+
+function legacyFifoControlPosition(bulkFrameCount: number): number {
+  const queue: SchedulingFrame[] = [
+    ...Array.from({ length: bulkFrameCount }, (_, sequence) => ({
+      priority: 'data' as const,
+      streamId: 'bulk',
+      sequence,
+    })),
+    { priority: 'control', streamId: 'control', sequence: 0 },
+  ]
+  return queue.findIndex(frame => frame.priority === 'control')
+}
+
+function priorityRoundRobinOrder(queue: SchedulingFrame[]): SchedulingFrame[] {
+  const control = queue.filter(frame => frame.priority === 'control')
+  const streams = new Map<string, SchedulingFrame[]>()
+  for (const frame of queue) {
+    if (frame.priority === 'data') {
+      const frames = streams.get(frame.streamId) ?? []
+      frames.push(frame)
+      streams.set(frame.streamId, frames)
+    }
+  }
+  const order = [...control]
+  while (streams.size > 0) {
+    for (const [streamId, frames] of [...streams]) {
+      const frame = frames.shift()
+      if (frame) {
+        order.push(frame)
+      }
+      if (frames.length === 0) {
+        streams.delete(streamId)
+      }
+    }
+  }
+  return order
+}
+
+function deltaPercent(old: number, next: number): string {
+  const delta = ((next - old) / old) * 100
+  return `${delta >= 0 ? '+' : ''}${delta.toFixed(1)}%`
+}
+
+function printBenchmark(codecSamples: CodecSample[], rows: BenchmarkRow[]): void {
+  const report = {
+    kind: 'relay-old-new-benchmark',
+    run: {
+      id: 'relay-v2-deterministic-compare',
+      protocol: { old: 1, new: RELAY_PROTOCOL_VERSION },
+      measurementBoundary: 'same-process codec and scheduler model',
+      payloadPattern: 'payload[index] = index & 0xff',
+      loss: 'none',
+      randomSeed: 'not applicable',
+    },
+    conditions: {
+      oldMaxStreamChunkBytes: 256 * 1024,
+      newMaxStreamChunkBytes: RELAY_MAX_STREAM_CHUNK_BYTES,
+      oldCreditBytes: OLD_CREDIT_BYTES,
+      newCreditRangeBytes: [OLD_CREDIT_BYTES, NEW_MAX_CREDIT_BYTES],
+      bulkFramesAheadOfControl: BULK_FRAMES_AHEAD_OF_CONTROL,
+    },
+    codecSamples: codecSamples.map(sample => ({
+      ...sample,
+      wireByteDeltaPercent: deltaPercent(sample.oldWireBytes, sample.newWireBytes),
+    })),
+    rows,
+    caveat: 'Wire and scheduler rows are exact under the stated inputs. Throughput rows are window bounds, not Internet throughput measurements. Run benchmark:relay:runtime for a local real-relayd cold/warm timestamp sample.',
+  }
+  const markdown = [
+    `# Relay Old/New Benchmark — ${report.run.id}`,
+    '',
+    '## Codec: exact byte measurements',
+    '',
+    '| Logical payload | V1 wire bytes | V2 wire bytes | Delta | V1 frames | V2 frames |',
+    '| ---: | ---: | ---: | ---: | ---: | ---: |',
+    ...report.codecSamples.map(sample =>
+      `| ${sample.payloadBytes} B | ${sample.oldWireBytes} | ${sample.newWireBytes} | ${sample.wireByteDeltaPercent} | ${sample.oldFrames} | ${sample.newFrames} |`),
+    '',
+    '## Checkpoints',
+    '',
+    '| Checkpoint | Old | New | Delta | Evidence |',
+    '| --- | ---: | ---: | ---: | --- |',
+    ...rows.map(row =>
+      `| ${row.checkpoint} | ${row.old} ${row.unit} | ${row.new} ${row.unit} | ${deltaPercent(row.old, row.new)} | ${row.evidence} |`),
+    '',
+    'The 8 MiB value is the bounded adaptive maximum after successful acknowledgements; new streams start at the same 512 KiB as V1.',
+  ].join('\n')
+  console.info(markdown)
+  console.info(JSON.stringify(report))
+}
+
+describe('relay Old/New performance comparison', () => {
+  it('emits a reproducible before/after report and guards the material gains', () => {
+    const codecSamples = [
+      measureCodec(1 * 1024),
+      measureCodec(64 * 1024),
+      measureCodec(256 * 1024),
+    ]
+    const oldControlPosition = legacyFifoControlPosition(BULK_FRAMES_AHEAD_OF_CONTROL)
+    const newSchedule = priorityRoundRobinOrder([
+      ...Array.from({ length: BULK_FRAMES_AHEAD_OF_CONTROL }, (_, sequence) => ({
+        priority: 'data' as const,
+        streamId: 'bulk',
+        sequence,
+      })),
+      { priority: 'control' as const, streamId: 'control', sequence: 0 },
+    ])
+    const newControlPosition = newSchedule.findIndex(frame => frame.priority === 'control')
+    const fairDataOrder = priorityRoundRobinOrder([
+      { priority: 'data', streamId: 'a', sequence: 1 },
+      { priority: 'data', streamId: 'a', sequence: 2 },
+      { priority: 'data', streamId: 'b', sequence: 1 },
+    ]).map(frame => `${frame.streamId}${frame.sequence}`)
+    expect(fairDataOrder).toEqual(['a1', 'b1', 'a2'])
+
+    const rows: BenchmarkRow[] = [
       {
-        checkpoint: 'wireBytes.streamData.64KiB',
-        old: oldWireBytes,
-        new: newWireBytes,
-        unit: 'bytes',
-        interpretation: 'V2 carries raw encrypted bytes instead of nested Base64 and JSON.',
+        checkpoint: 'control frames ahead of an interactive control frame',
+        old: oldControlPosition,
+        new: newControlPosition,
+        unit: 'bulk frames',
+        evidence: 'exact scheduler model',
+        conclusion: 'V2 control priority bypasses queued bulk transfer frames.',
       },
       {
-        checkpoint: 'readyRoundTrips.reconnect',
-        old: 1,
-        new: 1,
-        unit: 'round trips',
-        interpretation:
-          'Protocol encoding does not add a reconnect handshake round trip; warming removes it from a user request.',
+        checkpoint: 'window cap at 20 ms RTT',
+        old: windowCapMiBps(OLD_CREDIT_BYTES, 20),
+        new: windowCapMiBps(NEW_MAX_CREDIT_BYTES, 20),
+        unit: 'MiB/s',
+        evidence: 'bounded-window model',
+        conclusion: 'The new cap is reached only after ACK-driven credit growth.',
       },
       {
-        checkpoint: 'controlQueuePosition.behindBulk',
-        old: 65,
-        new: 0,
-        unit: 'bulk frames ahead',
-        interpretation:
-          'The legacy FIFO can place a control frame behind the full queue; V2 reserves control priority.',
+        checkpoint: 'window cap at 100 ms RTT',
+        old: windowCapMiBps(OLD_CREDIT_BYTES, 100),
+        new: windowCapMiBps(NEW_MAX_CREDIT_BYTES, 100),
+        unit: 'MiB/s',
+        evidence: 'bounded-window model',
+        conclusion: 'A fixed 512 KiB window is increasingly restrictive as delay rises.',
       },
       {
-        checkpoint: 'creditThroughputCap.200msRtt',
-        old: 2.5,
-        new: 40,
-        unit: 'MiB/s theoretical window cap',
-        interpretation:
-          'Old is 512 KiB / 200 ms; new may grow to 8 MiB after successful application acknowledgements.',
+        checkpoint: 'window cap at 200 ms RTT',
+        old: windowCapMiBps(OLD_CREDIT_BYTES, 200),
+        new: windowCapMiBps(NEW_MAX_CREDIT_BYTES, 200),
+        unit: 'MiB/s',
+        evidence: 'bounded-window model',
+        conclusion: 'High-delay transfers can use 16x more in-flight bytes, bounded at 8 MiB per stream.',
+      },
+      {
+        checkpoint: 'window cap at 400 ms RTT',
+        old: windowCapMiBps(OLD_CREDIT_BYTES, 400),
+        new: windowCapMiBps(NEW_MAX_CREDIT_BYTES, 400),
+        unit: 'MiB/s',
+        evidence: 'bounded-window model',
+        conclusion: 'The gain scales with delay only when the path and receiver can sustain it.',
+      },
+      {
+        checkpoint: 'bounded in-flight bytes per stream',
+        old: OLD_CREDIT_BYTES / (1024 * 1024),
+        new: NEW_MAX_CREDIT_BYTES / (1024 * 1024),
+        unit: 'MiB',
+        evidence: 'bounded-window model',
+        conclusion: 'This is the deliberate high-BDP trade-off; the new sender remains capped at 8 MiB per stream.',
       },
     ]
-    printComparison(checkpoints)
-    expect(newWireBytes).toBeLessThan(oldWireBytes * 0.7)
+    printBenchmark(codecSamples, rows)
+
+    for (const sample of codecSamples) {
+      expect(sample.newWireBytes).toBeLessThan(sample.oldWireBytes * 0.7)
+    }
+    expect(rows.find(row => row.checkpoint === 'control frames ahead of an interactive control frame')?.new).toBe(0)
+    expect(rows.find(row => row.checkpoint === 'window cap at 200 ms RTT')?.new).toBe(40)
   })
 })

--- a/apps/server/tests/relay-transport/session.test.ts
+++ b/apps/server/tests/relay-transport/session.test.ts
@@ -471,4 +471,51 @@ describe('relay session', () => {
     ).streams.get('c1')
     expect(flow?.creditBytes).toBeGreaterThan(512 * 1024)
   })
+
+  it('caps aggregate in-flight data across concurrent streams', () => {
+    const hostKeys = generateRelayKeyPair()
+    const controllerKeys = generateRelayKeyPair()
+    const roomId = 'room_connection_credit'
+    const host = new RelaySession(
+      'host',
+      hostKeys.privateKeyBase64,
+      { roomId, pairingCode: 'PAIR-CONNECTION-CREDIT', ourPublicKeyBase64: hostKeys.publicKeyBase64 },
+      { send: () => {}, onStreamOpen: () => {}, onStreamData: () => {} },
+    )
+    const controller = new RelaySession(
+      'controller',
+      controllerKeys.privateKeyBase64,
+      {
+        roomId,
+        pairingCode: 'PAIR-CONNECTION-CREDIT',
+        ourPublicKeyBase64: controllerKeys.publicKeyBase64,
+        maxConnectionCreditBytes: 1024 * 1024,
+      },
+      { send: () => {} },
+    )
+    const wire = wireSessions(host, controller, roomId)
+    ;(host as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send = wire.hostSend
+    ;(controller as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send
+      = wire.controllerSend
+    host.start()
+    controller.start()
+    controller.openStream('c1')
+    controller.openStream('c2')
+    controller.openStream('c3')
+
+    const window = new Uint8Array(512 * 1024)
+    controller.writeStreamData('c1', window)
+    controller.writeStreamData('c2', window)
+    controller.writeStreamData('c3', window)
+
+    const flows = (
+      controller as unknown as {
+        streams: Map<string, { sentBytes: number, peerAckedBytes: number, pendingData: Uint8Array[] }>
+      }
+    ).streams
+    const inFlight = [...flows.values()]
+      .reduce((total, flow) => total + flow.sentBytes - flow.peerAckedBytes, 0)
+    expect(inFlight).toBe(1024 * 1024)
+    expect(flows.get('c3')?.pendingData).toHaveLength(1)
+  })
 })

--- a/apps/server/tests/relay-transport/session.test.ts
+++ b/apps/server/tests/relay-transport/session.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { generateRelayKeyPair } from '../../src/modules/relay-transport/crypto'
 import type { RelayEnvelope } from '../../src/modules/relay-transport/protocol'
-import { relayEnvelopeSchema } from '../../src/modules/relay-transport/protocol'
+import {
+  decodeInnerFrame,
+  decodeRelayEnvelope,
+  encodeInnerFrame,
+} from '../../src/modules/relay-transport/protocol'
 import { RelaySession } from '../../src/modules/relay-transport/session'
 
 /**
@@ -14,13 +18,13 @@ function wireSessions(
   host: RelaySession,
   controller: RelaySession,
   roomId: string,
-): { hostSend: (data: string) => void, controllerSend: (data: string) => void } {
-  const hostSend = (data: string) => {
-    const env = relayEnvelopeSchema.parse(JSON.parse(data))
+): { hostSend: (data: Uint8Array) => void, controllerSend: (data: Uint8Array) => void } {
+  const hostSend = (data: Uint8Array) => {
+    const env = decodeRelayEnvelope(data)
     controller.handleEnvelope({ ...env, roomId })
   }
-  const controllerSend = (data: string) => {
-    const env = relayEnvelopeSchema.parse(JSON.parse(data))
+  const controllerSend = (data: Uint8Array) => {
+    const env = decodeRelayEnvelope(data)
     host.handleEnvelope({ ...env, roomId })
   }
   return { hostSend, controllerSend }
@@ -58,8 +62,9 @@ describe('relay session', () => {
 
     // Rebind the send callbacks now that both sessions exist.
     const wire = wireSessions(host, controller, roomId)
-    ;(host as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.hostSend
-    ;(controller as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.controllerSend
+    ;(host as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send = wire.hostSend
+    ;(controller as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send
+      = wire.controllerSend
 
     host.start()
     controller.start()
@@ -94,19 +99,28 @@ describe('relay session', () => {
     const host = new RelaySession(
       'host',
       hostKeys.privateKeyBase64,
-      { roomId, pinnedPeerPubkey: controllerKeys.publicKeyBase64, ourPublicKeyBase64: hostKeys.publicKeyBase64 },
+      {
+        roomId,
+        pinnedPeerPubkey: controllerKeys.publicKeyBase64,
+        ourPublicKeyBase64: hostKeys.publicKeyBase64,
+      },
       { send: () => {}, onReady: hostReady },
     )
     const controller = new RelaySession(
       'controller',
       controllerKeys.privateKeyBase64,
-      { roomId, pinnedPeerPubkey: hostKeys.publicKeyBase64, ourPublicKeyBase64: controllerKeys.publicKeyBase64 },
+      {
+        roomId,
+        pinnedPeerPubkey: hostKeys.publicKeyBase64,
+        ourPublicKeyBase64: controllerKeys.publicKeyBase64,
+      },
       { send: () => {}, onReady: controllerReady },
     )
 
     const wire = wireSessions(host, controller, roomId)
-    ;(host as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.hostSend
-    ;(controller as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.controllerSend
+    ;(host as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send = wire.hostSend
+    ;(controller as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send
+      = wire.controllerSend
 
     host.start()
     controller.start()
@@ -127,14 +141,22 @@ describe('relay session', () => {
     const host = new RelaySession(
       'host',
       hostKeys.privateKeyBase64,
-      { roomId, pinnedPeerPubkey: controllerKeys.publicKeyBase64, ourPublicKeyBase64: hostKeys.publicKeyBase64 },
+      {
+        roomId,
+        pinnedPeerPubkey: controllerKeys.publicKeyBase64,
+        ourPublicKeyBase64: hostKeys.publicKeyBase64,
+      },
       { send: () => {}, onError: hostError },
     )
     // Real controller, pinned to the host.
     const controller = new RelaySession(
       'controller',
       controllerKeys.privateKeyBase64,
-      { roomId, pinnedPeerPubkey: hostKeys.publicKeyBase64, ourPublicKeyBase64: controllerKeys.publicKeyBase64 },
+      {
+        roomId,
+        pinnedPeerPubkey: hostKeys.publicKeyBase64,
+        ourPublicKeyBase64: controllerKeys.publicKeyBase64,
+      },
       { send: () => {}, onError: controllerError },
     )
 
@@ -142,17 +164,21 @@ describe('relay session', () => {
     // its own, so each honest peer sees the MITM's pubkey where it expects the
     // real peer's. At least one honest peer must reject (whichever receives the
     // rewritten hello first); in a real relay the detection is symmetric.
-    const wire = (b: RelaySession) => (data: string) => {
-      const env = relayEnvelopeSchema.parse(JSON.parse(data))
-      if (env.payload && typeof env.payload === 'object' && (env.payload as { kind?: string }).kind === 'hello') {
-        const rewritten = { ...(env.payload as object), pubkey: mitmKeys.publicKeyBase64 }
-        b.handleEnvelope({ ...env, roomId, payload: rewritten })
+    const wire = (b: RelaySession) => (data: Uint8Array) => {
+      const env = decodeRelayEnvelope(data)
+      const frame = decodeInnerFrame(env.payload)
+      if (frame.kind === 'hello') {
+        b.handleEnvelope({
+          ...env,
+          roomId,
+          payload: encodeInnerFrame({ ...frame, pubkey: mitmKeys.publicKeyBase64 }),
+        })
         return
       }
       b.handleEnvelope({ ...env, roomId })
     }
-    ;(host as unknown as { cb: { send: (d: string) => void } }).cb.send = wire(controller)
-    ;(controller as unknown as { cb: { send: (d: string) => void } }).cb.send = wire(host)
+    ;(host as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send = wire(controller)
+    ;(controller as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send = wire(host)
 
     host.start()
     controller.start()
@@ -184,8 +210,9 @@ describe('relay session', () => {
     )
 
     const wire = wireSessions(host, controller, roomId)
-    ;(host as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.hostSend
-    ;(controller as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.controllerSend
+    ;(host as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send = wire.hostSend
+    ;(controller as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send
+      = wire.controllerSend
 
     host.start()
     controller.start()
@@ -206,11 +233,12 @@ describe('relay session', () => {
 
     // A bare plaintext stream_open injected pre-handshake must be rejected.
     const malicious: RelayEnvelope = {
-      version: 1,
+      version: 2,
       roomId: 'r',
       seq: 99,
       kind: 'relay_data_frame',
-      payload: { kind: 'stream_open', streamId: 'evil' },
+      priority: 'control',
+      payload: encodeInnerFrame({ kind: 'stream_open', streamId: 'evil' }),
     }
     host.handleEnvelope(malicious)
     expect(host.isReady).toBe(false)
@@ -230,7 +258,10 @@ describe('relay session', () => {
       {
         send: () => {},
         onStreamOpen: () => {},
-        onStreamData: (_streamId, data) => hostStreamData.push(data),
+        onStreamData: (streamId, data) => {
+          hostStreamData.push(data)
+          host.reportStreamDataConsumed(streamId, data.byteLength)
+        },
       },
     )
     const controller = new RelaySession(
@@ -241,8 +272,9 @@ describe('relay session', () => {
     )
 
     const wire = wireSessions(host, controller, roomId)
-    ;(host as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.hostSend
-    ;(controller as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.controllerSend
+    ;(host as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send = wire.hostSend
+    ;(controller as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send
+      = wire.controllerSend
 
     host.start()
     controller.start()
@@ -295,15 +327,18 @@ describe('relay session', () => {
     )
 
     const wire = wireSessions(host, controller, roomId)
-    ;(host as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.hostSend
-    ;(controller as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.controllerSend
+    ;(host as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send = wire.hostSend
+    ;(controller as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send
+      = wire.controllerSend
 
     host.start()
     controller.start()
     controller.openStream('c1')
 
     // Hold acks on the host so the controller exhausts its 512 KiB window.
-    ;(host as unknown as { cb: { onStreamData: (s: string, d: Uint8Array) => void } }).cb.onStreamData = () => {}
+    ;(
+      host as unknown as { cb: { onStreamData: (s: string, d: Uint8Array) => void } }
+    ).cb.onStreamData = () => {}
 
     const payload = new Uint8Array(512 * 1024)
     controller.writeStreamData('c1', payload)
@@ -355,8 +390,9 @@ describe('relay session', () => {
     )
 
     const wire = wireSessions(host, controller, roomId)
-    ;(host as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.hostSend
-    ;(controller as unknown as { cb: { send: (d: string) => void } }).cb.send = wire.controllerSend
+    ;(host as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send = wire.hostSend
+    ;(controller as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send
+      = wire.controllerSend
 
     host.start()
     controller.start()
@@ -391,5 +427,48 @@ describe('relay session', () => {
       controller.reportStreamDataConsumed('c1', chunk.byteLength)
     }
     expect(hostResume).toHaveBeenCalledWith('c1')
+  })
+
+  it('grows a stream window only after the peer has applied a substantial window', () => {
+    const hostKeys = generateRelayKeyPair()
+    const controllerKeys = generateRelayKeyPair()
+    const roomId = 'room_adaptive_credit'
+    const host = new RelaySession(
+      'host',
+      hostKeys.privateKeyBase64,
+      {
+        roomId,
+        pairingCode: 'PAIR-ADAPTIVE',
+        ourPublicKeyBase64: hostKeys.publicKeyBase64,
+      },
+      {
+        send: () => {},
+        onStreamOpen: () => {},
+        onStreamData: (streamId, data) => host.reportStreamDataConsumed(streamId, data.byteLength),
+      },
+    )
+    const controller = new RelaySession(
+      'controller',
+      controllerKeys.privateKeyBase64,
+      {
+        roomId,
+        pairingCode: 'PAIR-ADAPTIVE',
+        ourPublicKeyBase64: controllerKeys.publicKeyBase64,
+        maxStreamCreditBytes: 2 * 1024 * 1024,
+      },
+      { send: () => {} },
+    )
+    const wire = wireSessions(host, controller, roomId)
+    ;(host as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send = wire.hostSend
+    ;(controller as unknown as { cb: { send: (d: Uint8Array) => void } }).cb.send
+      = wire.controllerSend
+    host.start()
+    controller.start()
+    controller.openStream('c1')
+    controller.writeStreamData('c1', new Uint8Array(1024 * 1024))
+    const flow = (
+      controller as unknown as { streams: Map<string, { creditBytes: number }> }
+    ).streams.get('c1')
+    expect(flow?.creditBytes).toBeGreaterThan(512 * 1024)
   })
 })

--- a/apps/server/tests/relay-transport/websocket-data.test.ts
+++ b/apps/server/tests/relay-transport/websocket-data.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import type WebSocket from 'ws'
+
+import { relayWebSocketDataView } from '../../src/modules/relay-transport/websocket-data'
+
+describe('relay WebSocket data view', () => {
+  it('shares Buffer memory without copying', () => {
+    const source = Buffer.from([1, 2, 3])
+    const view = relayWebSocketDataView(source)
+
+    view[1] = 9
+    expect(source[1]).toBe(9)
+  })
+
+  it('shares ArrayBuffer memory without copying', () => {
+    const source = new Uint8Array([1, 2, 3])
+    const view = relayWebSocketDataView(source.buffer)
+
+    view[1] = 9
+    expect(source[1]).toBe(9)
+  })
+
+  it('coalesces the fragmented Buffer-array form', () => {
+    const source = [Buffer.from([1, 2]), Buffer.from([3, 4])] as WebSocket.RawData
+
+    expect(relayWebSocketDataView(source)).toEqual(new Uint8Array([1, 2, 3, 4]))
+  })
+})

--- a/apps/server/tests/remote-hosts.test.ts
+++ b/apps/server/tests/remote-hosts.test.ts
@@ -238,6 +238,7 @@ describe('remote Cradle Server hosts', () => {
         state: 'connected',
         localBaseUrl: fakeRemote.baseUrl,
         lastError: null,
+        relayPerformance: null,
       })
       expect(fakeRemote.healthRequestCount()).toBe(1)
 


### PR DESCRIPTION
## Summary

Optimizes the unmerged Relay V2 protocol directly. There is no V3 compatibility layer.

- Native Zstandard level 1 on independently decodable chunks, with raw fallback whenever compression does not save at least 64 bytes.
- Low-latency XChaCha20-Poly1305 for small frames and hardware-accelerated AES-256-GCM for bulk frames, selected without adding wire bytes.
- Zero-copy WebSocket Buffer views and zero-copy Relay envelope payload slices.
- Cached connection credit and round-robin endpoint flushing.
- relayd queue backpressure under slow consumers instead of disconnecting the tunnel; control capacity remains reserved.
- 256 KiB cumulative ACK cadence to reduce control traffic while retaining the adaptive 512 KiB to 8 MiB stream window.

## V2 before / after benchmark

### Exact endpoint wire bytes

| Payload | V2 baseline | V2 optimized | Reduction |
| --- | ---: | ---: | ---: |
| 1 KiB compressible | 1,119 B | 183 B | 83.6% |
| 64 KiB compressible | 65,631 B | 184 B | 99.7% |
| 256 KiB compressible | 262,524 B | 736 B | 99.7% |
| 1 KiB incompressible | 1,119 B | 1,107 B | 1.1% |
| 64 KiB incompressible | 65,631 B | 65,619 B | 0.018% |
| 256 KiB incompressible | 262,524 B | 262,476 B | 0.018% |

### Endpoint codec CPU, median of five interleaved samples

| Payload | V2 baseline | V2 optimized | Throughput change |
| --- | ---: | ---: | ---: |
| 512 B compressible | 30.5 MiB/s | 30.7 MiB/s | +1.0% |
| 512 B incompressible | 32.8 MiB/s | 32.5 MiB/s | -0.7% |
| 64 KiB compressible | 104.4 MiB/s | 820.9 MiB/s | +686.4% |
| 64 KiB incompressible | 104.5 MiB/s | 465.5 MiB/s | +345.6% |

The sub-1 KiB path is intentionally unchanged: raw frame plus XChaCha, with no compression call.

### Deterministic adverse-network matrix, 2 MiB compressible transfer

| Link | V2 baseline | V2 optimized | Completion improvement | Wire reduction |
| --- | ---: | ---: | ---: | ---: |
| 100 Mbps, 20 ms RTT, 0% loss | 176.8 ms | 53.2 ms | 69.9% | 99.7% |
| 5 Mbps, 100 ms RTT, 1% loss | 3,436.9 ms | 458.2 ms | 86.7% | 99.7% |
| 512 Kbps, 250 ms RTT, 3% loss | 34,524.2 ms | 1,347.7 ms | 96.1% | 99.7% |
| 128 Kbps, 800 ms RTT, 10% loss | 148,309.3 ms | 4,879.1 ms | 96.7% | 99.7% |

The same matrix with deterministic incompressible bytes stays effectively flat while saving the 12-byte bulk AEAD overhead per frame: completion improves 0.017-0.018% and wire bytes improve 0.017-0.018%.

### Real local-relayd loopback, observed before / after runs

| Checkpoint | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| 1 stream p50 | 13.40 ms | 5.72 ms | 57.3% lower |
| 8 streams p50 | 25.08 ms | 13.54 ms | 46.0% lower |
| 8 streams p95 | 32.73 ms | 16.23 ms | 50.4% lower |
| 8-stream aggregate useful throughput | 29.43 MiB/s | 54.45 MiB/s | 85.0% higher |

This uses a spawned Go relayd, real WebSockets, E2EE sessions, TCP bridges, and HTTP echo traffic on loopback. It is not a WAN claim.

### High-RTT flow-control matrix, 8 MiB virtual-time transfer

| RTT | Fixed 512 KiB window | Adaptive 8 MiB window | Completion improvement |
| ---: | ---: | ---: | ---: |
| 20 ms | 320 ms / 25.00 MiB/s | 90 ms / 88.89 MiB/s | 71.9% |
| 100 ms | 1,600 ms / 5.00 MiB/s | 450 ms / 17.78 MiB/s | 71.9% |
| 200 ms | 3,200 ms / 2.50 MiB/s | 900 ms / 8.89 MiB/s | 71.9% |
| 400 ms | 6,400 ms / 1.25 MiB/s | 1,800 ms / 4.44 MiB/s | 71.9% |

### relayd forward hot path, 64 KiB

| V2 before pass-through | V2 validated pass-through | Runtime reduction | Allocation reduction |
| ---: | ---: | ---: | ---: |
| 18,249 ns/op | 40.44 ns/op | 99.78% | 147,489 B/op -> 32 B/op; 4 -> 2 allocs/op |

## Validation

- `pnpm --filter @cradle/server benchmark:relay:full` passes with serialized benchmark workers.
- `pnpm --filter @cradle/server exec vitest run tests/relay-transport --reporter=dot`: 11 files, 40 tests pass.
- `pnpm --filter @cradle/server typecheck`: passes, including module-boundary validation.
- `cd apps/relayd && go test -race ./...`: passes.
- `pnpm --filter @cradle/relayd benchmark:forward`: passes.

---

Generated by [Cradle Agent](https://cradle.wibus.ren)
