### PR TITLE
fix(session-await): preserve GitHub CI await repository filters

### DIFF
--- a/apps/server/src/modules/session-await/sources/github-ci.ts
+++ b/apps/server/src/modules/session-await/sources/github-ci.ts
@@ -136,8 +136,7 @@ const GitHubRepoSchema = z.string().min(1).regex(/^[^/]+\/[^/]+$/).transform((re
     return { owner, repo }
   })
 
-const GitHubCIFilterSchema = z.object({
-  repo: GitHubRepoSchema,
+const GitHubCIFilterFieldsSchema = z.object({
   pr: z.number().int().positive().optional(),
   sha: z.string().min(1).optional(),
   runs_id: z.number().int().positive().optional(),
@@ -147,25 +146,69 @@ const GitHubCIFilterSchema = z.object({
   headSha: z.string().min(1).optional(),
   workId: z.string().min(1).optional(),
   allowNoChecksAfterSeconds: z.number().int().nonnegative().default(DEFAULT_NO_CHECKS_GRACE_SECONDS),
-}).transform((filter) => {
+})
+
+const GitHubCIFilterSchema = z.union([
+  GitHubCIFilterFieldsSchema.extend({ repo: GitHubRepoSchema })
+    .transform(({ repo, ...filter }) => ({ ...filter, owner: repo.owner, repo: repo.repo })),
+  // A previous head-update serializer persisted the parsed representation.
+  // Continue checking those pending awaits, then replace it with the canonical
+  // `{ repo: "owner/repo" }` representation below.
+  GitHubCIFilterFieldsSchema.extend({
+    owner: z.string().min(1),
+    repo: z.string().min(1).regex(/^[^/]+$/),
+  }),
+]).transform((filter) => {
   const checkRunId = filter.runs_id ?? filter.checkRunId ?? filter.runId
   return { ...filter, checkRunId }
 }).refine(filter => [filter.pr, filter.sha, filter.checkRunId].filter(value => value !== undefined).length === 1, {
   message: 'GitHub CI filter requires exactly one of pr, sha, or runs_id',
 }).refine(filter => filter.headSha === undefined || filter.pr !== undefined, {
   message: 'GitHub CI headSha requires a PR target',
-}).transform(({ repo, ...filter }) => ({
+}).transform(filter => ({
   ...filter,
-  owner: repo.owner,
-  repo: repo.repo,
   statusRef: filter.sha ?? '',
 }))
+
+const LegacyGitHubCIFilterSchema = z.object({
+  owner: z.string().min(1),
+  repo: z.string().min(1).regex(/^[^/]+$/),
+})
+
+function isLegacyGitHubCIFilter(filterJson: string): boolean {
+  return LegacyGitHubCIFilterSchema.safeParse(JSON.parse(filterJson)).success
+}
 
 export const GitHubCIFilterJsonSchema = z.string()
   .transform(raw => JSON.parse(raw))
   .pipe(GitHubCIFilterSchema)
 
 type GitHubCIFilter = z.infer<typeof GitHubCIFilterSchema>
+
+function serializeGitHubCIFilter(filter: GitHubCIFilter): string {
+  const target = filter.pr !== undefined
+    ? { pr: filter.pr }
+    : filter.sha !== undefined
+      ? { sha: filter.sha }
+      : { runs_id: filter.checkRunId }
+
+  return JSON.stringify({
+    repo: `${filter.owner}/${filter.repo}`,
+    ...target,
+    ...(filter.mode === undefined ? {} : { mode: filter.mode }),
+    ...(filter.headSha === undefined ? {} : { headSha: filter.headSha }),
+    ...(filter.workId === undefined ? {} : { workId: filter.workId }),
+    ...(filter.allowNoChecksAfterSeconds === DEFAULT_NO_CHECKS_GRACE_SECONDS
+      ? {}
+      : { allowNoChecksAfterSeconds: filter.allowNoChecksAfterSeconds }),
+  })
+}
+
+function pendingResult(awaitId: string, filter: GitHubCIFilter, needsNormalization: boolean): CheckResult {
+  return needsNormalization
+    ? { awaitId, matched: false, filterUpdate: serializeGitHubCIFilter(filter) }
+    : { awaitId, matched: false }
+}
 
 async function resolveTarget(filter: GitHubCIFilter): Promise<ResolvedCITarget | null> {
   let ref = filter.sha
@@ -220,8 +263,11 @@ function buildTerminalResult(awaitId: string, target: ResolvedCITarget, filter: 
   // headSha mismatch means the await is stale (new push happened).
   // Silently update the filter to track the new head instead of resuming.
   if (target.currentHeadSha !== target.ref) {
-    const updatedFilter = { ...filter, headSha: target.currentHeadSha, targetUrl: null }
-    return { awaitId, matched: false, filterUpdate: JSON.stringify(updatedFilter) }
+    return {
+      awaitId,
+      matched: false,
+      filterUpdate: serializeGitHubCIFilter({ ...filter, headSha: target.currentHeadSha }),
+    }
   }
 
   const outcome = target.merged
@@ -528,6 +574,7 @@ export const githubCISource: SessionAwaitSource = {
 
     for (const row of awaits) {
       const filter = GitHubCIFilterJsonSchema.parse(row.filterJson)
+      const needsNormalization = isLegacyGitHubCIFilter(row.filterJson)
       const perAwaitBypassed = row.bypassedChecksJson ? JSON.parse(row.bypassedChecksJson) as string[] : []
 
       let target: ResolvedCITarget | null
@@ -579,7 +626,7 @@ export const githubCISource: SessionAwaitSource = {
       }
 
       if (workflowAggregate.pendingCount) {
-        results.push({ awaitId: row.id, matched: false })
+        results.push(pendingResult(row.id, filter, needsNormalization))
         continue
       }
 
@@ -601,13 +648,13 @@ export const githubCISource: SessionAwaitSource = {
           })
         }
         else {
-          results.push({ awaitId: row.id, matched: false })
+          results.push(pendingResult(row.id, filter, needsNormalization))
         }
         continue
       }
 
       if (!aggregate.allCompleted) {
-        results.push({ awaitId: row.id, matched: false })
+        results.push(pendingResult(row.id, filter, needsNormalization))
         continue
       }
 

--- a/apps/server/tests/session-await-github.test.ts
+++ b/apps/server/tests/session-await-github.test.ts
@@ -242,6 +242,85 @@ describe('gitHub session-await sources', () => {
     expect(JSON.parse(result.resumePayloadJson ?? '{}')).toMatchObject({ outcome: 'merged' })
   })
 
+  it('serializes a CI head update with the canonical full repository name', async () => {
+    installGitHubFetch({
+      '/repos/acme/app/pulls/42': {
+        number: 42,
+        title: 'Ship feature',
+        state: 'open',
+        merged: false,
+        mergeable: true,
+        head: { sha: 'new-head-sha', ref: 'feature' },
+        base: { ref: 'main' },
+      },
+    })
+
+    const [result] = await githubCISource.checkPending([
+      awaitRow({ repo: 'acme/app', pr: 42, headSha: 'old-head-sha', workId: 'work-1' }),
+    ])
+
+    expect(result).toEqual({
+      awaitId: 'await-1',
+      matched: false,
+      filterUpdate: JSON.stringify({
+        repo: 'acme/app',
+        pr: 42,
+        headSha: 'new-head-sha',
+        workId: 'work-1',
+      }),
+    })
+  })
+
+  it('normalizes a malformed pending CI await from the old head-update serializer', async () => {
+    installGitHubFetch({
+      '/repos/acme/app/pulls/42': {
+        number: 42,
+        title: 'Ship feature',
+        state: 'open',
+        merged: false,
+        mergeable: true,
+        head: { sha: 'head-sha', ref: 'feature' },
+        base: { ref: 'main' },
+      },
+      '/repos/acme/app/commits/head-sha/check-runs?per_page=100&page=1': {
+        total_count: 0,
+        check_runs: [],
+      },
+      '/repos/acme/app/commits/head-sha/status': {
+        state: 'success',
+        total_count: 0,
+        statuses: [],
+      },
+      '/repos/acme/app/actions/runs?head_sha=head-sha&per_page=100&page=1': {
+        total_count: 0,
+        workflow_runs: [],
+      },
+    })
+
+    const [result] = await githubCISource.checkPending([
+      awaitRow({
+        owner: 'acme',
+        repo: 'app',
+        pr: 42,
+        headSha: 'head-sha',
+        workId: 'work-1',
+        statusRef: '',
+        targetUrl: null,
+      }),
+    ])
+
+    expect(result).toEqual({
+      awaitId: 'await-1',
+      matched: false,
+      filterUpdate: JSON.stringify({
+        repo: 'acme/app',
+        pr: 42,
+        headSha: 'head-sha',
+        workId: 'work-1',
+      }),
+    })
+  })
+
   it('resumes with a failure payload when any check or status fails', async () => {
     installGitHubFetch({
       '/repos/acme/app/commits/bad-sha/check-runs?per_page=100&page=1': {


### PR DESCRIPTION
## Summary
Serialize GitHub CI head updates using the persisted owner/repo form and accept then normalize legacy split owner/repo pending awaits. Add regression coverage for both the head update and self-healing path.

## Test plan
pnpm --filter @cradle/server exec vitest run tests/session-await-github.test.ts
pnpm --filter @cradle/server typecheck

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)