### PR TITLE
fix(work): preserve right aside preference

### DIFF
--- a/apps/web/src/features/work/work-page.test.tsx
+++ b/apps/web/src/features/work/work-page.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useLayoutStore } from '~/store/layout'
+
+import { WorkPage } from './work-page'
+
+const mocks = vi.hoisted(() => ({
+  updateSurfaceTitle: vi.fn(),
+  getWorkDetail: vi.fn(),
+}))
+
+vi.mock('~/features/chat/session/chat-session-route-content', () => ({
+  ChatSessionRouteContent: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="work-session-content">{sessionId}</div>
+  ),
+}))
+
+vi.mock('~/navigation/surface-store', () => ({
+  useSurfaceStore: <T,>(selector: (state: { updateSurfaceTitle: typeof mocks.updateSurfaceTitle }) => T) => selector({
+    updateSurfaceTitle: mocks.updateSurfaceTitle,
+  }),
+}))
+
+vi.mock('./use-work', () => ({
+  useWorkDetail: () => ({
+    data: mocks.getWorkDetail(),
+    error: null,
+  }),
+}))
+
+describe('WorkPage', () => {
+  beforeEach(() => {
+    mocks.updateSurfaceTitle.mockReset()
+    mocks.getWorkDetail.mockReset().mockReturnValue({
+      work: { title: 'Respect the user preference' },
+      primaryThread: { id: 'session-1' },
+    })
+    useLayoutStore.setState({
+      asideOpen: false,
+      asideActiveTab: 'git',
+    })
+  })
+
+  afterEach(cleanup)
+
+  it('preserves the user right aside preference when opening a Work', () => {
+    render(<WorkPage workId="work-1" />)
+
+    expect(screen.getByTestId('work-session-content')).toHaveTextContent('session-1')
+    expect(useLayoutStore.getState()).toMatchObject({
+      asideOpen: false,
+      asideActiveTab: 'git',
+    })
+  })
+})

--- a/apps/web/src/features/work/work-page.tsx
+++ b/apps/web/src/features/work/work-page.tsx
@@ -1,19 +1,14 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 
 import { Spinner } from '~/components/ui/spinner'
 import { ChatSessionRouteContent } from '~/features/chat/session/chat-session-route-content'
-import { useSurfaceActive } from '~/navigation/surface-activity-context'
 import { workSurfaceId } from '~/navigation/surface-identity'
 import { useSurfaceStore } from '~/navigation/surface-store'
-import { useLayoutStore } from '~/store/layout'
 
 import { useWorkDetail } from './use-work'
 
 export function WorkPage({ workId }: { workId: string }) {
-  const active = useSurfaceActive()
-  const initializedAsideRef = useRef(false)
   const updateSurfaceTitle = useSurfaceStore(state => state.updateSurfaceTitle)
-  const openAsideTab = useLayoutStore(state => state.openAsideTab)
   const workQuery = useWorkDetail(workId)
 
   useEffect(() => {
@@ -22,14 +17,6 @@ export function WorkPage({ workId }: { workId: string }) {
     }
     updateSurfaceTitle(workSurfaceId(workId), workQuery.data.work.title)
   }, [updateSurfaceTitle, workId, workQuery.data])
-
-  useEffect(() => {
-    if (!active || !workQuery.data || initializedAsideRef.current) {
-      return
-    }
-    initializedAsideRef.current = true
-    openAsideTab('work')
-  }, [active, openAsideTab, workQuery.data])
 
   if (workQuery.error) {
     throw workQuery.error


### PR DESCRIPTION
## Summary
Remove the WorkPage effect that unconditionally selected the Work tab and opened the right aside after Work data loaded. The persisted right-aside visibility and selected tab now remain entirely under user control. Add a regression test for an initially closed right aside.

## Test plan
Static verification: git diff --check passed. Focused web Vitest test and the commit ESLint hook were attempted but cannot start because this isolated worktree has no node_modules; Vite cannot resolve @cradle/plugin-sdk and ESLint cannot resolve eslint-config-hyoban.

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)