### PR TITLE
fix(work): refresh sidebar pull request status

### DIFF
--- a/apps/server/src/modules/work/README.md
+++ b/apps/server/src/modules/work/README.md
@@ -17,6 +17,9 @@ Session, Worktree, Pull Request, Chat Runtime, and Await read models.
   WIP.
 - Work stores facts only. Activity labels are derived and no Work status machine
   exists.
+- Listing Work detects the current state of each bound pull request through the
+  Pull Request owner, so sidebar summaries reflect GitHub merges without
+  opening the individual Work surface.
 - Preparing a handoff saves metadata locally. When an open Draft PR already exists, prepare also pushes the branch and updates the PR automatically.
 - The builtin `cradle` MCP server exposes `manage_pull_request` as the required
   Agent-facing closed-loop finalization tool; the tool delegates to this module's

--- a/apps/server/src/modules/work/service.test.ts
+++ b/apps/server/src/modules/work/service.test.ts
@@ -158,13 +158,29 @@ describe('work delivery control', () => {
     seedWork()
     mockHealthyDetailReads()
 
-    const [summary] = Work.list({ workspaceId: WORKSPACE_ID })
+    const [summary] = await Work.list({ workspaceId: WORKSPACE_ID })
     const detail = await Work.get(WORK_ID)
 
     expect(summary?.title).toBe('Primary Work Session')
     expect(detail?.work.title).toBe('Primary Work Session')
     expect(db().select({ title: works.title }).from(works).where(eq(works.id, WORK_ID)).get()?.title)
       .toBe('Implement Work')
+  })
+
+  it('detects the live pull request state when listing Work', async () => {
+    seedWork()
+    const { pullRequest } = mockHealthyDetailReads()
+    pullRequest.mockResolvedValue({
+      ...OPEN_PULL_REQUEST,
+      isDraft: false,
+      state: 'closed',
+      merged: true,
+    })
+
+    const [summary] = await Work.list({ workspaceId: WORKSPACE_ID })
+
+    expect(pullRequest).toHaveBeenCalledWith(SESSION_ID)
+    expect(summary?.pullRequest).toMatchObject({ state: 'closed', merged: true })
   })
 
   it('creates a primary Session in a healthy managed Worktree from a clean repository', async () => {

--- a/apps/server/src/modules/work/service.ts
+++ b/apps/server/src/modules/work/service.ts
@@ -148,11 +148,19 @@ function toSummary(work: Work, primaryThread: Session.SessionView): WorkSummary 
   }
 }
 
