### PR TITLE
fix(desktop): supervise complete server bootstrap

### DIFF
--- a/apps/desktop/src/main/README.md
+++ b/apps/desktop/src/main/README.md
@@ -20,7 +20,7 @@
 - `window-state.ts`：拥有主窗口 bounds 恢复校正逻辑，以及 tear-off window 的 size-only 持久化 helper；主窗口在 `electron-window-state` 持久化基础上按当前 display workArea 修正大小和位置，tear-off 只保存宽高不保存位置。
 - `window-manager.ts`：拥有 Electron window lifecycle 和 renderer/server URL 连接；session tear-off window 从专用 renderer entry 初始化、按释放点选择目标 display，在释放点附近打开并限制在目标 workArea 内、只记忆宽高，同一 session 的重复 open 会聚合到已登记窗口，并在关闭时通知 main renderer 恢复对应 main-window chat tab。
 - `window-manager.test.ts`：覆盖 session tear-off window 并发 open 去重，以及 renderer load 失败时清理 pending session 窗口。
-- `server-process.ts`：拥有 server 子进程启动、复用、显式停止、环境变量注入、Cradle app version 投影，以及 desktop-owned credential secret 文件；packaged runtime 只启动 `@cradle/server` 产出的 `dist/desktop-runtime` artifact；server ready 后写入 Desktop-owned CLI server locator，普通 App 退出只 detach 并保留 locator 供下次重连，更新/重启等显式 runtime 替换路径才停止 server。
+- `server-process.ts`：拥有 server 子进程启动、复用、显式停止、环境变量注入、Cradle app version 投影，以及 desktop-owned credential secret 文件；packaged runtime 只启动 `@cradle/server` 产出的 `dist/desktop-runtime` artifact。Server 通过嵌套 managed-process IPC 发送有时间戳的 migration、maintenance、persisted-run recovery、service initialization、plugin activation 和 listener establishment 生命周期事实；Desktop 保留最新 snapshot，并以全局和每 phase watchdog 监督它。只有实际 listen callback 的 `ready` 事件和 `/health` 成功才算 ready；超时诊断包含当前 phase、phase 时长、最后事件和最近 server 输出。server ready 后写入 Desktop-owned CLI server locator，普通 App 退出只 detach 并保留 locator 供下次重连，更新/重启等显式 runtime 替换路径才停止 server。
 - `data-directory.ts`：拥有可移动的 server 数据根、固定 bootstrap pointer 和 crash-safe 迁移状态机。Electron `userData`、CLI locator、缓存和 updater state 始终留在默认位置；迁移只复制 server data tree，校验 SHA-256 后切换 pointer，并且仅在新 root server ready 后把旧 root 重命名为 `.bak-*`。备份删除是独立显式操作，不与迁移事务绑定。
 - `native-services.ts`：拥有 main-process native IPC service 注册，包括 native dialog/path launch IPC、Desktop CLI install IPC、desktop chat stream broker IPC、Claude / Codex 会话文件的只读本机采样、Mac Appshot Cradle-native capture orchestration、Cradle-native image asset projection、Appshot source-window target locking、Codex temp asset observe-only evidence collection, and Appshot parity probe orchestration.
 - `desktop-cli-manager.ts`：拥有 packaged macOS Desktop CLI command lifecycle；读取 bundled launcher、检查 `/usr/local/bin/cradle` symlink 状态，并通过显式用户操作安装、修复或移除 PATH command。权限提升只用于 symlink 写入，不修改 shell rc 文件。
@@ -65,6 +65,7 @@
 `update-manager.ts` owns the renderer-visible Desktop Updates workflow. The explicit user flow is Check, Download, then Restart on Windows. On macOS, Cradle only opens Sparkle's native update UI; Sparkle exclusively owns discovery, download, installation, relaunch, and their state.
 
 Updates are available only in packaged macOS and Windows builds with update feeds configured:
+
 - macOS: `CRADLE_DESKTOP_SPARKLE_APPCAST_URL` (or derive `appcast.xml` from `CRADLE_DESKTOP_UPDATE_URL`) plus `SPARKLE_ED_PUBLIC_KEY`
 - Windows: `CRADLE_DESKTOP_UPDATE_URL` generic feed root containing `latest.yml`
 

--- a/apps/desktop/src/main/main-app.ts
+++ b/apps/desktop/src/main/main-app.ts
@@ -3,8 +3,9 @@ import { join, resolve } from 'node:path'
 import { app, BrowserWindow, dialog, ipcMain, nativeTheme, screen } from 'electron'
 import windowStateKeeper from 'electron-window-state'
 
-import type { DesktopServerStatus } from '../shared/server-runtime'
+import type { DesktopServerBootstrapSnapshot, DesktopServerStatus } from '../shared/server-runtime'
 import {
+  createDesktopServerBootstrapSnapshot,
   DESKTOP_SERVER_STATUS_CHANGED_CHANNEL,
   DESKTOP_SERVER_STATUS_GET_CHANNEL,
 } from '../shared/server-runtime'
@@ -37,9 +38,7 @@ import {
 } from './desktop-assets'
 import { DesktopDownloadCenterService } from './download-center'
 import { installExternalLinkPolicy } from './external-link-policy'
-import {
-  initializeIpcDevtool,
-} from './ipc-devtool'
+import { initializeIpcDevtool } from './ipc-devtool'
 import { MacBridgeManager } from './mac-bridge-manager'
 import type { MacInputBareModifier } from './mac-bridge-protocol'
 import { createNativeServices } from './native-services'
@@ -75,7 +74,12 @@ import {
   syncAllDesktopLayerSources,
 } from './plugin-source-sync'
 import { QuitGuard } from './quit-guard'
-import { getDesktopServerAuthHeaders, getDesktopServerAuthToken, startServer, stopServer } from './server-process'
+import {
+  getDesktopServerAuthHeaders,
+  getDesktopServerAuthToken,
+  startServer,
+  stopServer,
+} from './server-process'
 import { TrayManager } from './tray-manager'
 import { DesktopUpdateManager } from './update-manager'
 import { WindowManager } from './window-manager'
@@ -111,6 +115,7 @@ let canProcessOpenWorkspaceLinks = false
 const pendingOpenWorkspaceUrls: string[] = []
 const browserManager = new DesktopBrowserManager()
 let desktopServerStatus: DesktopServerStatus = { state: 'starting' }
+let desktopServerBootstrapSnapshot: DesktopServerBootstrapSnapshot | null = null
 
 async function readRendererRuntimeDiagnostics(): Promise<Array<Record<string, unknown>>> {
   const windows = BrowserWindow.getAllWindows().filter(window => !window.isDestroyed())
@@ -126,19 +131,20 @@ async function readRendererRuntimeDiagnostics(): Promise<Array<Record<string, un
       url: webContents.getURL(),
     }
     try {
-      const renderer = await webContents.executeJavaScript(
+      const renderer = (await webContents.executeJavaScript(
         'globalThis.__CRADLE_RENDERER_DIAGNOSTICS__?.() ?? null',
         true,
-      ) as unknown
+      )) as unknown
       diagnostics.push({ ...base, renderer })
     }
-    catch (error) {
+ catch (error) {
       diagnostics.push({
         ...base,
         renderer: null,
-        error: error instanceof Error
-          ? { name: error.name, message: error.message, stack: error.stack }
-          : { message: String(error) },
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message, stack: error.stack }
+            : { message: String(error) },
       })
     }
   }
@@ -438,15 +444,16 @@ async function openWorkspaceFromDeepLink(rawUrl: string): Promise<void> {
     }
     await trayManager.performAction('open-workspace', { workspaceId: request.workspaceId })
   }
