### PR TITLE
docs(agents): document Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,3 +168,27 @@ function Button({ variant = 'primary', size = 'md', className, ...props }: Butto
 
 - **Always use Drizzle**: For database interactions, use Drizzle ORM to ensure type safety and consistency. Avoid raw SQL queries or other database libraries. Use drizzle-kit for schema management and migrations.
 - **During code review**: Check for missing or outdated documentation
+
+## Cursor Cloud specific instructions
+
+Scope set up here: the core Cradle product in **web mode** — the `@cradle/server` backend (Elysia, `:21423`) + `@cradle/web` frontend (Vite, `:5174`). Dependencies install via the update script (`pnpm install`). Standard lint/test/build/dev commands live in root `package.json` and are documented in `README.md` / per-package `AGENTS.md`; reference those rather than duplicating.
+
+### Node version (important, non-obvious)
+
+- The VM's default `node` on `PATH` is `/exec-daemon/node` (v22.14.0), which is **missing `node:zlib` `zstdCompressSync`** (added in Node 22.15). This makes `relay-transport` compression code and its tests fail with `TypeError: zstdCompressSync is not a function`.
+- A newer Node is installed via nvm (`v22.22.2`, has zstd) but it sits **after** `/exec-daemon` on `PATH`, so `nvm use` alone does not win. To use it, prepend its bin explicitly in the shell that runs the server/tests:
+  `export PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" && hash -r`
+- Run tests and dev servers with this newer Node for CI parity. The core web+server app also boots on the default v22.14.0, but relay/zstd paths will error.
+
+### Running the app (web mode)
+
+- The server needs env vars (it does NOT auto-load `.env`; the schema throws without them): set `CRADLE_DATA_DIR=<writable dir>` and `CRADLE_CREDENTIAL_SECRET=<any string>` before starting.
+- Start both dev servers: `CRADLE_DATA_DIR=/workspace/.dev-data CRADLE_CREDENTIAL_SECRET=dev-secret pnpm dev:fullstack`. Web → `http://localhost:5174`, API → `http://127.0.0.1:21423` (e.g. `GET /workspaces`). SQLite is embedded and auto-migrates on boot.
+- On startup the server tries to auto-start the optional Go `relayd` daemon and logs `local relayd did not become ready ... ECONNREFUSED` when Go isn't installed. This is harmless for core dev; set `CRADLE_RELAYD_AUTOSTART=0` to silence it.
+- The in-app folder picker for "Add project" is restricted to allowed roots = the home dir plus already-added workspaces. To add a repo via the UI picker, place it under `$HOME` (e.g. `~/dev/<repo>`); the picker has a "dev" shortcut. Sending chat messages requires a configured LLM provider (API key) — not available by default, so provider-dependent flows can't be exercised end-to-end without credentials.
+
+### Tests
+
+- `pnpm test` (root unit) and `pnpm test:server` mostly pass (2200+ tests). With the newer Node, remaining failures are a handful of agent/chat-runtime **streaming tests that time out at 5000ms** (e.g. in `apps/server/tests/chat-runtime.test.ts`, `sdk-providers.test.ts`) — these use mocked SDKs but are timing-sensitive and also fail in isolation on this VM; treat as environment/timing flakiness, not a setup regression.
+- `pnpm lint` runs but reports 2 pre-existing repo errors (missing EOL newline in `apps/landing/public/{blog,changelog}/index.json`) unrelated to setup.
+- Desktop mode (`pnpm dev:desktop`, Electron) is not exercised here (no display); web mode is the supported path in this environment.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cradle development environment (web mode) for Cursor Cloud agents and records durable, non-obvious setup caveats in `AGENTS.md`.

The only code change is an appended `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code was modified. The dependency-refresh update script is configured separately as `pnpm install`.

## What was verified

- **Install**: `pnpm install` (native modules `better-sqlite3` / `node-pty` build fine).
- **Lint**: `pnpm lint` runs. 2 pre-existing repo errors (missing EOL newline in `apps/landing/public/{blog,changelog}/index.json`), unrelated to setup.
- **Tests**: `pnpm test` and `pnpm test:server` — 2200+ tests pass. Remaining failures are a handful of timing-sensitive agent/chat-runtime streaming tests (5s timeouts, fail in isolation too) and are documented as environment flakiness.
- **Build**: `pnpm build:web` and `pnpm build:server` both succeed.
- **Run + hello-world**: `pnpm dev:fullstack` (web `:5174`, API `:21423`, embedded SQLite). Added a project (`hello-cradle`) through the UI folder picker; it persisted across reload and opened into the workspace view.

## Key findings captured in AGENTS.md

- The VM default `node` (`/exec-daemon/node`, v22.14.0) lacks `node:zlib` `zstdCompressSync`; use the nvm-installed `v22.22.2` (prepend its bin to `PATH`) for CI parity, since `/exec-daemon` precedes nvm on `PATH`.
- The server does not auto-load `.env`; `CRADLE_DATA_DIR` and `CRADLE_CREDENTIAL_SECRET` must be exported.
- Optional Go `relayd` autostart logs a harmless `ECONNREFUSED` when Go is absent (`CRADLE_RELAYD_AUTOSTART=0` to silence).
- The "Add project" folder picker is restricted to `$HOME` + existing workspaces; chat requires an LLM provider key (not available by default).

## Demo

[cradle_add_project_hello_world-2.mp4](https://cursor.com/agents/bc-622f6076-33ef-4e9e-b79c-0ad59acc5576/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcradle_add_project_hello_world-2.mp4)

[Empty projects state](https://cursor.com/agents/bc-622f6076-33ef-4e9e-b79c-0ad59acc5576/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcradle_empty_projects.webp)
[hello-cradle project opened](https://cursor.com/agents/bc-622f6076-33ef-4e9e-b79c-0ad59acc5576/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcradle_project_opened.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-622f6076-33ef-4e9e-b79c-0ad59acc5576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-622f6076-33ef-4e9e-b79c-0ad59acc5576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

