### PR TITLE
fix(work): use worktree for diffs and terminals

### DIFF
--- a/apps/server/src/modules/git/README.md
+++ b/apps/server/src/modules/git/README.md
@@ -12,7 +12,8 @@ Route metadata includes `x-cradle-cli` descriptors for generated CLI commands.
 ## Routes
 
 - `GET /workspaces/:id/git/repositories`: discover Git repositories inside a workspace and return per-repository branch and file-change summaries. Exposed to CLI as `workspace git repositories`.
-- `GET /workspaces/:id/git/status`: current branch, tracking status, and normalized working-tree file changes for one repository. Accepts optional `repo` query; it is required when a workspace has multiple repositories. Exposed to CLI as `workspace git status`.
+- `GET /workspaces/:id/git/status`: current branch, tracking status, and normalized working-tree file changes for one repository. Accepts optional `repo` and `sessionId` queries; an isolated session resolves the managed worktree. `repo` is required when a workspace has multiple repositories. Exposed to CLI as `workspace git status`.
+- `GET /workspaces/:id/git/diff`: combined tracked and untracked working-tree patch for one repository. Accepts optional `repo`, `paths`, and `sessionId` queries; an isolated session resolves the managed worktree.
 - `GET /workspaces/:id/git/branches`: local and remote branch names for one repository. Accepts optional `repo` query. Exposed to CLI as `workspace git branches`.
 - `GET /workspaces/:id/git/remotes`: configured remote names and fetch/push URLs for one repository. Accepts optional `repo` query.
 - `GET /workspaces/:id/git/graph`: user commit graph data for rendering one repository. Accepts optional `repo` query and excludes Cradle-owned revisions and decorations under `refs/cradle/**` so internal checkpoint snapshots never appear as user history. Exposed to CLI as `workspace git graph`.