-export function list(input: {
+async function toLiveSummary(work: Work, primaryThread: Session.SessionView): Promise<WorkSummary> {
+  const summary = toSummary(work, primaryThread)
+  return {
+    ...summary,
+    pullRequest: await PullRequest.getPullRequest(primaryThread.id),
+  }
+}
+
+export async function list(input: {
   workspaceId?: string
   linkedIssueId?: string
   archived?: boolean
-} = {}): WorkSummary[] {
+} = {}): Promise<WorkSummary[]> {
   const predicates = [
     input.linkedIssueId ? eq(works.linkedIssueId, input.linkedIssueId) : undefined,
     input.archived ? isNotNull(works.archivedAt) : isNull(works.archivedAt),
@@ -161,13 +169,14 @@ export function list(input: {
   const query = db().select().from(works).orderBy(desc(works.updatedAt), desc(works.createdAt))
   const rows = where ? query.where(where).all() : query.all()
 
-  return rows.flatMap((work) => {
+  const visibleWorks = rows.flatMap((work) => {
     const primaryThread = requirePrimaryThread(work.id)
     if (input.workspaceId && primaryThread.workspaceId !== input.workspaceId) {
       return []
     }
-    return [toSummary(work, primaryThread)]
+    return [{ work, primaryThread }]
   })
+  return Promise.all(visibleWorks.map(({ work, primaryThread }) => toLiveSummary(work, primaryThread)))
 }
 
 export async function get(id: string): Promise<WorkDetail | null> {

--- a/apps/web/src/features/work/use-work.test.ts
+++ b/apps/web/src/features/work/use-work.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import type { WorkSummary } from './use-work'
+import { hasOpenWorkPullRequest } from './use-work'
+
+function createWork(pullRequest: WorkSummary['pullRequest']): WorkSummary {
+  return {
+    id: 'work-1',
+    workspaceId: 'workspace-1',
+    primarySessionId: 'session-1',
+    title: 'Refresh pull request state',
+    objective: 'Keep the sidebar current.',
+    linkedIssueId: null,
+    handoffTitle: null,
+    handoffSummary: null,
+    handoffTestPlan: null,
+    preparedAt: null,
+    lastSubmittedAt: null,
+    closedAt: null,
+    archivedAt: null,
+    createdAt: 1,
+    updatedAt: 1,
+    activity: 'idle',
+    pullRequest,
+  }
+}
+
+const openPullRequest: NonNullable<WorkSummary['pullRequest']> = {
+  owner: 'cradle',
+  repo: 'app',
+  number: 41,
+  url: 'https://example.test/pull/41',
+  title: 'Refresh status',
+  isDraft: false,
+  state: 'open',
+  merged: false,
+  headRef: 'cradle/wt/refresh-status',
+  baseRef: 'main',
+  headSha: 'abc123',
+  createdAt: 1,
+  updatedAt: 1,
+}
+
+describe('hasOpenWorkPullRequest', () => {
+  it('continues sidebar refreshes only while a Work pull request is open', () => {
+    expect(hasOpenWorkPullRequest(undefined)).toBe(false)
+    expect(hasOpenWorkPullRequest([createWork(null)])).toBe(false)
+    expect(hasOpenWorkPullRequest([createWork(openPullRequest)])).toBe(true)
+    expect(hasOpenWorkPullRequest([
+      createWork({ ...openPullRequest, state: 'closed', merged: true }),
+    ])).toBe(false)
+  })
+})

--- a/apps/web/src/features/work/use-work.ts
+++ b/apps/web/src/features/work/use-work.ts
@@ -21,6 +21,12 @@ export type WorkDetail = GetWorksByIdResponse
 export type WorkSummary = GetWorksResponse[number]
 export type SessionWorkResolution = GetSessionsByIdWorkResponse
 
+export const WORK_PULL_REQUEST_REFRESH_INTERVAL_MS = 30_000
+
+export function hasOpenWorkPullRequest(works: readonly WorkSummary[] | undefined): boolean {
+  return works?.some(work => work.pullRequest?.state === 'open' && !work.pullRequest.merged) ?? false
+}
+
 export function useWorkDetail(workId: string | null | undefined) {
   return useQuery({
     ...getWorksByIdOptions({ path: { id: workId ?? '' } }),
@@ -34,6 +40,10 @@ export function useWorkspaceWorks(workspaceId: string | null | undefined) {
     ...getWorksOptions({ query: workspaceId ? { workspaceId } : undefined }),
     enabled: !!workspaceId,
     staleTime: 5_000,
+    refetchInterval: query => hasOpenWorkPullRequest(query.state.data)
+      ? WORK_PULL_REQUEST_REFRESH_INTERVAL_MS
+      : false,
+    refetchIntervalInBackground: true,
   })
 }
 


### PR DESCRIPTION
## Summary
Work list reads now detect each bound pull request through the Pull Request GitHub API and return the refreshed snapshot. The workspace sidebar polls every 30 seconds in the background while a Work pull request remains open, then stops after it closes or merges.

## Test plan
Passed: pnpm --filter @cradle/server exec vitest run src/modules/work/service.test.ts (25 tests); pnpm --filter @cradle/web exec vitest run --environment jsdom src/features/work/use-work.test.ts (1 test); pnpm typecheck:server; pnpm typecheck:apps-web; staged ESLint hook.

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)