### PR TITLE
fix(relay): prevent websocket teardown crash

### DIFF
--- a/apps/server/src/modules/relay-transport/controller-transport.ts
+++ b/apps/server/src/modules/relay-transport/controller-transport.ts
@@ -11,6 +11,7 @@ import { generateRelayKeyPair, publicKeyFromPrivate } from './crypto'
 import type { RelayEnvelope } from './protocol'
 import { decodeRelayEnvelope } from './protocol'
 import { RelaySession } from './session'
+import { closeRelayWebSocket } from './websocket'
 import { relayWebSocketDataView } from './websocket-data'
 
 /**
@@ -380,10 +381,7 @@ class ControllerTransport {
     this.session?.close()
     this.session = null
     if (this.ws) {
-      this.ws.removeAllListeners()
-      if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
-        this.ws.close()
-      }
+      closeRelayWebSocket(this.ws)
       this.ws = null
     }
     if (this.server) {

--- a/apps/server/src/modules/relay-transport/host-connector.ts
+++ b/apps/server/src/modules/relay-transport/host-connector.ts
@@ -15,6 +15,7 @@ import type { RelayEnvelope } from './protocol'
 import { decodeRelayEnvelope } from './protocol'
 import { readOrCreateHostRelayAuthToken } from './relay-auth-token-service'
 import { RelaySession } from './session'
+import { closeRelayWebSocket } from './websocket'
 import { relayWebSocketDataView } from './websocket-data'
 
 const logger = createChildLogger({ module: 'relay-host-connector' })
@@ -326,10 +327,7 @@ class HostConnection {
     this.session?.close()
     this.session = null
     if (this.ws) {
-      this.ws.removeAllListeners()
-      if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
-        this.ws.close()
-      }
+      closeRelayWebSocket(this.ws)
       this.ws = null
     }
     for (const { socket } of this.streams.values()) {

--- a/apps/server/src/modules/relay-transport/websocket.ts
+++ b/apps/server/src/modules/relay-transport/websocket.ts
@@ -1,0 +1,17 @@
+import WebSocket from 'ws'
+
+/**
+ * Closes a relay websocket without allowing ws's asynchronous connection
+ * abort error to escape after transport listeners have been removed.
+ */
+export function closeRelayWebSocket(ws: WebSocket): void {
+  ws.removeAllListeners()
+  if (ws.readyState === WebSocket.CLOSED) {
+    return
+  }
+  // Closing a CONNECTING ws aborts its HTTP upgrade request. ws emits the
+  // resulting error on the next tick, so keep one listener installed after
+  // teardown to prevent it from becoming an uncaught process error.
+  ws.once('error', () => {})
+  ws.close()
+}

--- a/apps/server/tests/relay-transport/controller-transport.test.ts
+++ b/apps/server/tests/relay-transport/controller-transport.test.ts
@@ -1,0 +1,51 @@
+import net from 'node:net'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { generateRelaySigningKeyPair, signRelayAssertion } from '../../src/modules/relay-servers/relay-signature-service'
+import { startRelayControllerTransport } from '../../src/modules/relay-transport/controller-transport'
+import { generateRelayKeyPair } from '../../src/modules/relay-transport/crypto'
+
+describe('relay controller transport', () => {
+  const servers: net.Server[] = []
+  const sockets = new Set<net.Socket>()
+
+  afterEach(async () => {
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+    sockets.clear()
+    await Promise.all(servers.splice(0).map(server => new Promise<void>(resolve => server.close(() => resolve()))))
+  })
+
+  it('fails a stalled websocket handshake without an uncaught websocket error', async () => {
+    const server = net.createServer((socket) => {
+      sockets.add(socket)
+      socket.once('close', () => sockets.delete(socket))
+    })
+    servers.push(server)
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected the test server to have a TCP address.')
+    }
+
+    const controllerKeys = generateRelayKeyPair()
+    const signingKeys = generateRelaySigningKeyPair()
+    const wsAssertion = signRelayAssertion(signingKeys.privateKeyBase64, {
+      role: 'controller',
+      purpose: 'ws',
+      roomId: 'test-room',
+    })
+
+    await expect(startRelayControllerTransport({
+      hostId: 'test-host',
+      relayUrl: `http://127.0.0.1:${address.port}`,
+      roomId: 'test-room',
+      wsAssertion,
+      controllerPrivateKeyBase64: controllerKeys.privateKeyBase64,
+      controllerPublicKeyBase64: controllerKeys.publicKeyBase64,
+      readyTimeoutMs: 25,
+    })).rejects.toMatchObject({ code: 'relay_controller_connect_failed' })
+  })
+})


### PR DESCRIPTION
## Summary
Prevent relay WebSocket cleanup from emitting an unhandled error when a handshake is cancelled before connection establishment. The shared safe-close helper is used by controller and host transports, with a regression test for a stalled handshake.

## Test plan
Passed: controller relay stalled-handshake regression test; relay crypto/session tests; relay transport end-to-end test; ESLint on changed files. Server typecheck remains blocked by pre-existing errors in chat-runtime lifecycle routes, queue API tests, and provider catalog tests.

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)