--- a/apps/server/src/modules/git/index.ts
+++ b/apps/server/src/modules/git/index.ts
@@ -110,7 +110,7 @@ export const git = new Elysia({
   })
   .get('/:workspaceId/git/diff', async ({ params, query }) => {
     const paths = query.paths ? query.paths.split(',').map(p => p.trim()).filter(Boolean) : undefined
-    return await Git.getDiff(params.workspaceId, paths, query.repo)
+    return await Git.getDiff(params.workspaceId, paths, query.repo, query.sessionId)
   }, {
     detail: {
       'summary': 'Get git diff',

--- a/apps/server/src/modules/git/model.ts
+++ b/apps/server/src/modules/git/model.ts
@@ -50,6 +50,7 @@ export const GitModel = {
   diffQuery: t.Object({
     repo: t.Optional(t.String({ minLength: 1 })),
     paths: t.Optional(t.String()),
+    sessionId: t.Optional(t.String({ minLength: 1 })),
   }),
 
   mergeBaseQuery: t.Object({

--- a/apps/server/src/modules/git/service.ts
+++ b/apps/server/src/modules/git/service.ts
@@ -477,8 +477,10 @@ export async function getDiff(
   workspaceId: string,
   paths?: string[],
   repositoryPath?: string,
+  sessionId?: string,
 ): Promise<string> {
-  const { repository } = await resolveRepository(workspaceId, repositoryPath)
+  const cwdOverride = sessionId ? resolveGitCwd(workspaceId, sessionId) : undefined
+  const { repository } = await resolveRepository(workspaceId, repositoryPath, cwdOverride)
   try {
     const selectedPaths = normalizeDiffPaths(paths)
     const status = await simpleGit(repository.absolutePath).status()

--- a/apps/server/tests/git.test.ts
+++ b/apps/server/tests/git.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { workspaces } from '@cradle/db'
+import { sessions, workspaces, worktrees } from '@cradle/db'
 import { describe, expect, it } from 'vitest'
 
 import { createServerApp } from '../src/app'
@@ -131,6 +131,67 @@ function createGitWorkspaceFixture(dir: string): void {
 }
 
 describe('git capability', () => {
+  it('reads diffs from an isolated session worktree', async () => {
+    const dataDir = makeTempDir('cradle-data-')
+    const workspaceRoot = makeTempDir('cradle-git-workspace-')
+    const worktreePath = makeTempDir('cradle-git-worktree-')
+    const previousEnv = useIsolatedTestInfra(dataDir)
+
+    try {
+      createGitWorkspaceFixture(workspaceRoot)
+      rmSync(worktreePath, { recursive: true, force: true })
+      await addGitWorktree({
+        repoPath: workspaceRoot,
+        worktreePath,
+        branch: 'cradle/wt/git-diff-session',
+      })
+      writeFileSync(join(worktreePath, 'worktree-only.txt'), 'worktree change\n', 'utf8')
+
+      const app = await createServerApp({ startBackgroundTasks: false })
+      const now = Date.now()
+      db().insert(workspaces).values(workspaceFixture({
+        id: 'workspace-git-session',
+        name: 'Workspace Git Session',
+        path: workspaceRoot,
+      })).run()
+      db().insert(worktrees).values({
+        id: 'worktree-git-session',
+        sourceWorkspaceId: 'workspace-git-session',
+        name: 'git-diff-session',
+        path: worktreePath,
+        branch: 'cradle/wt/git-diff-session',
+        baseRef: 'HEAD',
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+      }).run()
+      db().insert(sessions).values({
+        id: 'session-git-worktree',
+        workspaceId: 'workspace-git-session',
+        worktreeId: 'worktree-git-session',
+        title: 'Git Worktree Session',
+        runtimeKind: 'standard',
+        configJson: '{}',
+        pinned: 0,
+        createdAt: now,
+        updatedAt: now,
+      }).run()
+
+      const response = await app.handle(
+        new Request('http://localhost/workspaces/workspace-git-session/git/diff?sessionId=session-git-worktree'),
+      )
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toContain('worktree-only.txt')
+    }
+    finally {
+      restoreTestInfra(previousEnv)
+      rmSync(dataDir, { recursive: true, force: true })
+      rmSync(workspaceRoot, { recursive: true, force: true })
+      rmSync(worktreePath, { recursive: true, force: true })
+    }
+  })
+
   it('returns workspace-owned status, branches, and commit graph for a real git repository', async () => {
     const dataDir = makeTempDir('cradle-data-')
     const workspaceRoot = makeTempDir('cradle-git-workspace-')

--- a/apps/web/src/components/layout/app-layout.tsx
+++ b/apps/web/src/components/layout/app-layout.tsx
@@ -34,6 +34,7 @@ import {
 import { useLayoutSlotsCtx } from '~/components/layout/use-layout-slots'
 import { Skeleton } from '~/components/ui/skeleton'
 import { useChatSplitFocusedSessionId } from '~/features/chat/split-workspace/chat-split-workspace-store'
+import { useSessionIsolationState } from '~/features/session/use-session-isolation'
 import { useJarvisUiStore } from '~/features/system-agent/jarvis-ui-store'
 import { useGlobalEventListeners } from '~/hooks/use-global-event-listeners'
 import { useShortcut } from '~/hooks/use-shortcut'
@@ -637,6 +638,8 @@ function AppLayoutContent({
   const activeChromeOwnerId = activeSurface?.id ?? null
   const activeBrowserPanelOwnerId = activeChromeOwnerId
   const activeSessionLayout = useChatSessionLayoutRecord(activeSessionId)
+  const { data: activeSessionIsolation, isLoading: isActiveSessionIsolationLoading }
+    = useSessionIsolationState(activeSessionId)
   const layoutContract = deriveActiveLayoutContract({
     activeTab,
     slots,
@@ -658,6 +661,11 @@ function AppLayoutContent({
       ?? (activeSessionLayout?.workspaceId === resolvedAsideWorkspaceId
       ? activeSessionLayout.workspacePath
       : null)
+  const resolvedTerminalCwd = activeSessionId && isActiveSessionIsolationLoading
+    ? null
+    : activeSessionIsolation?.isIsolated && activeSessionIsolation.worktreePath
+      ? activeSessionIsolation.worktreePath
+      : resolvedAsideWorkspacePath
   const resolvedAsideWorkspaceName = resolvedWorkspaceLayout?.workspaceName ?? null
   const jarvisExpanded = useJarvisUiStore(s => s.expanded)
 
@@ -901,7 +909,7 @@ function AppLayoutContent({
                 ownerId={activeBrowserPanelOwnerId}
                 activeSessionId={activeSessionId}
                 activeSessionTitle={activeSessionTitle}
-                terminalCwd={resolvedAsideWorkspacePath}
+                terminalCwd={resolvedTerminalCwd}
                 nativeBoundsPaused={browserPanelNativeBoundsPaused}
                 onCloseLastTab={handleCloseLastBrowserPanelTab}
                 validOwnerIds={validChromeOwnerIds}

--- a/apps/web/src/features/browser/browser-panel.test.tsx
+++ b/apps/web/src/features/browser/browser-panel.test.tsx
@@ -142,6 +142,7 @@ vi.mock('./workspace-diff-viewer', () => ({
   WorkspaceDiffViewer: (props: {
     tabId: string
     workspaceId: string
+    sessionId?: string | null
     repositoryPath?: string | null
     paths?: string[]
   }) => {
@@ -212,6 +213,21 @@ describe('browserPanel rendering', () => {
     })
 
     expect(diffViewerRender).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes the worktree session to workspace diff tabs', () => {
+    useBrowserPanelStore.getState().openWorkspaceDiffTab({
+      workspaceId: 'workspace-1',
+      sessionId: 'session-worktree-1',
+      title: 'All Changes',
+    })
+
+    render(<BrowserPanel />)
+
+    expect(diffViewerRender).toHaveBeenLastCalledWith(expect.objectContaining({
+      sessionId: 'session-worktree-1',
+      workspaceId: 'workspace-1',
+    }))
   })
 
   it('renders pull request details as a Browser Panel tab', () => {

--- a/apps/web/src/features/browser/browser-panel.tsx
+++ b/apps/web/src/features/browser/browser-panel.tsx
@@ -3317,6 +3317,7 @@ export function BrowserPanel({
             ownerId={resolvedOwnerId}
             tabId={activePanelTab.id}
             workspaceId={activePanelTab.workspaceId}
+            sessionId={activePanelTab.sessionId}
             repositoryPath={activePanelTab.repositoryPath}
             paths={activePanelTab.paths}
           />

--- a/apps/web/src/features/browser/workspace-diff-viewer.tsx
+++ b/apps/web/src/features/browser/workspace-diff-viewer.tsx
@@ -20,6 +20,7 @@ interface WorkspaceDiffViewerProps {
   ownerId?: string | null
   tabId: string
   workspaceId: string
+  sessionId?: string | null
   repositoryPath?: string | null
   paths?: string[]
 }
@@ -32,8 +33,8 @@ export function WorkspaceDiffViewer(props: WorkspaceDiffViewerProps) {
   )
 }
 
-function WorkspaceDiffViewerContent({ ownerId, tabId, workspaceId, repositoryPath, paths }: WorkspaceDiffViewerProps) {
-  const { data: patch, isLoading, isError } = useGitDiff(workspaceId, repositoryPath, paths)
+function WorkspaceDiffViewerContent({ ownerId, tabId, workspaceId, sessionId, repositoryPath, paths }: WorkspaceDiffViewerProps) {
+  const { data: patch, isLoading, isError } = useGitDiff(workspaceId, repositoryPath, paths, sessionId)
   const deferredPatch = useDeferredValue(patch)
   const [diffStyle, setDiffStyle] = useState<DiffStyle>('split')
   const [isDiffStylePending, startDiffStyleTransition] = useTransition()

--- a/apps/web/src/features/git/changes-panel.test.ts
+++ b/apps/web/src/features/git/changes-panel.test.ts
@@ -155,7 +155,10 @@ describe('changesPanel type interactions', () => {
       isSuccess: true,
     })
 
-    renderWithQueryClient(createElement(ChangesPanel, { workspaceId: 'workspace-1' }))
+    renderWithQueryClient(createElement(ChangesPanel, {
+      workspaceId: 'workspace-1',
+      sessionId: 'session-worktree-1',
+    }))
 
     const rows = screen.getAllByTestId('changes-file-row')
     fireEvent.click(rows[0]!)
@@ -166,6 +169,7 @@ describe('changesPanel type interactions', () => {
     expect(state.tabs[0]).toMatchObject({
       kind: 'workspace-diff',
       workspaceId: 'workspace-1',
+      sessionId: 'session-worktree-1',
       repositoryPath: undefined,
       paths: undefined,
       title: 'All Changes',
@@ -181,7 +185,10 @@ describe('changesPanel type interactions', () => {
 
 describe('changesPanel tree interactions', () => {
   it('opens the All Changes browser panel tab for the double-clicked tree file', () => {
-    renderWithQueryClient(createElement(ChangesPanel, { workspaceId: 'workspace-1' }))
+    renderWithQueryClient(createElement(ChangesPanel, {
+      workspaceId: 'workspace-1',
+      sessionId: 'session-worktree-1',
+    }))
 
     fireEvent.click(screen.getByRole('radio', { name: 'Show changes as tree' }))
     fireEvent.doubleClick(screen.getByText('src/app.tsx'))
@@ -193,6 +200,7 @@ describe('changesPanel tree interactions', () => {
     expect(state.tabs[0]).toMatchObject({
       kind: 'workspace-diff',
       workspaceId: 'workspace-1',
+      sessionId: 'session-worktree-1',
       repositoryPath: undefined,
       paths: undefined,
       title: 'All Changes',

--- a/apps/web/src/features/git/changes-panel.tsx
+++ b/apps/web/src/features/git/changes-panel.tsx
@@ -76,6 +76,7 @@ export function ChangesPanel({ workspaceId, workspacePath, sessionId }: ChangesP
     }
     const tabId = openWorkspaceDiffTab({
       workspaceId,
+      sessionId,
       repositoryPath: getWorkspaceDiffRepositoryPath(repository.path, gitRepositories.length),
       title: 'All Changes',
     })

--- a/apps/web/src/features/git/use-git.ts
+++ b/apps/web/src/features/git/use-git.ts
@@ -3,8 +3,6 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import {
   getWorkspacesByWorkspaceIdGitBranchesOptions,
   getWorkspacesByWorkspaceIdGitBranchesQueryKey,
-  getWorkspacesByWorkspaceIdGitDiffOptions,
-  getWorkspacesByWorkspaceIdGitDiffQueryKey,
   getWorkspacesByWorkspaceIdGitGraphOptions,
   getWorkspacesByWorkspaceIdGitGraphQueryKey,
   getWorkspacesByWorkspaceIdGitRemotesOptions,
@@ -13,6 +11,7 @@ import {
   getWorkspacesByWorkspaceIdGitStatusOptions,
   getWorkspacesByWorkspaceIdGitStatusQueryKey,
 } from '~/api-gen/@tanstack/react-query.gen'
+import { client } from '~/api-gen/client.gen'
 import { queryRefreshPolicies } from '~/lib/query-refresh-policy'
 
 // ─── Re-export generated query key builders so callers don't import from api-gen ──
@@ -21,7 +20,15 @@ export { getWorkspacesByWorkspaceIdGitStatusQueryKey as gitStatusQueryKey }
 export { getWorkspacesByWorkspaceIdGitRepositoriesQueryKey as gitRepositoriesQueryKey }
 export { getWorkspacesByWorkspaceIdGitBranchesQueryKey as gitBranchesQueryKey }
 export { getWorkspacesByWorkspaceIdGitGraphQueryKey as gitGraphQueryKey }
-export { getWorkspacesByWorkspaceIdGitDiffQueryKey as gitDiffQueryKey }
+
+export function gitDiffQueryKey(
+  workspaceId: string,
+  repositoryPath?: string | null,
+  paths?: string[],
+  sessionId?: string | null,
+) {
+  return ['git-diff', workspaceId, repositoryPath ?? null, paths?.join(',') ?? null, sessionId ?? null] as const
+}
 
 // ─── Hooks ───────────────────────────────────────────────────────────────────
 
@@ -141,23 +148,27 @@ export function useGitDiff(
   workspaceId: string | null | undefined,
   repositoryPath?: string | null,
   paths?: string[],
+  sessionId?: string | null,
 ) {
   const pathsStr = paths?.length ? paths.join(',') : undefined
   return useQuery({
-    ...getWorkspacesByWorkspaceIdGitDiffOptions({
-      path: { workspaceId: workspaceId! },
-      ...(repositoryPath || pathsStr
-        ? {
-            query: {
-              ...(repositoryPath ? { repo: repositoryPath } : {}),
-              ...(pathsStr ? { paths: pathsStr } : {}),
-            },
-          }
-        : {}),
-    }),
+    queryKey: gitDiffQueryKey(workspaceId ?? '', repositoryPath, paths, sessionId),
+    queryFn: async () => {
+      const { data, error } = await client.get<string>({
+        url: `/workspaces/${workspaceId}/git/diff`,
+        query: {
+          ...(repositoryPath ? { repo: repositoryPath } : {}),
+          ...(pathsStr ? { paths: pathsStr } : {}),
+          ...(sessionId ? { sessionId } : {}),
+        },
+      })
+      if (error) {
+        throw error
+      }
+      return data ?? ''
+    },
     ...queryRefreshPolicies.active,
     enabled: !!workspaceId,
     retry: false,
-    select: data => (typeof data === 'string' ? data : ''),
   })
 }

--- a/apps/web/src/store/browser-panel.test.ts
+++ b/apps/web/src/store/browser-panel.test.ts
@@ -403,6 +403,7 @@ describe('browser panel shortcuts', () => {
     })
     const reopenedTabId = useBrowserPanelStore.getState().openWorkspaceDiffTab({
       workspaceId: 'workspace-2',
+      sessionId: 'session-worktree-2',
       repositoryPath: 'packages/web',
       paths: ['src/app.tsx'],
       title: 'app.tsx',
@@ -414,6 +415,7 @@ describe('browser panel shortcuts', () => {
         id: firstTabId,
         kind: 'workspace-diff',
         workspaceId: 'workspace-2',
+        sessionId: 'session-worktree-2',
         repositoryPath: 'packages/web',
         paths: ['src/app.tsx'],
         title: 'app.tsx',

--- a/apps/web/src/store/browser-panel.ts
+++ b/apps/web/src/store/browser-panel.ts
@@ -132,6 +132,7 @@ export interface BrowserWorkspaceDiffTab {
   kind: 'workspace-diff'
   id: string
   workspaceId: string
+  sessionId?: string
   repositoryPath?: string
   paths?: string[]
   title: string
@@ -391,6 +392,7 @@ const workspaceDiffTabSchema = z.object({
   kind: z.literal('workspace-diff'),
   id: z.string(),
   workspaceId: z.string(),
+  sessionId: z.string().optional(),
   repositoryPath: z.string().optional(),
   paths: z.array(z.string()).optional(),
   title: z.string(),
@@ -861,6 +863,7 @@ interface BrowserPanelState {
   }) => string
   openWorkspaceDiffTab: (input: {
     workspaceId: string
+    sessionId?: string | null
     repositoryPath?: string | null
     paths?: string[]
     title?: string
@@ -1596,12 +1599,13 @@ function createBrowserPanelStore() {
         return commitOpenTab(set, ownerId, tab)
       },
 
-      openWorkspaceDiffTab: ({ workspaceId, repositoryPath, paths, title, ownerId: ownerIdInput }) => {
+      openWorkspaceDiffTab: ({ workspaceId, sessionId, repositoryPath, paths, title, ownerId: ownerIdInput }) => {
         const ownerId = normalizeBrowserPanelOwnerId(ownerIdInput ?? get().activeOwnerId)
         const tab: BrowserWorkspaceDiffTab = {
           kind: 'workspace-diff',
           id: `legacy-workspace-diff-${++localTabCounter}`,
           workspaceId,
+          sessionId: sessionId ?? undefined,
           repositoryPath: repositoryPath ?? undefined,
           paths,
           title:


### PR DESCRIPTION
## Summary
Keep the isolated session identity from Right Dock Changes into workspace diff tabs, resolve git diffs from that session's worktree, and open embedded terminals in the isolated worktree cwd instead of the main workspace.

## Test plan
Added server and web regression coverage for worktree diff identity. `git diff --check` passes. Focused Vitest suites and API generation could not start because this managed worktree has no installed dependencies (missing vite-node, unplugin-swc, and plugin SDK); the commit hook likewise could not load eslint-config-hyoban.

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)