-  catch (err) {
+ catch (err) {
     console.error('[open-workspace] deep link failed:', err)
     const message = err instanceof Error ? err.message : String(err)
     await dialog.showMessageBox({
       type: 'error',
       title: 'Open Workspace Failed',
-      message: err instanceof OpenWorkspaceLinkError
-        ? 'The open workspace link is invalid.'
-        : 'Cradle could not open the workspace.',
+      message:
+        err instanceof OpenWorkspaceLinkError
+          ? 'The open workspace link is invalid.'
+          : 'Cradle could not open the workspace.',
       detail: message,
       buttons: ['OK'],
     })
@@ -471,7 +478,9 @@ function processPendingOpenWorkspaceUrls(): void {
 
 async function shutdownDesktopRuntime(options: { stopServerRuntime: boolean }): Promise<void> {
   if (!options.stopServerRuntime) {
-    console.warn('[desktop] stopServerRuntime=false is ignored; desktop-owned server will be stopped')
+    console.warn(
+      '[desktop] stopServerRuntime=false is ignored; desktop-owned server will be stopped',
+    )
   }
 
   browserManager.dispose()
@@ -496,7 +505,11 @@ async function shutdownDesktopRuntime(options: { stopServerRuntime: boolean }): 
   await stopServer()
 }
 
-function requestDesktopExit(input: { reason: string, exitCode: number, stopServerRuntime: boolean }): void {
+function requestDesktopExit(input: {
+  reason: string
+  exitCode: number
+  stopServerRuntime: boolean
+}): void {
   if (shutdownPromise) {
     return
   }
@@ -523,7 +536,10 @@ function requestDesktopExit(input: { reason: string, exitCode: number, stopServe
     })
 }
 
-async function prepareDesktopExitForExternalQuit(input: { reason: string, stopServerRuntime: boolean }): Promise<void> {
+async function prepareDesktopExitForExternalQuit(input: {
+  reason: string
+  stopServerRuntime: boolean
+}): Promise<void> {
   if (shutdownPromise) {
     await shutdownPromise
     return
@@ -531,10 +547,11 @@ async function prepareDesktopExitForExternalQuit(input: { reason: string, stopSe
 
   console.warn(`[desktop] preparing runtime shutdown: ${input.reason}`)
   isQuitting = true
-  shutdownPromise = shutdownDesktopRuntime({ stopServerRuntime: input.stopServerRuntime })
-    .catch((error) => {
+  shutdownPromise = shutdownDesktopRuntime({ stopServerRuntime: input.stopServerRuntime }).catch(
+    (error) => {
       console.error('[desktop] runtime shutdown failed:', error)
-    })
+    },
+  )
   await shutdownPromise
 }
 
@@ -552,7 +569,10 @@ function registerProcessShutdownHandlers(): void {
   process.once('SIGTERM', handleSignal)
 }
 
-async function applyAppshotHotkeyPreference(enabled: boolean, trigger: MacInputBareModifier = 'DoubleCommand'): Promise<void> {
+async function applyAppshotHotkeyPreference(
+  enabled: boolean,
+  trigger: MacInputBareModifier = 'DoubleCommand',
+): Promise<void> {
   if (process.platform !== 'darwin' || !macBridgeManager) {
     return
   }
@@ -571,7 +591,9 @@ async function applyAppshotHotkeyPreference(enabled: boolean, trigger: MacInputB
 
 async function syncDesktopPreferencesFromServer(serverUrl: string): Promise<void> {
   try {
-    const response = await fetch(new URL('/preferences/desktop', serverUrl), { headers: getDesktopServerAuthHeaders() })
+    const response = await fetch(new URL('/preferences/desktop', serverUrl), {
+      headers: getDesktopServerAuthHeaders(),
+    })
     if (!response.ok) {
       await applyAppshotHotkeyPreference(true)
       updateManager?.configurePreferences({
@@ -580,7 +602,7 @@ async function syncDesktopPreferencesFromServer(serverUrl: string): Promise<void
       })
       return
     }
-    const preferences = await response.json() as DesktopRuntimePreferences
+    const preferences = (await response.json()) as DesktopRuntimePreferences
     quitGuard.updatePreferences({
       requireDoubleCommandQToQuit: preferences.requireDoubleCommandQToQuit,
     })
@@ -593,7 +615,7 @@ async function syncDesktopPreferencesFromServer(serverUrl: string): Promise<void
       autoDownloadUpdates: preferences.autoDownloadUpdates,
     })
   }
-  catch (error) {
+ catch (error) {
     console.warn('[preferences] failed to read desktop preferences:', error)
     await applyAppshotHotkeyPreference(true)
     updateManager?.configurePreferences({
@@ -703,10 +725,13 @@ export async function startDesktopApp(): Promise<void> {
   })
   macBridgeManager.on('hotkeyTriggered', (event) => {
     console.log('[mac-bridge] forwarding Appshot hotkey to renderer:', event)
-    const targetWindow = windowManager?.getLastFocusedAppshotWindow()
-      ?? (mainWindow && !mainWindow.isDestroyed() ? mainWindow : null)
+    const targetWindow
+      = windowManager?.getLastFocusedAppshotWindow()
+        ?? (mainWindow && !mainWindow.isDestroyed() ? mainWindow : null)
     if (!targetWindow || targetWindow.isDestroyed()) {
-      console.warn('[mac-bridge] Appshot hotkey ignored because no Appshot renderer window is available.')
+      console.warn(
+        '[mac-bridge] Appshot hotkey ignored because no Appshot renderer window is available.',
+      )
       return
     }
     targetWindow.webContents.send('capture:appshot-hotkey', event)
@@ -746,96 +771,110 @@ export async function startDesktopApp(): Promise<void> {
     handlePluginInstallUrls([url])
   })
 
-  app.whenReady().then(async () => {
-    await initializeDesktopDataDirectory()
-    desktopDownloadCenter = new DesktopDownloadCenterService({ userDataPath: app.getPath('userData') })
-    await desktopDownloadCenter.boot()
-    await updateManager?.recoverDownloadCenter(desktopDownloadCenter)
-    desktopDownloadCenter.onTaskChange((task) => {
-      for (const window of BrowserWindow.getAllWindows()) {
-        if (!window.isDestroyed()) {
-          window.webContents.send('download-center:task-changed', task)
+  app
+    .whenReady()
+    .then(async () => {
+      await initializeDesktopDataDirectory()
+      desktopDownloadCenter = new DesktopDownloadCenterService({
+        userDataPath: app.getPath('userData'),
+      })
+      await desktopDownloadCenter.boot()
+      await updateManager?.recoverDownloadCenter(desktopDownloadCenter)
+      desktopDownloadCenter.onTaskChange((task) => {
+        for (const window of BrowserWindow.getAllWindows()) {
+          if (!window.isDestroyed()) {
+            window.webContents.send('download-center:task-changed', task)
+          }
         }
-      }
-    })
-    appBadgeManager.initialize()
-    mainWindow = await createMainWindow()
-    setMainWindow(mainWindow)
+      })
+      appBadgeManager.initialize()
+      mainWindow = await createMainWindow()
+      setMainWindow(mainWindow)
 
-    app.on('activate', async () => {
-      if (!mainWindow || mainWindow.isDestroyed()) {
-        const restoredWindow = await createMainWindow()
-        setMainWindow(restoredWindow)
-        return
-      }
-      showMainWindow()
-    })
+      app.on('activate', async () => {
+        if (!mainWindow || mainWindow.isDestroyed()) {
+          const restoredWindow = await createMainWindow()
+          setMainWindow(restoredWindow)
+          return
+        }
+        showMainWindow()
+      })
 
-    void (async () => {
-      publishDesktopServerStatus({ state: 'starting' })
-      try {
-        if (process.platform === 'darwin') {
-          await macBridgeManager?.start()
-        }
-        await activateDesktopPlugins()
-        processPendingPluginInstallUrls()
-        handlePluginInstallUrls(collectPluginInstallUrls(process.argv))
-        handleOpenWorkspaceUrls(collectOpenWorkspaceUrls(process.argv))
-
-        const pendingDataMigration = getDesktopDataDirectoryState().pendingMigration
-        if (pendingDataMigration && !['completed', 'failed'].includes(pendingDataMigration.phase)) {
-          // A previous process may have survived a desktop crash. Stop its
-          // located server before copying the filesystem tree.
-          await stopServer()
-        }
-        const migration = await runPendingDesktopDataMigration((phase) => {
-          publishDesktopServerStatus({ state: 'migrating', phase })
-        })
-        if (migration.failed) {
-          console.error('[desktop] data migration failed:', migration.message)
-        }
-
-        let serverUrl: string
-        const publishServerStartupPhase = (phase: 'migrating' | 'compacting') => {
-          publishDesktopServerStatus(
-            phase === 'compacting'
-              ? { state: 'compacting' }
-              : { state: 'migrating', phase: 'database' },
-          )
-        }
+      void (async () => {
+        publishDesktopServerStatus({ state: 'starting' })
         try {
-          serverUrl = await startServer(publishServerStartupPhase)
-        }
-        catch (error) {
-          await rollbackDesktopDataMigrationAfterHealthFailure(error instanceof Error ? error.message : String(error))
-          if (migration.migrated) {
-            console.error('[desktop] new data root failed health check; restored previous root')
-            serverUrl = await startServer(publishServerStartupPhase)
+          if (process.platform === 'darwin') {
+            await macBridgeManager?.start()
           }
-          else {
-            throw error
+          await activateDesktopPlugins()
+          processPendingPluginInstallUrls()
+          handlePluginInstallUrls(collectPluginInstallUrls(process.argv))
+          handleOpenWorkspaceUrls(collectOpenWorkspaceUrls(process.argv))
+
+          const pendingDataMigration = getDesktopDataDirectoryState().pendingMigration
+          if (
+            pendingDataMigration
+            && !['completed', 'failed'].includes(pendingDataMigration.phase)
+          ) {
+            // A previous process may have survived a desktop crash. Stop its
+            // located server before copying the filesystem tree.
+            await stopServer()
           }
+          const migration = await runPendingDesktopDataMigration((phase) => {
+            publishDesktopServerStatus({ state: 'migrating', phase })
+          })
+          if (migration.failed) {
+            console.error('[desktop] data migration failed:', migration.message)
+          }
+
+          let serverUrl: string
+          desktopServerBootstrapSnapshot = createDesktopServerBootstrapSnapshot()
+          const publishServerBootstrapSnapshot = (snapshot: DesktopServerBootstrapSnapshot) => {
+            desktopServerBootstrapSnapshot = snapshot
+            publishDesktopServerStatus({ state: 'bootstrapping', bootstrap: snapshot })
+          }
+          try {
+            serverUrl = await startServer(publishServerBootstrapSnapshot)
+          }
+ catch (error) {
+            await rollbackDesktopDataMigrationAfterHealthFailure(
+              error instanceof Error ? error.message : String(error),
+            )
+            if (migration.migrated) {
+              console.error('[desktop] new data root failed health check; restored previous root')
+              desktopServerBootstrapSnapshot = createDesktopServerBootstrapSnapshot()
+              serverUrl = await startServer(publishServerBootstrapSnapshot)
+            }
+ else {
+              throw error
+            }
+          }
+          initializeDesktopServicesForServer(serverUrl)
+          await completeDesktopDataMigrationAfterHealthyStart()
+          publishDesktopServerStatus({
+            state: 'ready',
+            serverUrl,
+            bootstrap: desktopServerBootstrapSnapshot ?? createDesktopServerBootstrapSnapshot(),
+          })
         }
-        initializeDesktopServicesForServer(serverUrl)
-        await completeDesktopDataMigrationAfterHealthyStart()
-        publishDesktopServerStatus({ state: 'ready', serverUrl })
-      }
-      catch (error) {
-        console.error('[desktop] runtime startup failed:', error)
-        publishDesktopServerStatus({
-          state: 'failed',
-          message: error instanceof Error ? error.message : String(error),
-        })
-      }
-    })()
-  }).catch((error) => {
-    console.error('[desktop] app startup failed:', error)
-    requestDesktopExit({
-      reason: 'startup failure',
-      exitCode: 1,
-      stopServerRuntime: true,
+ catch (error) {
+          console.error('[desktop] runtime startup failed:', error)
+          publishDesktopServerStatus({
+            state: 'failed',
+            message: error instanceof Error ? error.message : String(error),
+            bootstrap: desktopServerBootstrapSnapshot,
+          })
+        }
+      })()
     })
-  })
+    .catch((error) => {
+      console.error('[desktop] app startup failed:', error)
+      requestDesktopExit({
+        reason: 'startup failure',
+        exitCode: 1,
+        stopServerRuntime: true,
+      })
+    })
 
   app.on('window-all-closed', () => {
     if (!trayManager && process.platform !== 'darwin') {

--- a/apps/desktop/src/main/managed-process-protocol.test.ts
+++ b/apps/desktop/src/main/managed-process-protocol.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { forwardManagedTargetMessage } from './managed-process-protocol'
+
+describe('managed process IPC forwarding', () => {
+  it('preserves server bootstrap events inside the runner envelope', () => {
+    const bootstrapEvent = {
+      type: 'cradle-server-bootstrap' as const,
+      phase: 'persisted-run-recovery',
+      kind: 'started' as const,
+      at: '2026-07-24T00:00:00.000Z',
+    }
+
+    expect(forwardManagedTargetMessage(bootstrapEvent)).toEqual({
+      type: 'target-message',
+      message: bootstrapEvent,
+    })
+  })
+})

--- a/apps/desktop/src/main/managed-process-protocol.ts
+++ b/apps/desktop/src/main/managed-process-protocol.ts
@@ -1,0 +1,7 @@
+/** Preserve target IPC payloads while the runner adds its ownership envelope. */
+export function forwardManagedTargetMessage(message: unknown): {
+  type: 'target-message'
+  message: unknown
+} {
+  return { type: 'target-message', message }
+}

--- a/apps/desktop/src/main/managed-process-runner.ts
+++ b/apps/desktop/src/main/managed-process-runner.ts
@@ -1,6 +1,8 @@
 import type { ChildProcess } from 'node:child_process'
 import { fork, spawn } from 'node:child_process'
 
+import { forwardManagedTargetMessage } from './managed-process-protocol'
+
 interface BaseTarget {
   cwd?: string
   env?: Record<string, string | undefined>
@@ -71,12 +73,12 @@ function signalChild(signal: NodeJS.Signals): boolean {
     if (process.platform !== 'win32') {
       process.kill(-pid, signal)
     }
-    else {
+ else {
       child.kill(signal)
     }
     return true
   }
-  catch (error) {
+ catch (error) {
     if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ESRCH') {
       return false
     }
@@ -108,7 +110,7 @@ try {
   }
   child.stdout?.pipe(process.stdout)
   child.stderr?.pipe(process.stderr)
-  child.on('message', message => emitStatus({ type: 'target-message', message }))
+  child.on('message', message => emitStatus(forwardManagedTargetMessage(message)))
   child.once('error', (error) => {
     emitStatus({ type: 'error', message: error.message })
     process.exit(1)
@@ -118,7 +120,7 @@ try {
     process.exit(code ?? (signal ? 1 : 0))
   })
 }
-catch (error) {
+ catch (error) {
   emitStatus({ type: 'error', message: error instanceof Error ? error.message : String(error) })
   process.exit(1)
 }

--- a/apps/desktop/src/main/server-process.test.ts
+++ b/apps/desktop/src/main/server-process.test.ts
@@ -2,7 +2,13 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { DesktopServerBootstrapSnapshot } from '../shared/server-runtime'
+import {
+  applyServerBootstrapEvent,
+  createDesktopServerBootstrapSnapshot,
+} from '../shared/server-runtime'
 
 const electronMocks = vi.hoisted(() => ({
   app: {
@@ -16,28 +22,220 @@ const electronMocks = vi.hoisted(() => ({
 
 vi.mock('electron', () => electronMocks)
 
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('desktop server readiness', () => {
+  it.each(['database-migration', 'database-maintenance'] as const)(
+    'allows %s to run beyond the former 90 second deadline',
+    async (phase) => {
+      vi.useFakeTimers()
+      const startedAt = Date.now()
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => {
+          if (Date.now() - startedAt >= 91_000) {
+            return { ok: true }
+          }
+          throw new Error('not listening')
+        }),
+      )
+      const { waitForServer } = await import('./server-process')
+      let snapshot = applyServerBootstrapEvent(createDesktopServerBootstrapSnapshot(), {
+        type: 'cradle-server-bootstrap',
+        phase,
+        kind: 'started',
+        at: new Date(startedAt).toISOString(),
+      })
+
+      const ready = waitForServer('http://127.0.0.1:21423', {
+        bootstrapWatchdog: {
+          globalTimeoutMs: 180_000,
+          phaseTimeoutMs: 120_000,
+          readSnapshot: () => snapshot,
+        },
+      })
+      await vi.advanceTimersByTimeAsync(90_800)
+      snapshot = finishBootstrap(snapshot)
+      await vi.advanceTimersByTimeAsync(200)
+
+      await expect(ready).resolves.toBeUndefined()
+    },
+  )
+
+  it('allows delayed persisted-run recovery before the listener becomes healthy', async () => {
+    vi.useFakeTimers()
+    const startedAt = Date.now()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        if (Date.now() - startedAt >= 91_000) {
+          return { ok: true }
+        }
+        throw new Error('not listening')
+      }),
+    )
+    const { waitForServer } = await import('./server-process')
+    let snapshot = applyServerBootstrapEvent(createDesktopServerBootstrapSnapshot(), {
+      type: 'cradle-server-bootstrap',
+      phase: 'persisted-run-recovery',
+      kind: 'started',
+      at: new Date(startedAt).toISOString(),
+    })
+
+    const ready = waitForServer('http://127.0.0.1:21423', {
+      bootstrapWatchdog: {
+        globalTimeoutMs: 180_000,
+        phaseTimeoutMs: 120_000,
+        readSnapshot: () => snapshot,
+      },
+    })
+    await vi.advanceTimersByTimeAsync(90_800)
+    snapshot = finishBootstrap(snapshot)
+    await vi.advanceTimersByTimeAsync(200)
+
+    await expect(ready).resolves.toBeUndefined()
+  })
+
+  it('includes the stalled phase and last event in watchdog diagnostics', async () => {
+    vi.useFakeTimers()
+    const startedAt = Date.now()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('not listening')
+      }),
+    )
+    const { waitForServer } = await import('./server-process')
+    const snapshot = applyServerBootstrapEvent(createDesktopServerBootstrapSnapshot(), {
+      type: 'cradle-server-bootstrap',
+      phase: 'persisted-run-recovery',
+      kind: 'started',
+      at: new Date(startedAt).toISOString(),
+    })
+
+    const ready = waitForServer('http://127.0.0.1:21423', {
+      bootstrapWatchdog: {
+        globalTimeoutMs: 1_000,
+        phaseTimeoutMs: 400,
+        readSnapshot: () => snapshot,
+      },
+    })
+    const expectation = expect(ready).rejects.toThrow(
+      'Last bootstrap phase: "persisted-run-recovery". Phase duration: 400ms. Last known bootstrap event: started:persisted-run-recovery',
+    )
+    await vi.advanceTimersByTimeAsync(400)
+
+    await expectation
+  })
+
+  it('keeps bounded readiness probes for located servers', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('not listening')
+      }),
+    )
+    const { waitForServer } = await import('./server-process')
+
+    const ready = waitForServer('http://127.0.0.1:21423', { timeoutMs: 400 })
+    const expectation = expect(ready).rejects.toThrow('Server failed to start within 400ms')
+    await vi.advanceTimersByTimeAsync(400)
+
+    await expectation
+  })
+
+  it('requires the listener ready lifecycle event in addition to health', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })))
+    const { waitForServer } = await import('./server-process')
+
+    const ready = waitForServer('http://127.0.0.1:21423', {
+      bootstrapWatchdog: {
+        globalTimeoutMs: 1_000,
+        phaseTimeoutMs: 400,
+        readSnapshot: createDesktopServerBootstrapSnapshot,
+      },
+    })
+    const expectation = expect(ready).rejects.toThrow('Server bootstrap global timeout after 1000ms')
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await expectation
+  })
+
+  it('accepts bootstrap events forwarded through the nested managed-process envelope', async () => {
+    const { readServerBootstrapEvent } = await import('./server-process')
+
+    expect(
+      readServerBootstrapEvent({
+        type: 'target-message',
+        message: {
+          type: 'cradle-server-bootstrap',
+          phase: 'listener-establishment',
+          kind: 'ready',
+          at: '2026-07-24T00:00:00.000Z',
+        },
+      }),
+    ).toEqual({
+      type: 'cradle-server-bootstrap',
+      phase: 'listener-establishment',
+      kind: 'ready',
+      at: '2026-07-24T00:00:00.000Z',
+    })
+  })
+})
+
+function finishBootstrap(
+  snapshot: DesktopServerBootstrapSnapshot,
+): DesktopServerBootstrapSnapshot {
+  const at = new Date().toISOString()
+  let next = snapshot
+  if (next.currentPhase) {
+    next = applyServerBootstrapEvent(next, {
+      type: 'cradle-server-bootstrap',
+      phase: next.currentPhase,
+      kind: 'completed',
+      at,
+    })
+  }
+  for (const kind of ['started', 'completed', 'ready'] as const) {
+    next = applyServerBootstrapEvent(next, {
+      type: 'cradle-server-bootstrap',
+      phase: 'listener-establishment',
+      kind,
+      at,
+    })
+  }
+  return next
+}
+
 describe('desktop server process observability env', () => {
   it('passes telemetry, exporter, and diagnostics env to the server child process', async () => {
     const { pickDesktopServerObservabilityEnv } = await import('./server-process')
 
-    expect(pickDesktopServerObservabilityEnv({
-      CRADLE_OTEL_ENABLED: '1',
-      CRADLE_OTEL_PROMETHEUS_ENABLED: '1',
-      CRADLE_OTEL_PROMETHEUS_PORT: '9464',
-      CRADLE_OTEL_EXPORTER_OTLP_ENDPOINT: 'http://127.0.0.1:4318',
-      OTEL_EXPORTER_OTLP_HEADERS: 'Authorization=Bearer token',
-      CRADLE_LANGFUSE_ENABLED: '1',
-      LANGFUSE_PUBLIC_KEY: 'pk-test',
-      LANGFUSE_SECRET_KEY: 'sk-test',
-      CRADLE_POSTHOG_AI_OBSERVABILITY_ENABLED: '1',
-      CRADLE_POSTHOG_AI_CAPTURE_MODE: 'full',
-      CRADLE_POSTHOG_PROJECT_TOKEN: 'phc-test',
-      CRADLE_POSTHOG_HOST: 'https://us.i.posthog.com',
-      CRADLE_DIAGNOSTICS_TOKEN: 'local-token',
-      CRADLE_HOST: '0.0.0.0',
-      CRADLE_DATA_DIR: '/tmp/other-data',
-      EMPTY_VALUE: '',
-    })).toEqual({
+    expect(
+      pickDesktopServerObservabilityEnv({
+        CRADLE_OTEL_ENABLED: '1',
+        CRADLE_OTEL_PROMETHEUS_ENABLED: '1',
+        CRADLE_OTEL_PROMETHEUS_PORT: '9464',
+        CRADLE_OTEL_EXPORTER_OTLP_ENDPOINT: 'http://127.0.0.1:4318',
+        OTEL_EXPORTER_OTLP_HEADERS: 'Authorization=Bearer token',
+        CRADLE_LANGFUSE_ENABLED: '1',
+        LANGFUSE_PUBLIC_KEY: 'pk-test',
+        LANGFUSE_SECRET_KEY: 'sk-test',
+        CRADLE_POSTHOG_AI_OBSERVABILITY_ENABLED: '1',
+        CRADLE_POSTHOG_AI_CAPTURE_MODE: 'full',
+        CRADLE_POSTHOG_PROJECT_TOKEN: 'phc-test',
+        CRADLE_POSTHOG_HOST: 'https://us.i.posthog.com',
+        CRADLE_DIAGNOSTICS_TOKEN: 'local-token',
+        CRADLE_HOST: '0.0.0.0',
+        CRADLE_DATA_DIR: '/tmp/other-data',
+        EMPTY_VALUE: '',
+      }),
+    ).toEqual({
       CRADLE_OTEL_ENABLED: '1',
       CRADLE_OTEL_PROMETHEUS_ENABLED: '1',
       CRADLE_OTEL_PROMETHEUS_PORT: '9464',
@@ -57,10 +255,12 @@ describe('desktop server process observability env', () => {
   it('ignores blank observability values', async () => {
     const { pickDesktopServerObservabilityEnv } = await import('./server-process')
 
-    expect(pickDesktopServerObservabilityEnv({
-      CRADLE_OTEL_ENABLED: '   ',
-      CRADLE_OTEL_PROMETHEUS_ENABLED: '1',
-    })).toEqual({
+    expect(
+      pickDesktopServerObservabilityEnv({
+        CRADLE_OTEL_ENABLED: '   ',
+        CRADLE_OTEL_PROMETHEUS_ENABLED: '1',
+      }),
+    ).toEqual({
       CRADLE_OTEL_PROMETHEUS_ENABLED: '1',
     })
   })
@@ -70,62 +270,73 @@ describe('desktop server process identity', () => {
   it('recognizes Cradle development and packaged server process commands', async () => {
     const { isDesktopServerProcessCommand } = await import('./server-process')
 
-    expect(isDesktopServerProcessCommand(
-      '/Users/wibus/.vite-plus/js_runtime/node/24.16.0/bin/node --import tsx /Users/wibus/dev/Cradle/apps/server/src/index.ts',
-    )).toBe(true)
-    expect(isDesktopServerProcessCommand(
-      '/Applications/Cradle.app/Contents/Resources/node /Applications/Cradle.app/Contents/Resources/server/dist/main.js',
-    )).toBe(true)
+    expect(
+      isDesktopServerProcessCommand(
+        '/Users/wibus/.vite-plus/js_runtime/node/24.16.0/bin/node --import tsx /Users/wibus/dev/Cradle/apps/server/src/index.ts',
+      ),
+    ).toBe(true)
+    expect(
+      isDesktopServerProcessCommand(
+        '/Applications/Cradle.app/Contents/Resources/node /Applications/Cradle.app/Contents/Resources/server/dist/main.js',
+      ),
+    ).toBe(true)
   })
 
   it('rejects unrelated node processes', async () => {
     const { isDesktopServerProcessCommand } = await import('./server-process')
 
-    expect(isDesktopServerProcessCommand(
-      '/Users/wibus/.vite-plus/js_runtime/node/24.16.0/bin/node ./node_modules/.bin/../vite-node/dist/cli.mjs src/index.ts',
-    )).toBe(false)
-    expect(isDesktopServerProcessCommand(
-      '/Applications/Codex.app/Contents/Resources/node_repl',
-    )).toBe(false)
+    expect(
+      isDesktopServerProcessCommand(
+        '/Users/wibus/.vite-plus/js_runtime/node/24.16.0/bin/node ./node_modules/.bin/../vite-node/dist/cli.mjs src/index.ts',
+      ),
+    ).toBe(false)
+    expect(
+      isDesktopServerProcessCommand('/Applications/Codex.app/Contents/Resources/node_repl'),
+    ).toBe(false)
   })
 })
 
 describe('desktop server inbound access preferences', () => {
   it('defaults to local-only server binding', async () => {
-    const { desktopServerBindHostForAccessMode, readDesktopServerAccessMode } = await import('./server-process')
+    const { desktopServerBindHostForAccessMode, readDesktopServerAccessMode }
+      = await import('./server-process')
     const dataDir = mkdtempSync(join(tmpdir(), 'cradle-desktop-server-access-'))
 
     try {
       expect(readDesktopServerAccessMode(dataDir)).toBe('local')
       expect(desktopServerBindHostForAccessMode('local')).toBe('127.0.0.1')
     }
-    finally {
+ finally {
       rmSync(dataDir, { recursive: true, force: true })
     }
   })
 
   it('reads the persisted other-device access mode before spawning the server', async () => {
-    const { desktopServerBindHostForAccessMode, readDesktopServerAccessMode } = await import('./server-process')
+    const { desktopServerBindHostForAccessMode, readDesktopServerAccessMode }
+      = await import('./server-process')
     const dataDir = mkdtempSync(join(tmpdir(), 'cradle-desktop-server-access-'))
 
     try {
       mkdirSync(join(dataDir, 'preferences'), { recursive: true })
-      writeFileSync(join(dataDir, 'preferences/network.json'), JSON.stringify({
-        proxyEnabled: true,
-        proxyMode: 'system',
-        customProxyUrl: null,
-        inbound: {
-          serverAccessMode: 'network',
-          managedRelayAccessMode: 'local',
-          managedRelayPublicUrl: null,
-        },
-      }))
+      writeFileSync(
+        join(dataDir, 'preferences/network.json'),
+        JSON.stringify({
+          proxyEnabled: true,
+          proxyMode: 'system',
+          customProxyUrl: null,
+          inbound: {
+            serverAccessMode: 'network',
+            managedRelayAccessMode: 'local',
+            managedRelayPublicUrl: null,
+          },
+        }),
+      )
 
       const accessMode = readDesktopServerAccessMode(dataDir)
       expect(accessMode).toBe('network')
       expect(desktopServerBindHostForAccessMode(accessMode)).toBe('0.0.0.0')
     }
-    finally {
+ finally {
       rmSync(dataDir, { recursive: true, force: true })
     }
   })
@@ -135,24 +346,28 @@ describe('desktop server exit classification', () => {
   it('treats desktop-marked exits as intentional', async () => {
     const { classifyDesktopServerExit } = await import('./server-process')
 
-    expect(classifyDesktopServerExit({
-      signal: 'SIGTERM',
-      expectation: {
-        pid: 123,
-        source: 'desktop',
-        reason: 'test shutdown',
-        requestedAt: '2026-06-08T00:00:00.000Z',
-        requestedSignal: 'SIGTERM',
-      },
-    })).toBe('desktop-requested')
+    expect(
+      classifyDesktopServerExit({
+        signal: 'SIGTERM',
+        expectation: {
+          pid: 123,
+          source: 'desktop',
+          reason: 'test shutdown',
+          requestedAt: '2026-06-08T00:00:00.000Z',
+          requestedSignal: 'SIGTERM',
+        },
+      }),
+    ).toBe('desktop-requested')
   })
 
   it('treats unmarked signal exits as external kills', async () => {
     const { classifyDesktopServerExit } = await import('./server-process')
 
-    expect(classifyDesktopServerExit({
-      signal: 'SIGTERM',
-      expectation: null,
-    })).toBe('external-signal-or-os-kill')
+    expect(
+      classifyDesktopServerExit({
+        signal: 'SIGTERM',
+        expectation: null,
+      }),
+    ).toBe('external-signal-or-os-kill')
   })
 })

--- a/apps/desktop/src/main/server-process.ts
+++ b/apps/desktop/src/main/server-process.ts
@@ -1,7 +1,15 @@
 import type { ChildProcess } from 'node:child_process'
 import { execFile } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
-import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { homedir } from 'node:os'
 import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path'
 
@@ -9,19 +17,28 @@ import { app, dialog } from 'electron'
 import getPort from 'get-port'
 import { z } from 'zod'
 
+import type { DesktopServerBootstrapSnapshot, ServerBootstrapEvent, ServerBootstrapEventKind, ServerBootstrapPhase } from '../shared/server-runtime'
+import {
+  applyServerBootstrapEvent,
+  createDesktopServerBootstrapSnapshot,
+  SERVER_BOOTSTRAP_PHASES,
+} from '../shared/server-runtime'
 import { getDesktopDataDirectoryState } from './data-directory'
 import type { ManagedChildProcess } from './managed-process'
 import { spawnManagedProcess } from './managed-process'
 import { resolveDesktopInstalledPluginsDir } from './plugin-install-links'
 import { getPluginEnvVars } from './plugin-loader'
-import { resolveDesktopPrimaryPluginsDir, resolveDesktopPrimaryPluginsSourceKind } from './plugin-paths'
+import {
+  resolveDesktopPrimaryPluginsDir,
+  resolveDesktopPrimaryPluginsSourceKind,
+} from './plugin-paths'
 
 let serverProcess: ManagedChildProcess | null = null
 let restartCount = 0
 let locatedServerPid: number | null = null
 const MAX_RESTARTS = 3
-const SERVER_STARTUP_TIMEOUT_MS = 90_000
-const SERVER_RESTART_READY_TIMEOUT_MS = 60_000
+const SERVER_BOOTSTRAP_GLOBAL_TIMEOUT_MS = 30 * 60_000
+const SERVER_BOOTSTRAP_PHASE_TIMEOUT_MS = 10 * 60_000
 const SERVER_OUTPUT_LINE_LIMIT = 200
 const SERVER_PROCESS_COMMAND_TIMEOUT_MS = 1_000
 const LOGIN_SHELL_PATH_TIMEOUT_MS = 1500
@@ -76,25 +93,27 @@ const DESKTOP_SERVER_OBSERVABILITY_ENV_KEYS = [
   'OTEL_EXPORTER_OTLP_TRACES_PROTOCOL',
   'OTEL_EXPORTER_OTLP_METRICS_PROTOCOL',
 ] as const
-const ExternalPluginsDirsSchema = z.array(z.string().optional())
-  .transform(values => values.flatMap(value => value?.trim() ? [value.trim()] : []))
+const ExternalPluginsDirsSchema = z
+  .array(z.string().optional())
+  .transform(values => values.flatMap(value => (value?.trim() ? [value.trim()] : [])))
 const ServerLocatorSchema = z.object({
   serverUrl: z.string().url(),
   pid: z.number().int().positive().nullable().optional(),
   version: z.string().optional(),
   updatedAt: z.string().optional(),
 })
-const DesktopServerAccessModeSchema = z.object({
-  inbound: z.object({
-    serverAccessMode: z.enum(['local', 'network']).default('local'),
-  }).default({ serverAccessMode: 'local' }),
-}).passthrough()
+const DesktopServerAccessModeSchema = z
+  .object({
+    inbound: z
+      .object({
+        serverAccessMode: z.enum(['local', 'network']).default('local'),
+      })
+      .default({ serverAccessMode: 'local' }),
+  })
+  .passthrough()
 let currentServerUrl = ''
 let currentServerAuthToken = ''
 const recentServerOutputLines: string[] = []
-
-export type ServerStartupPhase = 'migrating' | 'compacting'
-type ServerStartupSignal = ServerStartupPhase | 'initializing'
 
 interface DesktopServerExitExpectation {
   pid: number | null
@@ -104,7 +123,10 @@ interface DesktopServerExitExpectation {
   requestedSignal: NodeJS.Signals
 }
 
-type DesktopServerExitClassification = 'desktop-requested' | 'external-signal-or-os-kill' | 'process-exit-or-crash'
+type DesktopServerExitClassification
+  = | 'desktop-requested'
+    | 'external-signal-or-os-kill'
+    | 'process-exit-or-crash'
 
 let expectedServerExit: DesktopServerExitExpectation | null = null
 let lastServerSignalBeforeExit: { signal: string, line: string, observedAt: string } | null = null
@@ -135,9 +157,11 @@ export function readDesktopServerAccessMode(dataDir: string): DesktopServerAcces
     return 'local'
   }
   try {
-    return DesktopServerAccessModeSchema.parse(JSON.parse(readFileSync(preferencesPath, 'utf8'))).inbound.serverAccessMode
+    return DesktopServerAccessModeSchema.parse(JSON.parse(readFileSync(preferencesPath, 'utf8')))
+      .inbound
+.serverAccessMode
   }
-  catch {
+ catch {
     return 'local'
   }
 }
@@ -146,7 +170,9 @@ export function readDesktopServerAccessMode(dataDir: string): DesktopServerAcces
  * Start the Cradle server as a forked child process.
  * Returns the full URL the server is listening on.
  */
-export async function startServer(onStartupPhase?: (phase: ServerStartupPhase) => void): Promise<string> {
+export async function startServer(
+  onBootstrapSnapshot?: (snapshot: DesktopServerBootstrapSnapshot) => void,
+): Promise<string> {
   expectedServerExit = null
   lastServerSignalBeforeExit = null
   restartCount = 0
@@ -165,33 +191,27 @@ export async function startServer(onStartupPhase?: (phase: ServerStartupPhase) =
   const port = await getPort({ port: [21423, 21424, 21425, 21426] })
   const host = desktopServerBindHostForAccessMode(readDesktopServerAccessMode(dataDir))
   currentServerUrl = `http://127.0.0.1:${port}`
+  let bootstrapSnapshot = createDesktopServerBootstrapSnapshot()
+  const bootstrapWatchdog: ServerBootstrapWatchdog = {
+    globalTimeoutMs: SERVER_BOOTSTRAP_GLOBAL_TIMEOUT_MS,
+    phaseTimeoutMs: SERVER_BOOTSTRAP_PHASE_TIMEOUT_MS,
+    readSnapshot: () => bootstrapSnapshot,
+  }
 
-  let startupPhase: ServerStartupPhase | null = null
-  let startupTimeoutStartedAt = Date.now()
   await spawnServer({
     host,
     port,
     dataDir,
     credentialSecret,
     serverAuthToken: currentServerAuthToken,
-    onStartupSignal: (signal) => {
-      if (signal === 'initializing') {
-        startupPhase = null
-        startupTimeoutStartedAt = Date.now()
-        return
-      }
-      startupPhase = signal
-      onStartupPhase?.(signal)
+    bootstrapWatchdog,
+    onBootstrapEvent: (event) => {
+      bootstrapSnapshot = applyServerBootstrapEvent(bootstrapSnapshot, event)
+      onBootstrapSnapshot?.(bootstrapSnapshot)
     },
   })
 
-  // Wait for server to be ready
-  await waitForServer(
-    currentServerUrl,
-    SERVER_STARTUP_TIMEOUT_MS,
-    () => startupPhase !== null,
-    () => startupTimeoutStartedAt,
-  )
+  await waitForServer(currentServerUrl, { bootstrapWatchdog })
   writeCliServerLocator({
     dataDir: app.getPath('userData'),
     serverUrl: currentServerUrl,
@@ -201,7 +221,9 @@ export async function startServer(onStartupPhase?: (phase: ServerStartupPhase) =
   return currentServerUrl
 }
 
-async function readHealthyLocatedServerUrl(dataDir: string): Promise<{ serverUrl: string, pid: number | null } | null> {
+async function readHealthyLocatedServerUrl(
+  dataDir: string,
+): Promise<{ serverUrl: string, pid: number | null } | null> {
   const locatorPath = join(dataDir, CLI_SERVER_LOCATOR_FILE)
   if (!existsSync(locatorPath)) {
     return null
@@ -209,10 +231,10 @@ async function readHealthyLocatedServerUrl(dataDir: string): Promise<{ serverUrl
 
   try {
     const locator = ServerLocatorSchema.parse(JSON.parse(readFileSync(locatorPath, 'utf8')))
-    await waitForServer(locator.serverUrl, 1_000)
+    await waitForServer(locator.serverUrl, { timeoutMs: 1_000 })
     return { serverUrl: locator.serverUrl, pid: locator.pid ?? null }
   }
-  catch {
+ catch {
     removeCliServerLocator()
     return null
   }
@@ -241,7 +263,7 @@ function removeCliServerLocator(): void {
   try {
     rmSync(join(app.getPath('userData'), CLI_SERVER_LOCATOR_FILE), { force: true })
   }
-  catch {
+ catch {
     // Shutdown should not fail because the optional CLI locator cannot be cleared.
   }
 }
@@ -252,7 +274,8 @@ async function spawnServer(opts: {
   dataDir: string
   credentialSecret: string
   serverAuthToken: string
-  onStartupSignal?: (signal: ServerStartupSignal) => void
+  bootstrapWatchdog?: ServerBootstrapWatchdog
+  onBootstrapEvent?: (event: ServerBootstrapEvent) => void
 }): Promise<void> {
   const { host, port, dataDir, credentialSecret } = opts
 
@@ -268,15 +291,14 @@ async function spawnServer(opts: {
   const pluginsDir = resolveDesktopPrimaryPluginsDir({ isDev, moduleDir: __dirname })
   const pluginsSourceKind = resolveDesktopPrimaryPluginsSourceKind({ isDev })
   const configuredMigrationsDir = process.env.CRADLE_MIGRATIONS_DIR?.trim()
-  const migrationsDir = configuredMigrationsDir || (isDev ? undefined : join(process.resourcesPath, 'drizzle'))
+  const migrationsDir
+    = configuredMigrationsDir || (isDev ? undefined : join(process.resourcesPath, 'drizzle'))
   const builtinSkillsDir = isDev ? undefined : join(process.resourcesPath, 'resources/skills')
   const codexAppServerPath = resolveDesktopCodexAppServerPath({ isDev, moduleDir: __dirname })
   const installedPluginsDir = resolveDesktopInstalledPluginsDir(app.getPath('userData'))
-  const externalPluginsDirs = [
-    installedPluginsDir,
-    process.env.CRADLE_EXTERNAL_PLUGINS_DIRS,
-  ]
-  const externalPluginsDirList = ExternalPluginsDirsSchema.parse(externalPluginsDirs).join(delimiter)
+  const externalPluginsDirs = [installedPluginsDir, process.env.CRADLE_EXTERNAL_PLUGINS_DIRS]
+  const externalPluginsDirList
+    = ExternalPluginsDirsSchema.parse(externalPluginsDirs).join(delimiter)
   const serverEnv: NodeJS.ProcessEnv = {
     ...process.env,
     ...getPluginEnvVars(),
@@ -315,13 +337,13 @@ async function spawnServer(opts: {
   child.stdout?.on('data', chunk => recordServerOutput('stdout', chunk))
   child.stderr?.on('data', chunk => recordServerOutput('stderr', chunk))
   child.on('message', (message) => {
-    const signal = readServerStartupSignal(message)
-    if (signal) {
-      opts.onStartupSignal?.(signal)
+    const event = readServerBootstrapEvent(message)
+    if (event) {
+      opts.onBootstrapEvent?.(event)
     }
   })
   child.on('error', (err) => {
-    const message = `[server:error] ${err instanceof Error ? err.stack ?? err.message : String(err)}`
+    const message = `[server:error] ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`
     appendServerOutputLine(message)
     console.error(message)
   })
@@ -360,7 +382,7 @@ async function spawnServer(opts: {
       restartCount++
       console.warn(`[desktop] Restarting server (attempt ${restartCount}/${MAX_RESTARTS})...`)
       spawnServer(opts)
-        .then(() => waitForServer(currentServerUrl, SERVER_RESTART_READY_TIMEOUT_MS))
+        .then(() => waitForServer(currentServerUrl, { bootstrapWatchdog: opts.bootstrapWatchdog }))
         .then(() => {
           writeCliServerLocator({
             dataDir: app.getPath('userData'),
@@ -372,13 +394,15 @@ async function spawnServer(opts: {
           showServerCrashDialog(code)
         })
     }
-    else {
+ else {
       showServerCrashDialog(code)
     }
   })
 }
 
-export function pickDesktopServerObservabilityEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+export function pickDesktopServerObservabilityEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
   const picked: NodeJS.ProcessEnv = {}
   for (const key of DESKTOP_SERVER_OBSERVABILITY_ENV_KEYS) {
     const value = env[key]
@@ -403,7 +427,9 @@ export function classifyDesktopServerExit(input: {
   return 'process-exit-or-crash'
 }
 
-function markExpectedServerExit(input: Pick<DesktopServerExitExpectation, 'pid' | 'reason' | 'requestedSignal'>): void {
+function markExpectedServerExit(
+  input: Pick<DesktopServerExitExpectation, 'pid' | 'reason' | 'requestedSignal'>,
+): void {
   expectedServerExit = {
     pid: input.pid,
     source: 'desktop',
@@ -433,7 +459,10 @@ function writeServerExitDiagnostic(input: {
   classification: DesktopServerExitClassification
   expectation: DesktopServerExitExpectation | null
 }): string | null {
-  const diagnosticsPath = join(getDesktopDataDirectoryState().serverDataRoot, SERVER_EXIT_DIAGNOSTICS_FILE)
+  const diagnosticsPath = join(
+    getDesktopDataDirectoryState().serverDataRoot,
+    SERVER_EXIT_DIAGNOSTICS_FILE,
+  )
   try {
     mkdirSync(dirname(diagnosticsPath), { recursive: true })
     appendFileSync(
@@ -455,7 +484,7 @@ function writeServerExitDiagnostic(input: {
     )
     return diagnosticsPath
   }
-  catch (err) {
+ catch (err) {
     console.error('[desktop] Failed to write server exit diagnostics:', err)
     return null
   }
@@ -482,7 +511,7 @@ function recordServerOutput(source: 'stdout' | 'stderr', chunk: Buffer | string)
     if (source === 'stderr') {
       console.error(message)
     }
-    else {
+ else {
       console.warn(message)
     }
   }
@@ -508,13 +537,29 @@ function rememberServerSignalLine(line: string): void {
   }
 }
 
-function createServerStartupError(url: string, timeoutMs: number): Error {
-  const recentOutput = recentServerOutputLines.slice(-40).join('\n')
-  if (!recentOutput) {
-    return new Error(`Server failed to start within ${timeoutMs}ms at ${url}`)
-  }
+function createServerStartupError(
+  url: string,
+  input: {
+    timeoutMs?: number
+    watchdogFailure?: string
+    bootstrapSnapshot?: DesktopServerBootstrapSnapshot
+  } = {},
+): Error {
+  const message
+    = input.watchdogFailure
+      ?? (input.timeoutMs === undefined
+      ? `Server exited before becoming ready at ${url}`
+      : `Server failed to start within ${input.timeoutMs}ms at ${url}`)
+  const bootstrapDiagnostics = input.bootstrapSnapshot
+    ? describeBootstrapDiagnostics(input.bootstrapSnapshot, Date.now())
+    : null
+  const recentOutput = recentServerOutputLines.slice(-40).join('\n') || '(none)'
   return new Error(
-    `Server failed to start within ${timeoutMs}ms at ${url}\n\nRecent server output:\n${recentOutput}`,
+    [
+      message,
+      ...(bootstrapDiagnostics ? [bootstrapDiagnostics] : []),
+      `Recent server output:\n${recentOutput}`,
+    ].join('\n\n'),
   )
 }
 
@@ -605,7 +650,10 @@ function joinPathSegments(segments: string[]): string {
   return uniqueSegments.join(delimiter)
 }
 
-function resolveDesktopCodexAppServerPath(input: { isDev: boolean, moduleDir: string }): string | undefined {
+function resolveDesktopCodexAppServerPath(input: {
+  isDev: boolean
+  moduleDir: string
+}): string | undefined {
   const configuredPath = process.env[CODEX_APP_SERVER_PATH_ENV]?.trim()
   if (configuredPath) {
     return configuredPath
@@ -621,9 +669,24 @@ function resolveDesktopCodexAppServerPath(input: { isDev: boolean, moduleDir: st
   }
 
   return [
-    resolve(input.moduleDir, '../../resources/codex', `${process.platform}-${process.arch}`, executableName),
-    resolve(process.cwd(), 'resources/codex', `${process.platform}-${process.arch}`, executableName),
-    resolve(process.cwd(), 'apps/desktop/resources/codex', `${process.platform}-${process.arch}`, executableName),
+    resolve(
+      input.moduleDir,
+      '../../resources/codex',
+      `${process.platform}-${process.arch}`,
+      executableName,
+    ),
+    resolve(
+      process.cwd(),
+      'resources/codex',
+      `${process.platform}-${process.arch}`,
+      executableName,
+    ),
+    resolve(
+      process.cwd(),
+      'apps/desktop/resources/codex',
+      `${process.platform}-${process.arch}`,
+      executableName,
+    ),
   ].find(candidate => existsSync(candidate))
 }
 
@@ -687,15 +750,15 @@ function resolveDesktopServerAuthToken(dataDir: string): string {
 
 export function getDesktopServerAuthToken(): string {
   if (!currentServerAuthToken) {
-    currentServerAuthToken = resolveDesktopServerAuthToken(getDesktopDataDirectoryState().serverDataRoot)
+    currentServerAuthToken = resolveDesktopServerAuthToken(
+      getDesktopDataDirectoryState().serverDataRoot,
+    )
   }
   return currentServerAuthToken
 }
 
 export function getDesktopServerAuthHeaders(): HeadersInit {
-  return currentServerAuthToken
-    ? { authorization: `Bearer ${currentServerAuthToken}` }
-    : {}
+  return currentServerAuthToken ? { authorization: `Bearer ${currentServerAuthToken}` } : {}
 }
 
 function readDesktopCredentialSecret(secretPath: string): string {
@@ -725,18 +788,20 @@ function archiveKeychainBackedSecret(secretPath: string): void {
 }
 
 function showServerCrashDialog(exitCode: number | null): void {
-  dialog.showMessageBox({
-    type: 'error',
-    title: 'Server Error',
-    message: 'The Cradle server has stopped unexpectedly.',
-    detail: `Exit code: ${exitCode}\nThe app may not function correctly. Please restart the application.`,
-    buttons: ['Restart App', 'Close'],
-  }).then(({ response }) => {
-    if (response === 0) {
-      app.relaunch()
-      app.exit(0)
-    }
-  })
+  dialog
+    .showMessageBox({
+      type: 'error',
+      title: 'Server Error',
+      message: 'The Cradle server has stopped unexpectedly.',
+      detail: `Exit code: ${exitCode}\nThe app may not function correctly. Please restart the application.`,
+      buttons: ['Restart App', 'Close'],
+    })
+    .then(({ response }) => {
+      if (response === 0) {
+        app.relaunch()
+        app.exit(0)
+      }
+    })
 }
 
 /**
@@ -775,8 +840,10 @@ async function stopLocatedServer(timeoutMs: number): Promise<void> {
     return
   }
 
-  if (!await canStopLocatedServer(pid)) {
-    console.warn(`[desktop] Skipping located server stop because pid ${pid} no longer matches a Cradle server.`)
+  if (!(await canStopLocatedServer(pid))) {
+    console.warn(
+      `[desktop] Skipping located server stop because pid ${pid} no longer matches a Cradle server.`,
+    )
     removeCliServerLocator()
     return
   }
@@ -784,7 +851,7 @@ async function stopLocatedServer(timeoutMs: number): Promise<void> {
   try {
     process.kill(pid, 'SIGTERM')
   }
-  catch {
+ catch {
     // The located server may have already exited.
     removeCliServerLocator()
     return
@@ -795,7 +862,7 @@ async function stopLocatedServer(timeoutMs: number): Promise<void> {
     try {
       process.kill(pid, 0)
     }
-    catch {
+ catch {
       removeCliServerLocator()
       return
     }
@@ -805,7 +872,7 @@ async function stopLocatedServer(timeoutMs: number): Promise<void> {
   try {
     process.kill(pid, 'SIGKILL')
   }
-  catch {
+ catch {
     // The located server may have exited after the timeout check.
   }
   removeCliServerLocator()
@@ -817,9 +884,9 @@ async function canStopLocatedServer(pid: number): Promise<boolean> {
   }
 
   try {
-    await waitForServer(currentServerUrl, 1_000)
+    await waitForServer(currentServerUrl, { timeoutMs: 1_000 })
   }
-  catch {
+ catch {
     return false
   }
 
@@ -832,8 +899,10 @@ async function readProcessCommandLine(pid: number): Promise<string | null> {
     return null
   }
 
-  return await readUnixProcessCommandLine(pid, ['-p', String(pid), '-wwE', '-o', 'command='])
-    ?? await readUnixProcessCommandLine(pid, ['-p', String(pid), '-ww', '-o', 'command='])
+  return (
+    (await readUnixProcessCommandLine(pid, ['-p', String(pid), '-wwE', '-o', 'command=']))
+    ?? (await readUnixProcessCommandLine(pid, ['-p', String(pid), '-ww', '-o', 'command=']))
+  )
 }
 
 function readUnixProcessCommandLine(pid: number, args: string[]): Promise<string | null> {
@@ -861,15 +930,17 @@ function readUnixProcessCommandLine(pid: number, args: string[]): Promise<string
 
 export function isDesktopServerProcessCommand(commandLine: string): boolean {
   const normalizedCommand = commandLine.replaceAll('\\', '/')
-  return normalizedCommand.includes(DEV_SERVER_ENTRY_PATTERN)
+  return (
+    normalizedCommand.includes(DEV_SERVER_ENTRY_PATTERN)
     || normalizedCommand.includes(PACKAGED_SERVER_ENTRY_PATTERN)
+  )
 }
 
 function readServerTargetPid(child: ManagedChildProcess | null): number | null {
   return child?.targetPid ?? child?.pid ?? null
 }
 
-function readServerStartupSignal(message: unknown): ServerStartupSignal | null {
+export function readServerBootstrapEvent(message: unknown): ServerBootstrapEvent | null {
   if (
     typeof message !== 'object'
     || message === null
@@ -884,40 +955,126 @@ function readServerStartupSignal(message: unknown): ServerStartupSignal | null {
     typeof targetMessage !== 'object'
     || targetMessage === null
     || !('type' in targetMessage)
-    || targetMessage.type !== 'cradle-server-startup'
+    || targetMessage.type !== 'cradle-server-bootstrap'
     || !('phase' in targetMessage)
+    || !('kind' in targetMessage)
+    || !('at' in targetMessage)
+    || typeof targetMessage.phase !== 'string'
+    || typeof targetMessage.kind !== 'string'
+    || typeof targetMessage.at !== 'string'
   ) {
     return null
   }
-  return targetMessage.phase === 'migrating'
-    || targetMessage.phase === 'compacting'
-    || targetMessage.phase === 'initializing'
-    ? targetMessage.phase
-    : null
+  if (
+    !SERVER_BOOTSTRAP_PHASES.includes(targetMessage.phase as ServerBootstrapPhase)
+    || !(['started', 'completed', 'failed', 'ready'] as ServerBootstrapEventKind[]).includes(
+      targetMessage.kind as ServerBootstrapEventKind,
+    )
+  ) {
+    return null
+  }
+  return {
+    type: 'cradle-server-bootstrap',
+    phase: targetMessage.phase as ServerBootstrapPhase,
+    kind: targetMessage.kind as ServerBootstrapEventKind,
+    at: targetMessage.at,
+    ...('error' in targetMessage && typeof targetMessage.error === 'string'
+      ? { error: targetMessage.error }
+      : {}),
+  }
 }
 
-async function waitForServer(
+export interface ServerBootstrapWatchdog {
+  globalTimeoutMs: number
+  phaseTimeoutMs: number
+  readSnapshot: () => DesktopServerBootstrapSnapshot
+}
+
+export interface WaitForServerOptions {
+  timeoutMs?: number
+  bootstrapWatchdog?: ServerBootstrapWatchdog
+}
+
+export async function waitForServer(
   url: string,
-  timeoutMs: number,
-  isLongRunningStartup: () => boolean = () => false,
-  readTimeoutStartedAt?: () => number,
+  options: WaitForServerOptions = {},
 ): Promise<void> {
   const start = Date.now()
-  const timeoutStartedAt = readTimeoutStartedAt ?? (() => start)
-  while (Date.now() - timeoutStartedAt() < timeoutMs || isLongRunningStartup()) {
+  while (options.timeoutMs === undefined || Date.now() - start < options.timeoutMs) {
+    const bootstrapSnapshot = options.bootstrapWatchdog?.readSnapshot()
     if (serverProcess && (serverProcess.exitCode !== null || serverProcess.signalCode !== null)) {
-      throw createServerStartupError(url, timeoutMs)
+      throw createServerStartupError(url, { bootstrapSnapshot })
+    }
+    const watchdogFailure = readBootstrapWatchdogFailure(start, options.bootstrapWatchdog)
+    if (watchdogFailure) {
+      throw createServerStartupError(url, { watchdogFailure, bootstrapSnapshot })
     }
     try {
       const res = await fetch(`${url}/health`, { headers: getDesktopServerAuthHeaders() })
-      if (res.ok) {
+      if (res.ok && isBootstrapReady(bootstrapSnapshot)) {
         return
       }
     }
-    catch {
+ catch {
       // Server not ready yet
     }
     await new Promise(r => setTimeout(r, 200))
   }
-  throw createServerStartupError(url, timeoutMs)
+  throw createServerStartupError(url, {
+    timeoutMs: options.timeoutMs,
+    bootstrapSnapshot: options.bootstrapWatchdog?.readSnapshot(),
+  })
+}
+
+function isBootstrapReady(snapshot: DesktopServerBootstrapSnapshot | undefined): boolean {
+  // A managed server must prove both that its listener callback ran and that
+  // its ready-only health endpoint responds. Located external servers use the
+  // bounded health probe without a local bootstrap watchdog.
+  return (
+    !snapshot
+    || (snapshot.lastEvent?.phase === 'listener-establishment' && snapshot.lastEvent.kind === 'ready')
+  )
+}
+
+function readBootstrapWatchdogFailure(
+  startedAt: number,
+  watchdog: ServerBootstrapWatchdog | undefined,
+): string | null {
+  if (!watchdog) {
+    return null
+  }
+  const now = Date.now()
+  const snapshot = watchdog.readSnapshot()
+  if (now - startedAt >= watchdog.globalTimeoutMs) {
+    return `Server bootstrap global timeout after ${watchdog.globalTimeoutMs}ms.`
+  }
+  if (
+    snapshot.currentPhase
+    && snapshot.phaseStartedAt
+    && now - Date.parse(snapshot.phaseStartedAt) >= watchdog.phaseTimeoutMs
+  ) {
+    return `Server bootstrap phase timeout after ${watchdog.phaseTimeoutMs}ms.`
+  }
+  return null
+}
+
+function describeBootstrapDiagnostics(
+  snapshot: DesktopServerBootstrapSnapshot,
+  now: number,
+): string {
+  const phase = snapshot.currentPhase ?? snapshot.lastEvent?.phase ?? 'no reported phase'
+  const phaseReport = phase === 'no reported phase' ? undefined : snapshot.phases[phase]
+  const phaseStartedAt = snapshot.phaseStartedAt ?? phaseReport?.startedAt
+  const phaseEndedAt = phaseReport?.failedAt ?? phaseReport?.completedAt
+  const phaseDurationMs = phaseStartedAt
+    ? Math.max(0, (phaseEndedAt ? Date.parse(phaseEndedAt) : now) - Date.parse(phaseStartedAt))
+    : null
+  const lastEvent = snapshot.lastEvent
+    ? `${snapshot.lastEvent.kind}:${snapshot.lastEvent.phase} at ${snapshot.lastEvent.at}`
+    : 'none'
+  return [
+    `Last bootstrap phase: "${phase}".`,
+    `Phase duration: ${phaseDurationMs === null ? 'unavailable' : `${phaseDurationMs}ms`}.`,
+    `Last known bootstrap event: ${lastEvent}.`,
+  ].join(' ')
 }

--- a/apps/desktop/src/shared/server-runtime.test.ts
+++ b/apps/desktop/src/shared/server-runtime.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyServerBootstrapEvent,
+  createDesktopServerBootstrapSnapshot,
+} from './server-runtime'
+
+describe('desktop server bootstrap snapshot', () => {
+  it('retains phase start, completion, and failure timestamps from server events', () => {
+    const startedAt = '2026-07-24T00:00:00.000Z'
+    const completedAt = '2026-07-24T00:00:10.000Z'
+    const failedAt = '2026-07-24T00:00:20.000Z'
+    let snapshot = createDesktopServerBootstrapSnapshot(new Date(startedAt))
+
+    snapshot = applyServerBootstrapEvent(snapshot, {
+      type: 'cradle-server-bootstrap',
+      phase: 'database-migration',
+      kind: 'started',
+      at: startedAt,
+    })
+    snapshot = applyServerBootstrapEvent(snapshot, {
+      type: 'cradle-server-bootstrap',
+      phase: 'database-migration',
+      kind: 'completed',
+      at: completedAt,
+    })
+    snapshot = applyServerBootstrapEvent(snapshot, {
+      type: 'cradle-server-bootstrap',
+      phase: 'database-maintenance',
+      kind: 'started',
+      at: completedAt,
+    })
+    snapshot = applyServerBootstrapEvent(snapshot, {
+      type: 'cradle-server-bootstrap',
+      phase: 'database-maintenance',
+      kind: 'failed',
+      at: failedAt,
+      error: 'compaction failed',
+    })
+
+    expect(snapshot.phases).toMatchObject({
+      'database-migration': { startedAt, completedAt },
+      'database-maintenance': { startedAt: completedAt, failedAt, error: 'compaction failed' },
+    })
+  })
+})

--- a/apps/desktop/src/shared/server-runtime.ts
+++ b/apps/desktop/src/shared/server-runtime.ts
@@ -1,9 +1,88 @@
 export const DESKTOP_SERVER_STATUS_GET_CHANNEL = 'desktop-server:get-status'
 export const DESKTOP_SERVER_STATUS_CHANGED_CHANNEL = 'desktop-server:status-changed'
 
+export const SERVER_BOOTSTRAP_PHASES = [
+  'database-migration',
+  'database-maintenance',
+  'persisted-run-recovery',
+  'service-initialization',
+  'plugin-activation',
+  'listener-establishment',
+] as const
+
+export type ServerBootstrapPhase = (typeof SERVER_BOOTSTRAP_PHASES)[number]
+export type ServerBootstrapEventKind = 'started' | 'completed' | 'failed' | 'ready'
+
+/** Lifecycle fact emitted by the server and forwarded through the managed process. */
+export interface ServerBootstrapEvent {
+  type: 'cradle-server-bootstrap'
+  phase: ServerBootstrapPhase
+  kind: ServerBootstrapEventKind
+  at: string
+  error?: string
+}
+
+/** Desktop-owned projection retained for both IPC snapshots and diagnostics. */
+export interface DesktopServerBootstrapSnapshot {
+  startedAt: string
+  currentPhase: ServerBootstrapPhase | null
+  phaseStartedAt: string | null
+  lastEvent: ServerBootstrapEvent | null
+  phases: Partial<Record<ServerBootstrapPhase, DesktopServerBootstrapPhaseReport>>
+}
+
+export interface DesktopServerBootstrapPhaseReport {
+  startedAt?: string
+  completedAt?: string
+  failedAt?: string
+  error?: string
+}
+
 export type DesktopServerStatus
   = | { state: 'starting' }
     | { state: 'migrating', phase: string }
-    | { state: 'compacting' }
-    | { state: 'ready', serverUrl: string }
-    | { state: 'failed', message: string }
+    | { state: 'bootstrapping', bootstrap: DesktopServerBootstrapSnapshot }
+    | { state: 'ready', serverUrl: string, bootstrap: DesktopServerBootstrapSnapshot }
+    | { state: 'failed', message: string, bootstrap: DesktopServerBootstrapSnapshot | null }
+
+export function createDesktopServerBootstrapSnapshot(
+  now = new Date(),
+): DesktopServerBootstrapSnapshot {
+  return {
+    startedAt: now.toISOString(),
+    currentPhase: null,
+    phaseStartedAt: null,
+    lastEvent: null,
+    phases: {},
+  }
+}
+
+export function applyServerBootstrapEvent(
+  snapshot: DesktopServerBootstrapSnapshot,
+  event: ServerBootstrapEvent,
+): DesktopServerBootstrapSnapshot {
+  const previousReport = snapshot.phases[event.phase]
+  const report: DesktopServerBootstrapPhaseReport = {
+    ...previousReport,
+    ...(event.kind === 'started' ? { startedAt: event.at } : {}),
+    ...(event.kind === 'completed' ? { completedAt: event.at } : {}),
+    ...(event.kind === 'failed' ? { failedAt: event.at, error: event.error } : {}),
+  }
+  const currentPhase
+    = event.kind === 'started'
+      ? event.phase
+      : snapshot.currentPhase === event.phase
+        ? null
+        : snapshot.currentPhase
+  return {
+    ...snapshot,
+    currentPhase,
+    phaseStartedAt:
+      event.kind === 'started' ? event.at : currentPhase === null ? null : snapshot.phaseStartedAt,
+    lastEvent: event,
+    phases: {
+      ...snapshot.phases,
+      [event.phase]: report,
+    },
+  }
+}

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -53,6 +53,10 @@ The server follows the repository convention of **technical primitives + busines
 - `CRADLE_LOG_SYNC`: set to `1` to write the file log synchronously during crash diagnostics
 - `CRADLE_CREDENTIAL_SECRET`: secret used to encrypt server-owned secrets
 
+## Desktop Bootstrap
+
+Desktop startup reports ordered, timestamped IPC lifecycle events from `src/bootstrap-lifecycle.ts`: database migration, database maintenance, persisted run recovery, service initialization, plugin activation, and listener establishment. The server emits `ready` only from the `app.listen` callback. Desktop owns supervision and renderer projection; `/health` continues to mean the server is actually ready to serve requests.
+
 ## Commands
 
 - `pnpm dev`: start nodemon development server

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -4,10 +4,12 @@ import { cors } from '@elysiajs/cors'
 import { node } from '@elysiajs/node'
 import { Elysia } from 'elysia'
 
+import type { ServerBootstrapReporter } from './bootstrap-lifecycle'
 import { loadServerAuthConfig } from './config/server-config'
 import { createAuthPlugin } from './http/auth'
 import { createOpenApiPlugin, registerOpenApiAlias } from './http/openapi'
 import { createRequestIdPlugin } from './http/request-id'
+import { getServerConfig, initializeDatabase, shutdownInfra } from './infra'
 import { createAcpModule } from './modules/acp'
 import { agentIdentity } from './modules/agent-identity'
 import { agentInteractionRuntime } from './modules/agent-interaction-runtime'
@@ -61,7 +63,6 @@ import { providers } from './modules/provider-catalog'
 import { providerTargets } from './modules/provider-targets'
 import { registerPtyRoutes } from './modules/pty'
 import { pullRequest, pullRequestFeed } from './modules/pull-request'
-import { recall } from './modules/recall'
 import { relayServers } from './modules/relay-servers'
 import { relayTransport } from './modules/relay-transport'
 import { listActiveRelayAuthTokens } from './modules/relay-transport/relay-auth-token-service'
@@ -88,6 +89,7 @@ import { RuntimeResourceRegistry } from './runtime-resource-registry'
 
 interface CreateServerAppOptions {
   startBackgroundTasks?: boolean
+  bootstrapReporter?: ServerBootstrapReporter
 }
 
 interface CreateServerContractAppOptions {
@@ -125,6 +127,14 @@ function isAllowedCorsOriginValue(origin: string | null): boolean {
 
 function isAllowedCorsOrigin({ headers }: { headers: Headers }): boolean {
   return isAllowedCorsOriginValue(headers.get('origin'))
+}
+
+async function runBootstrapPhase<T>(
+  reporter: ServerBootstrapReporter | undefined,
+  phase: Parameters<ServerBootstrapReporter['run']>[0],
+  operation: () => Promise<T>,
+): Promise<T> {
+  return reporter ? reporter.run(phase, operation) : operation()
 }
 
 export async function createServerContractApp(options: CreateServerContractAppOptions = {}) {
@@ -228,7 +238,6 @@ export async function createServerContractApp(options: CreateServerContractAppOp
   app.use(kanban)
   app.use(linkPreview)
   app.use(search)
-  app.use(recall)
   app.use(createPluginsModule({ downloadCenter: downloadCenter.service }))
   app.use(skills)
   app.use(workflowRules)
@@ -265,93 +274,156 @@ export async function createServerContractApp(options: CreateServerContractAppOp
 }
 
 export async function createServerApp(options: CreateServerAppOptions = {}) {
-  const { startBackgroundTasks = process.env.NODE_ENV !== 'test' } = options
+  const { startBackgroundTasks = process.env.NODE_ENV !== 'test', bootstrapReporter } = options
   const downloadCenterService = new DownloadCenterService()
-  await downloadCenterService.boot()
-  const [
-    { shutdownInfra, getServerConfig },
-    { abortAllRuns, flushAllActiveRunSnapshots, recoverPersistedRunProjections },
-    { shutdownTraceStreams },
-    { cleanup: chronicleCleanup },
-    chronicleService,
-    { refreshAllExternalProviderSources },
-    { reconcileExternalIssueSourceRegistrations },
-    { providerRuntimeHostManager },
-    { clearSideConversations },
-    { activateServerPlugins, deactivateAllPlugins },
-    conversationBridgeSupervisor,
-    { destroyWorkspaceFileIndexes },
-    localRelaydSupervisor,
-    { prepareOpencodeManagedPathForRemoval, stopOpencodeServer },
-    { initHostConnectorService, getHostConnectorService },
-    { shutdownRemoteHostConnections, startEnabledRelayRemoteHostConnections },
-    { shutdownImageOcr },
-    { CodexUsageReconciliationScheduler },
-    { RunSnapshotMaintenanceScheduler },
-    { initializeRecallProjection },
-  ] = await Promise.all([
-    import('./infra'),
-    import('./modules/chat-runtime/runtime'),
-    import('./modules/chat-runtime/stream-trace'),
-    import('./modules/chronicle/daemon-manager'),
-    import('./modules/chronicle/service'),
-    import('./modules/external-provider-sources/service'),
-    import('./modules/external-issue-sources/service'),
-    import('./modules/provider-runtime/host-manager'),
-    import('./modules/provider-runtime/side-conversation-registry'),
-    import('./plugins/loader'),
-    import('./modules/conversation-bridge/runtime-supervisor'),
-    import('./modules/workspace/files'),
-    import('./modules/relay-servers/local-relayd-supervisor'),
-    import('./modules/chat-runtime-providers/opencode/runtime-context'),
-    import('./modules/relay-transport/host-connector'),
-    import('./modules/remote-hosts/service'),
-    import('./modules/image-ocr/service'),
-    import('./modules/chat-runtime-providers/codex/usage-reconciliation-scheduler'),
-    import('./modules/chat-runtime/run-snapshot-maintenance'),
-    import('./modules/recall'),
-  ])
-  await recoverPersistedRunProjections()
-  initializeRecallProjection()
+  initializeDatabase(bootstrapReporter)
 
-  const opencodeRuntimeInstallationService = new OpencodeRuntimeInstallationService({
-    downloadCenter: downloadCenterService,
-    prepareManagedPathForRemoval: prepareOpencodeManagedPathForRemoval,
+  await runBootstrapPhase(bootstrapReporter, 'persisted-run-recovery', async () => {
+    const { recoverPersistedRunProjections } = await import('./modules/chat-runtime/runtime')
+    await recoverPersistedRunProjections()
   })
-  await opencodeRuntimeInstallationService.boot()
 
-  const managedResourceService = new ManagedResourceService([
-    createChronicleManagedResourceAdapter(downloadCenterService),
-    createOpencodeManagedResourceAdapter(opencodeRuntimeInstallationService),
-  ])
+  await runBootstrapPhase(bootstrapReporter, 'recall-projection', async () => {
+    const { initializeRecallProjection } = await import('./modules/recall')
+    initializeRecallProjection()
+  })
 
-  const app = await createServerContractApp({
-    includeRuntimeHttpPlugins: true,
-    downloadCenterService,
+  const [
+    app,
     managedResourceService,
     opencodeRuntimeInstallationService,
-  })
-  Worktree.registerStorageMeasurementActivity()
-  registerAgentToolsMcpServer()
-
-  // Initialize the always-on relay host-connector (connects to the host's own
-  // HTTP port to bridge controller tunnels). The local target is this server's
-  // own listen port — stream_open from a controller lands here.
-  const serverConfig = getServerConfig()
-  const hostConnector = initHostConnectorService({
-    localServerHost: '127.0.0.1',
-    localServerPort: serverConfig.port,
-  })
-
-  // Plugin system — discover and activate server plugins
-  await activateServerPlugins(app, {
-    hostServices: {
+    serverConfig,
+    hostConnector,
+    runtime,
+  ] = await runBootstrapPhase(bootstrapReporter, 'service-initialization', async () => {
+    await downloadCenterService.boot()
+    const [
+      { abortAllRuns, flushAllActiveRunSnapshots },
+      { shutdownTraceStreams },
+      { cleanup: chronicleCleanup },
+      chronicleService,
+      { refreshAllExternalProviderSources },
+      { reconcileExternalIssueSourceRegistrations },
+      { providerRuntimeHostManager },
+      { clearSideConversations },
+      { activateServerPlugins, deactivateAllPlugins },
+      conversationBridgeSupervisor,
+      { destroyWorkspaceFileIndexes },
+      localRelaydSupervisor,
+      { prepareOpencodeManagedPathForRemoval, stopOpencodeServer },
+      { initHostConnectorService, getHostConnectorService },
+      { shutdownRemoteHostConnections, startEnabledRelayRemoteHostConnections },
+      { shutdownImageOcr },
+      { CodexUsageReconciliationScheduler },
+      { RunSnapshotMaintenanceScheduler },
+    ] = await Promise.all([
+      import('./modules/chat-runtime/runtime'),
+      import('./modules/chat-runtime/stream-trace'),
+      import('./modules/chronicle/daemon-manager'),
+      import('./modules/chronicle/service'),
+      import('./modules/external-provider-sources/service'),
+      import('./modules/external-issue-sources/service'),
+      import('./modules/provider-runtime/host-manager'),
+      import('./modules/provider-runtime/side-conversation-registry'),
+      import('./plugins/loader'),
+      import('./modules/conversation-bridge/runtime-supervisor'),
+      import('./modules/workspace/files'),
+      import('./modules/relay-servers/local-relayd-supervisor'),
+      import('./modules/chat-runtime-providers/opencode/runtime-context'),
+      import('./modules/relay-transport/host-connector'),
+      import('./modules/remote-hosts/service'),
+      import('./modules/image-ocr/service'),
+      import('./modules/chat-runtime-providers/codex/usage-reconciliation-scheduler'),
+      import('./modules/chat-runtime/run-snapshot-maintenance'),
+    ])
+    const opencodeRuntimeInstallationService = new OpencodeRuntimeInstallationService({
       downloadCenter: downloadCenterService,
-      managedResources: managedResourceService,
-      dataDir: serverConfig.dataDir ?? dirname(serverConfig.dbPath),
-    },
+      prepareManagedPathForRemoval: prepareOpencodeManagedPathForRemoval,
+    })
+    await opencodeRuntimeInstallationService.boot()
+    const managedResourceService = new ManagedResourceService([
+      createChronicleManagedResourceAdapter(downloadCenterService),
+      createOpencodeManagedResourceAdapter(opencodeRuntimeInstallationService),
+    ])
+    const app = await createServerContractApp({
+      includeRuntimeHttpPlugins: true,
+      downloadCenterService,
+      managedResourceService,
+      opencodeRuntimeInstallationService,
+    })
+    Worktree.registerStorageMeasurementActivity()
+    registerAgentToolsMcpServer()
+    const serverConfig = getServerConfig()
+    const hostConnector = initHostConnectorService({
+      localServerHost: '127.0.0.1',
+      localServerPort: serverConfig.port,
+    })
+    return [
+      app,
+      managedResourceService,
+      opencodeRuntimeInstallationService,
+      serverConfig,
+      hostConnector,
+      {
+        abortAllRuns,
+        flushAllActiveRunSnapshots,
+        shutdownTraceStreams,
+        chronicleCleanup,
+        chronicleService,
+        refreshAllExternalProviderSources,
+        reconcileExternalIssueSourceRegistrations,
+        providerRuntimeHostManager,
+        clearSideConversations,
+        activateServerPlugins,
+        deactivateAllPlugins,
+        conversationBridgeSupervisor,
+        destroyWorkspaceFileIndexes,
+        localRelaydSupervisor,
+        stopOpencodeServer,
+        getHostConnectorService,
+        shutdownRemoteHostConnections,
+        startEnabledRelayRemoteHostConnections,
+        shutdownImageOcr,
+        CodexUsageReconciliationScheduler,
+        RunSnapshotMaintenanceScheduler,
+      },
+    ] as const
   })
-  reconcileExternalIssueSourceRegistrations()
+
+  const {
+    abortAllRuns,
+    flushAllActiveRunSnapshots,
+    shutdownTraceStreams,
+    chronicleCleanup,
+    chronicleService,
+    refreshAllExternalProviderSources,
+    reconcileExternalIssueSourceRegistrations,
+    providerRuntimeHostManager,
+    clearSideConversations,
+    activateServerPlugins,
+    deactivateAllPlugins,
+    conversationBridgeSupervisor,
+    destroyWorkspaceFileIndexes,
+    localRelaydSupervisor,
+    stopOpencodeServer,
+    getHostConnectorService,
+    shutdownRemoteHostConnections,
+    startEnabledRelayRemoteHostConnections,
+    shutdownImageOcr,
+    CodexUsageReconciliationScheduler,
+    RunSnapshotMaintenanceScheduler,
+  } = runtime
+
+  await runBootstrapPhase(bootstrapReporter, 'plugin-activation', async () => {
+    await activateServerPlugins(app, {
+      hostServices: {
+        downloadCenter: downloadCenterService,
+        managedResources: managedResourceService,
+        dataDir: serverConfig.dataDir ?? dirname(serverConfig.dbPath),
+      },
+    })
+    reconcileExternalIssueSourceRegistrations()
+  })
 
   const runtimeResources = new RuntimeResourceRegistry()
   const claudeUsageReconciliation = new ClaudeUsageReconciliationScheduler()

--- a/apps/server/src/bootstrap-lifecycle.test.ts
+++ b/apps/server/src/bootstrap-lifecycle.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ServerBootstrapReporter } from './bootstrap-lifecycle'
+
+describe('server bootstrap lifecycle', () => {
+  it('reports ordered phase timestamps and emits ready only after listener completion', async () => {
+    const publish = vi.fn()
+    const reporter = new ServerBootstrapReporter(publish)
+
+    await reporter.run('persisted-run-recovery', async () => undefined)
+    reporter.started('listener-establishment')
+    reporter.completed('listener-establishment')
+    reporter.ready()
+
+    expect(publish.mock.calls.map(([event]) => ({ phase: event.phase, kind: event.kind }))).toEqual(
+      [
+        { phase: 'persisted-run-recovery', kind: 'started' },
+        { phase: 'persisted-run-recovery', kind: 'completed' },
+        { phase: 'listener-establishment', kind: 'started' },
+        { phase: 'listener-establishment', kind: 'completed' },
+        { phase: 'listener-establishment', kind: 'ready' },
+      ],
+    )
+    expect(publish.mock.calls.every(([event]) => typeof event.at === 'string')).toBe(true)
+  })
+
+  it('timestamps the phase failure before preserving the original error', async () => {
+    const publish = vi.fn()
+    const reporter = new ServerBootstrapReporter(publish)
+
+    await expect(
+      reporter.run('plugin-activation', async () => {
+        throw new Error('plugin failed')
+      }),
+    ).rejects.toThrow('plugin failed')
+
+    expect(publish).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        phase: 'plugin-activation',
+        kind: 'failed',
+        error: 'plugin failed',
+        at: expect.any(String),
+      }),
+    )
+  })
+})

--- a/apps/server/src/bootstrap-lifecycle.ts
+++ b/apps/server/src/bootstrap-lifecycle.ts
@@ -1,0 +1,81 @@
+export const SERVER_BOOTSTRAP_PHASES = [
+  'database-migration',
+  'database-maintenance',
+  'persisted-run-recovery',
+  'service-initialization',
+  'plugin-activation',
+  'listener-establishment',
+] as const
+
+export type ServerBootstrapPhase = (typeof SERVER_BOOTSTRAP_PHASES)[number]
+export type ServerBootstrapEventKind = 'started' | 'completed' | 'failed' | 'ready'
+
+export interface ServerBootstrapEvent {
+  type: 'cradle-server-bootstrap'
+  phase: ServerBootstrapPhase
+  kind: ServerBootstrapEventKind
+  at: string
+  error?: string
+}
+
+type BootstrapEventSink = (event: ServerBootstrapEvent) => void
+
+function publishToParent(event: ServerBootstrapEvent): void {
+  process.send?.(event)
+}
+
+export class ServerBootstrapReporter {
+  constructor(private readonly publish: BootstrapEventSink = publishToParent) {}
+
+  started(phase: ServerBootstrapPhase): void {
+    this.emit(phase, 'started')
+  }
+
+  completed(phase: ServerBootstrapPhase): void {
+    this.emit(phase, 'completed')
+  }
+
+  failed(phase: ServerBootstrapPhase, error: unknown): void {
+    this.emit(phase, 'failed', error instanceof Error ? error.message : String(error))
+  }
+
+  ready(): void {
+    this.emit('listener-establishment', 'ready')
+  }
+
+  async run<T>(phase: ServerBootstrapPhase, operation: () => Promise<T>): Promise<T> {
+    this.started(phase)
+    try {
+      const result = await operation()
+      this.completed(phase)
+      return result
+    }
+ catch (error) {
+      this.failed(phase, error)
+      throw error
+    }
+  }
+
+  runSync<T>(phase: ServerBootstrapPhase, operation: () => T): T {
+    this.started(phase)
+    try {
+      const result = operation()
+      this.completed(phase)
+      return result
+    }
+ catch (error) {
+      this.failed(phase, error)
+      throw error
+    }
+  }
+
+  private emit(phase: ServerBootstrapPhase, kind: ServerBootstrapEventKind, error?: string): void {
+    this.publish({
+      type: 'cradle-server-bootstrap',
+      phase,
+      kind,
+      at: new Date().toISOString(),
+      ...(error ? { error } : {}),
+    })
+  }
+}

--- a/apps/server/src/database/migration-runner.ts
+++ b/apps/server/src/database/migration-runner.ts
@@ -3,22 +3,29 @@ import { eq } from 'drizzle-orm'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 import { z } from 'zod'
 
+import type { ServerBootstrapReporter } from '../bootstrap-lifecycle'
 import type { Logger } from '../logging/logger'
 import type { DatabaseConfig } from './database.config'
 import type { DbProvider } from './database.provider'
 
-const ErrorCauseCarrierSchema = z.object({
-  cause: z.object({
-    message: z.string().optional(),
-    code: z.string().optional(),
-  }).passthrough().optional(),
-}).passthrough()
+const ErrorCauseCarrierSchema = z
+  .object({
+    cause: z
+      .object({
+        message: z.string().optional(),
+        code: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough()
 
 export class MigrationRunner {
   constructor(
     private readonly provider: DbProvider,
     private readonly config: DatabaseConfig,
     private readonly logger: Logger,
+    private readonly bootstrapReporter?: ServerBootstrapReporter,
   ) {}
 
   onModuleInit(): void {
@@ -26,18 +33,18 @@ export class MigrationRunner {
     const { dbPath, migrationsDir } = this.config.getOptions()
 
     try {
-      this.publishStartupPhase('migrating')
-      migrate(db, { migrationsFolder: migrationsDir })
+      this.bootstrapReporter?.runSync('database-migration', () => {
+        migrate(db, { migrationsFolder: migrationsDir })
+      })
       this.runPendingMaintenanceTasks()
-      this.publishStartupPhase('initializing')
     }
-    catch (error) {
+ catch (error) {
       const cause = ErrorCauseCarrierSchema.parse(error).cause
       this.logger.error('Database migration failed', {
         dbPath,
         migrationsDir,
         errorMessage: error instanceof Error ? error.message : String(error),
-        causeMessage: cause instanceof Error ? cause.message : cause?.message ?? cause?.code,
+        causeMessage: cause instanceof Error ? cause.message : (cause?.message ?? cause?.code),
         error,
       })
       throw error
@@ -45,60 +52,67 @@ export class MigrationRunner {
   }
 
   private runPendingMaintenanceTasks(): void {
-    const pendingTasks = this.provider
-      .getDb()
-      .select()
-      .from(databaseMaintenanceTasks)
-      .where(eq(databaseMaintenanceTasks.status, 'pending'))
-      .all()
+    this.bootstrapReporter?.started('database-maintenance')
+    try {
+      const pendingTasks = this.provider
+        .getDb()
+        .select()
+        .from(databaseMaintenanceTasks)
+        .where(eq(databaseMaintenanceTasks.status, 'pending'))
+        .all()
 
-    for (const task of pendingTasks) {
-      if (task.id !== 'compact-chat-storage-v1') {
-        this.logger.warn('Unknown database maintenance task remains pending', { taskId: task.id })
-        continue
-      }
-
-      try {
-        this.publishStartupPhase('compacting')
-        const result = this.provider.compactDatabase()
-        if (result.status === 'deferred') {
-          this.logger.warn('Database compaction deferred because free space is insufficient', {
-            taskId: task.id,
-          })
+      let failedTask: unknown = null
+      for (const task of pendingTasks) {
+        if (task.id !== 'compact-chat-storage-v1') {
+          this.logger.warn('Unknown database maintenance task remains pending', { taskId: task.id })
           continue
         }
 
-        this.provider
-          .getDb()
-          .update(databaseMaintenanceTasks)
-          .set({
-            status: 'completed',
-            completedAt: Math.floor(Date.now() / 1000),
-            detailJson: JSON.stringify({
-              request: JSON.parse(task.detailJson),
-              result,
-            }),
+        try {
+          const result = this.provider.compactDatabase()
+          if (result.status === 'deferred') {
+            this.logger.warn('Database compaction deferred because free space is insufficient', {
+              taskId: task.id,
+            })
+            continue
+          }
+
+          this.provider
+            .getDb()
+            .update(databaseMaintenanceTasks)
+            .set({
+              status: 'completed',
+              completedAt: Math.floor(Date.now() / 1000),
+              detailJson: JSON.stringify({
+                request: JSON.parse(task.detailJson),
+                result,
+              }),
+            })
+            .where(eq(databaseMaintenanceTasks.id, task.id))
+            .run()
+          this.logger.info('Database maintenance task completed', {
+            taskId: task.id,
+            result,
           })
-          .where(eq(databaseMaintenanceTasks.id, task.id))
-          .run()
-        this.logger.info('Database maintenance task completed', {
-          taskId: task.id,
-          result,
-        })
+        }
+ catch (error) {
+          failedTask ??= error
+          this.logger.error('Database maintenance task failed and remains pending', {
+            taskId: task.id,
+            error,
+          })
+        }
       }
-      catch (error) {
-        this.logger.error('Database maintenance task failed and remains pending', {
-          taskId: task.id,
-          error,
-        })
+      if (failedTask) {
+        this.bootstrapReporter?.failed('database-maintenance', failedTask)
+      }
+ else {
+        this.bootstrapReporter?.completed('database-maintenance')
       }
     }
-  }
-
-  private publishStartupPhase(phase: 'migrating' | 'compacting' | 'initializing'): void {
-    process.send?.({
-      type: 'cradle-server-startup',
-      phase,
-    })
+ catch (error) {
+      this.bootstrapReporter?.failed('database-maintenance', error)
+      throw error
+    }
   }
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,3 +1,4 @@
+import { ServerBootstrapReporter } from './bootstrap-lifecycle'
 import { flushLogger, getLogger, initializeLogger } from './logging/logger'
 import type { CreateEventInput } from './modules/observability/contract'
 import { OBSERVABILITY_CODES } from './modules/observability/contract'
@@ -113,11 +114,8 @@ async function bootstrap() {
   initializeLogger()
   await initializeTelemetry()
   installProcessFatalHandlers()
-  const [
-    { createServerApp },
-    { loadServerConfig },
-    { warmupModelsDevCache },
-  ] = await Promise.all([
+  const bootstrapReporter = new ServerBootstrapReporter()
+  const [{ createServerApp }, { loadServerConfig }, { warmupModelsDevCache }] = await Promise.all([
     import('./app'),
     import('./config/server-config'),
     import('./modules/model-registry/model-info-registry'),
@@ -126,25 +124,32 @@ async function bootstrap() {
   const config = loadServerConfig()
   const logger = getLogger()
 
-  const app = await createServerApp()
+  const app = await createServerApp({ bootstrapReporter })
   activeRuntimeApp = app
   let runtimeServer: RuntimeServer | null = null
 
-  app.listen(
-    {
-      port: config.port,
-      hostname: config.host,
-    },
-    (server) => {
-      runtimeServer = server
-      activeRuntimeServer = server
-    },
-  )
-
-  // Force-refresh models.dev catalog on boot (SWR soft/hard TTL applies afterward)
-  warmupModelsDevCache()
-
-  logger.info(`listening on http://${config.host}:${config.port}`)
+  bootstrapReporter.started('listener-establishment')
+  try {
+    app.listen(
+      {
+        port: config.port,
+        hostname: config.host,
+      },
+      (server) => {
+        runtimeServer = server
+        activeRuntimeServer = server
+        bootstrapReporter.completed('listener-establishment')
+        bootstrapReporter.ready()
+        logger.info(`listening on http://${config.host}:${config.port}`)
+        // Force-refresh models.dev catalog on boot (SWR soft/hard TTL applies afterward)
+        warmupModelsDevCache()
+      },
+    )
+  }
+ catch (error) {
+    bootstrapReporter.failed('listener-establishment', error)
+    throw error
+  }
 
   let shutdownStarted = false
   const gracefulShutdown = async (signal: string) => {

--- a/apps/server/src/infra.ts
+++ b/apps/server/src/infra.ts
@@ -1,6 +1,7 @@
 import type { dbSchema } from '@cradle/db'
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
 
+import type { ServerBootstrapReporter } from './bootstrap-lifecycle'
 import type { ServerConfigValues } from './config/server-config'
 import { ServerConfig } from './config/server-config'
 import { DatabaseConfig } from './database/database.config'
@@ -88,13 +89,13 @@ export function getLogger(): Logger {
   return _logger
 }
 
-function ensureDbProvider(): DbProvider {
+function ensureDbProvider(bootstrapReporter?: ServerBootstrapReporter): DbProvider {
   refreshInfraForEnv()
   if (!_dbProvider) {
     const sc = _serverConfig ?? (_serverConfig = new ServerConfig())
     const dbConfig = new DatabaseConfig(sc)
     _dbProvider = new DbProvider(dbConfig)
-    new MigrationRunner(_dbProvider, dbConfig, getLogger()).onModuleInit()
+    new MigrationRunner(_dbProvider, dbConfig, getLogger(), bootstrapReporter).onModuleInit()
   }
   return _dbProvider
 }
@@ -102,6 +103,11 @@ function ensureDbProvider(): DbProvider {
 /** Return the raw drizzle database instance — the one thing services actually need. */
 export function db(): BetterSQLite3Database<typeof dbSchema> {
   return ensureDbProvider().getDb()
+}
+
+/** Initialize the database before other bootstrap services acquire it lazily. */
+export function initializeDatabase(bootstrapReporter?: ServerBootstrapReporter): void {
+  ensureDbProvider(bootstrapReporter)
 }
 
 /** Gracefully close the database and clear all cached singletons. */

--- a/apps/server/src/modules/health/index.ts
+++ b/apps/server/src/modules/health/index.ts
@@ -10,7 +10,7 @@ export const health = new Elysia({
   .get('', () => Health.check(), {
     detail: {
       'summary': 'Health check',
-      'description': 'Server liveness snapshot',
+      'description': 'Server readiness snapshot',
       'x-cradle-cli': {
         command: ['health'],
       },

--- a/apps/web/src/api-gen/@tanstack/react-query.gen.ts
+++ b/apps/web/src/api-gen/@tanstack/react-query.gen.ts
@@ -78,7 +78,7 @@ export const getHealthQueryKey = (options?: Options<GetHealthData>) => createQue
 /**
  * Health check
  *
- * Server liveness snapshot
+ * Server readiness snapshot
  */
 export const getHealthOptions = (options?: Options<GetHealthData>) => queryOptions<GetHealthResponse, DefaultError, GetHealthResponse, ReturnType<typeof getHealthQueryKey>>({
     queryFn: async ({ queryKey, signal }) => {

--- a/apps/web/src/api-gen/sdk.gen.ts
+++ b/apps/web/src/api-gen/sdk.gen.ts
@@ -54,7 +54,7 @@ export const postAuthBrowserSession = <ThrowOnError extends boolean = false>(opt
 /**
  * Health check
  *
- * Server liveness snapshot
+ * Server readiness snapshot
  */
 export const getHealth = <ThrowOnError extends boolean = false>(options?: Options<GetHealthData, ThrowOnError>) => (options?.client ?? client).get<GetHealthResponses, unknown, ThrowOnError>({
     requestValidator: async (data) => await z.object({

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -17,8 +17,36 @@ interface ImportMeta {
 
 type DesktopServerStatus
   = | { state: 'starting' }
-    | { state: 'ready', serverUrl: string }
-    | { state: 'failed', message: string }
+    | { state: 'migrating', phase: string }
+    | { state: 'bootstrapping', bootstrap: DesktopServerBootstrapSnapshot }
+    | { state: 'ready', serverUrl: string, bootstrap: DesktopServerBootstrapSnapshot }
+    | { state: 'failed', message: string, bootstrap: DesktopServerBootstrapSnapshot | null }
+
+type DesktopServerBootstrapSnapshot = {
+  startedAt: string
+  currentPhase:
+    | 'database-migration'
+    | 'database-maintenance'
+    | 'persisted-run-recovery'
+    | 'service-initialization'
+    | 'plugin-activation'
+    | 'listener-establishment'
+    | null
+  phaseStartedAt: string | null
+  phases: Partial<Record<NonNullable<DesktopServerBootstrapSnapshot['currentPhase']>, {
+    startedAt?: string
+    completedAt?: string
+    failedAt?: string
+    error?: string
+  }>>
+  lastEvent: {
+    type: 'cradle-server-bootstrap'
+    phase: NonNullable<DesktopServerBootstrapSnapshot['currentPhase']>
+    kind: 'started' | 'completed' | 'failed' | 'ready'
+    at: string
+    error?: string
+  } | null
+}
 
 // Stub out Electron-only window properties so devtool code compiles in web context.
 // These features are non-functional in the web build but won't crash.
@@ -65,7 +93,9 @@ interface Window {
       list: () => Promise<import('@cradle/download-center').DownloadTaskView[]>
       get: (taskId: string) => Promise<import('@cradle/download-center').DownloadTaskView | null>
       cancel: (taskId: string) => Promise<import('@cradle/download-center').DownloadTaskView | null>
-      onTaskChanged: (handler: (task: import('@cradle/download-center').DownloadTaskView) => void) => () => void
+      onTaskChanged: (
+        handler: (task: import('@cradle/download-center').DownloadTaskView) => void,
+      ) => () => void
     }
     serverRuntime?: {
       getStatus: () => Promise<DesktopServerStatus>
@@ -149,12 +179,14 @@ interface Window {
         method: string
         params?: Record<string, unknown>
       }) => Promise<unknown>
-      discoverLocalServers: () => Promise<Array<{
-        port: number
-        url: string
-        title: string
-        statusCode: number | null
-      }>>
+      discoverLocalServers: () => Promise<
+        Array<{
+          port: number
+          url: string
+          title: string
+          statusCode: number | null
+        }>
+      >
       navigate: (input: {
         threadId: string
         tabId?: string

--- a/apps/web/src/lib/server-readiness.test.ts
+++ b/apps/web/src/lib/server-readiness.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { waitForDesktopServer } from './server-readiness'
+
+afterEach(() => {
+  delete window.cradle
+})
+
+describe('desktop server readiness bridge', () => {
+  it('uses the retained status snapshot when the renderer attaches after ready was emitted', async () => {
+    const onStatusChanged = vi.fn(() => () => {})
+    window.cradle = {
+      env: { isElectron: true },
+      serverRuntime: {
+        getStatus: vi.fn(async () => ({
+          state: 'ready' as const,
+          serverUrl: 'http://127.0.0.1:21423',
+          bootstrap: {
+            currentPhase: null,
+            phaseStartedAt: null,
+            lastEvent: {
+              type: 'cradle-server-bootstrap' as const,
+              phase: 'listener-establishment' as const,
+              kind: 'ready' as const,
+              at: '2026-07-24T00:00:00.000Z',
+            },
+          },
+        })),
+        onStatusChanged,
+      },
+    } as unknown as typeof window.cradle
+
+    await expect(waitForDesktopServer()).resolves.toBe('http://127.0.0.1:21423')
+    expect(onStatusChanged).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/server-readiness.ts
+++ b/apps/web/src/lib/server-readiness.ts
@@ -4,9 +4,21 @@ import { getConfiguredServerUrl, setRuntimeServerUrl } from './server-endpoint-p
 type DesktopServerStatus
   = | { state: 'starting' }
     | { state: 'migrating', phase: string }
-    | { state: 'compacting' }
-    | { state: 'ready', serverUrl: string }
-    | { state: 'failed', message: string }
+    | { state: 'bootstrapping', bootstrap: DesktopServerBootstrapSnapshot }
+    | { state: 'ready', serverUrl: string, bootstrap: DesktopServerBootstrapSnapshot }
+    | { state: 'failed', message: string, bootstrap: DesktopServerBootstrapSnapshot | null }
+
+type DesktopServerBootstrapSnapshot = {
+  currentPhase:
+    | 'database-migration'
+    | 'database-maintenance'
+    | 'persisted-run-recovery'
+    | 'service-initialization'
+    | 'plugin-activation'
+    | 'listener-establishment'
+    | null
+  phaseStartedAt: string | null
+}
 
 const HEALTH_RETRY_DELAYS_MS = [200, 400, 800, 1_000] as const
 
@@ -25,7 +37,7 @@ async function waitForHostedServer(): Promise<string> {
         return serverUrl
       }
     }
-    catch {
+ catch {
       // The server is still starting or temporarily unreachable.
     }
 
@@ -35,19 +47,25 @@ async function waitForHostedServer(): Promise<string> {
   }
 }
 
-function waitForDesktopServer(): Promise<string> {
+export async function waitForDesktopServer(): Promise<string> {
   const runtime = window.cradle?.serverRuntime
   if (!runtime) {
-    return Promise.reject(new Error('Desktop server readiness bridge is unavailable.'))
+    throw new Error('Desktop server readiness bridge is unavailable.')
   }
 
+  const initialStatus = await runtime.getStatus()
   return new Promise((resolve, reject) => {
     let settled = false
     let unsubscribe = () => {}
 
     const handleStatus = (status: DesktopServerStatus) => {
       updateBootstrapStatus(status)
-      if (settled || status.state === 'starting' || status.state === 'migrating' || status.state === 'compacting') {
+      if (
+        settled
+        || status.state === 'starting'
+        || status.state === 'migrating'
+        || status.state === 'bootstrapping'
+      ) {
         return
       }
       settled = true
@@ -62,11 +80,13 @@ function waitForDesktopServer(): Promise<string> {
       resolve(getConfiguredServerUrl())
     }
 
-    const unsubscribeStatus = runtime.onStatusChanged(handleStatus)
-    unsubscribe = unsubscribeStatus
+    // Snapshot first: a renderer may attach after the server emitted ready.
+    handleStatus(initialStatus)
     if (settled) {
-      unsubscribeStatus()
+      return
     }
+    unsubscribe = runtime.onStatusChanged(handleStatus)
+    // Close the snapshot/subscribe race; updates remain event-driven afterward.
     void runtime.getStatus().then(handleStatus, reject)
   })
 }
@@ -76,19 +96,35 @@ function updateBootstrapStatus(status: DesktopServerStatus): void {
   if (!message) {
     return
   }
-  if (status.state === 'migrating') {
+  if (
+    status.state === 'migrating'
+    || (status.state === 'bootstrapping' && status.bootstrap.currentPhase === 'database-migration')
+  ) {
     message.textContent = 'Preparing your data…'
   }
-  else if (status.state === 'compacting') {
+ else if (
+    status.state === 'bootstrapping'
+    && status.bootstrap.currentPhase === 'database-maintenance'
+  ) {
     message.textContent = 'Making a little room…'
   }
-  else if (status.state === 'starting') {
+ else if (
+    status.state === 'bootstrapping'
+    && status.bootstrap.currentPhase === 'persisted-run-recovery'
+  ) {
+    message.textContent = 'Restoring your work…'
+  }
+ else if (
+    status.state === 'bootstrapping'
+    && status.bootstrap.currentPhase === 'plugin-activation'
+  ) {
+    message.textContent = 'Starting extensions…'
+  }
+ else if (status.state === 'starting') {
     message.textContent = 'Opening Cradle…'
   }
 }
 
 export function waitForServer(): Promise<string> {
-  return window.cradle?.env.isElectron
-    ? waitForDesktopServer()
-    : waitForHostedServer()
+  return window.cradle?.env.isElectron ? waitForDesktopServer() : waitForHostedServer()
 }


### PR DESCRIPTION
## Summary
Replace the migration-only startup exception with a server-owned, ordered bootstrap lifecycle covering migration, maintenance, persisted run recovery, service initialization, plugin activation, and listener establishment. Desktop retains a phase-timestamp snapshot, forwards nested managed-process IPC, supervises the full pre-listen lifecycle with bounded global/phase watchdogs, and requires both the listener-ready fact and /health before declaring ready. Renderer bootstrap reads the retained status snapshot before subscribing, and diagnostics report the stalled phase, duration, last event, and recent server output.

## Test plan
Passed: pnpm exec vitest run apps/server/src/bootstrap-lifecycle.test.ts apps/desktop/src/shared/server-runtime.test.ts apps/desktop/src/main/managed-process-protocol.test.ts apps/desktop/src/main/server-process.test.ts apps/web/src/lib/server-readiness.test.ts --no-file-parallelism (5 files, 20 tests). Passed: pnpm --filter @cradle/server typecheck && pnpm --filter @cradle/desktop typecheck && pnpm --filter @cradle/web typecheck. Passed targeted ESLint and git diff --check.

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)