### PR TITLE
feat(provider-auth): coordinate credential refreshes

### DIFF
--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/account-diagnostics.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/account-diagnostics.ts
@@ -19,10 +19,10 @@ import type { CodexAppServerClientLike } from '../types'
 import { buildDefaultCodexAppServerRequestResult } from './bridge'
 import type { CodexAppServerAuthResolution } from './chatgpt-auth'
 import {
-  ensureCodexChatgptAuthAccessToken,
   readCodexApiKeyAuth,
   readCodexChatgptAuth,
   resolveCodexAppServerAuth,
+  resolveFreshCodexChatgptAuthCredential,
 } from './chatgpt-auth'
 import type { CodexAppServerClientOptions } from './client'
 import { buildCodexAppServerEnv } from './env'
@@ -290,8 +290,13 @@ export async function readCodexWhamDiagnostics(
     }
   }
 
-  const chatgptAuth = await ensureCodexChatgptAuthAccessToken(readCodexChatgptAuth(resolved.auth)!, {
-    updateSecretValue: deps.updateSecretValue,
+  const currentChatgptAuth = readCodexChatgptAuth(resolved.auth)!
+  const chatgptAuth = await resolveFreshCodexChatgptAuthCredential({
+    credentialRef: currentChatgptAuth.credentialRef,
+    store: {
+      readSecret: deps.readSecret,
+      updateSecretValue: deps.updateSecretValue,
+    },
   })
   if (!chatgptAuth.accessToken) {
     throw new AppError({
@@ -383,10 +388,12 @@ async function acquireDiagnosticsHostLease(input: {
       }, input.auth),
       serverRequestHandler: request => buildDefaultCodexAppServerRequestResult(request, {
         chatgptAuth,
+        readSecret: input.deps.readSecret,
         updateSecretValue: input.deps.updateSecretValue,
       }),
     },
     deps: {
+      readSecret: input.deps.readSecret,
       createAppServerClient: input.deps.createAppServerClient,
       readCodexPreferences: input.deps.readCodexPreferences,
       readCodexCliCompatibleIdentity: input.deps.readCodexCliCompatibleIdentity,

--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/bridge.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/bridge.ts
@@ -19,8 +19,8 @@ import type { CodexAppServerAuthResolution, CodexChatgptAuthCredential } from '.
 import {
   readCodexApiKeyAuth,
   readCodexChatgptAuth,
-  refreshCodexChatgptAuthCredential,
   resolveCodexAppServerAuth,
+  resolveFreshCodexChatgptAuthCredential,
 } from './chatgpt-auth'
 import type { CodexAppServerClientOptions, CodexAppServerServerRequest } from './client'
 import { isCodexAppServerUnknownMethodError } from './client'
@@ -108,6 +108,7 @@ export class CodexAppServerBridge {
     const hostLease = await this.acquireHostLease(input, input.method, {
       serverRequestHandler: (request, auth) => buildDefaultCodexAppServerRequestResult(request, {
         chatgptAuth: auth,
+        readSecret: this.deps.readSecret,
         updateSecretValue: this.deps.updateSecretValue,
       }),
     })
@@ -143,6 +144,7 @@ export class CodexAppServerBridge {
               serverRequestHandler: async (request, auth) => {
                 const result = await buildDefaultCodexAppServerRequestResult(request, {
                   chatgptAuth: auth,
+                  readSecret: this.deps.readSecret,
                   updateSecretValue: this.deps.updateSecretValue,
                 })
                 writeSse(controller, encoder, 'server_request', {
@@ -260,6 +262,7 @@ export class CodexAppServerBridge {
       chatgptAuth,
       authenticateChatgpt: !isAccountAuthMutationMethod(requestedMethod),
       deps: {
+        readSecret: this.deps.readSecret,
         createAppServerClient: this.deps.createAppServerClient,
         readCodexPreferences: this.deps.readCodexPreferences,
         readCodexCliCompatibleIdentity: this.deps.readCodexCliCompatibleIdentity,
@@ -385,6 +388,7 @@ export async function buildDefaultCodexAppServerRequestResult(
   request: CodexAppServerServerRequest,
   options: {
     chatgptAuth?: CodexChatgptAuthCredential | null
+    readSecret?: (credentialRef: string) => string
     updateSecretValue?: (credentialRef: string, secret: string) => void
   } = {},
 ): Promise<unknown> {
@@ -405,8 +409,13 @@ export async function buildDefaultCodexAppServerRequestResult(
       if (!options.chatgptAuth) {
         throw new Error('Cradle Codex app-server bridge cannot refresh ChatGPT auth tokens without a ChatGPT credential')
       }
-      return projectChatgptAuthRefreshResponse(await refreshCodexChatgptAuthCredential(options.chatgptAuth, {
-        updateSecretValue: options.updateSecretValue,
+      if (!options.readSecret || !options.updateSecretValue) {
+        throw new Error('Cradle Codex app-server bridge cannot refresh ChatGPT auth tokens without a credential lifecycle store')
+      }
+      return projectChatgptAuthRefreshResponse(await resolveFreshCodexChatgptAuthCredential({
+        credentialRef: options.chatgptAuth.credentialRef,
+        store: { readSecret: options.readSecret, updateSecretValue: options.updateSecretValue },
+        forceRefresh: true,
       }))
     case 'attestation/generate':
       throw new Error('Cradle Codex app-server bridge cannot generate client attestation tokens')

--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/chatgpt-auth.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/chatgpt-auth.test.ts
@@ -224,8 +224,9 @@ describe('resolveFreshCodexChatgptAuthCredential', () => {
     })
     setCodexChatgptAuthRefreshFetchForTests(refresh)
 
-    const results = await Promise.all(Array.from({ length: 6 }).fill(resolveFreshCodexChatgptAuthCredential({
-      credentialRef: 'credential-chatgpt',
+    const credentialRefs = Array.from({ length: 6 }).fill('credential-chatgpt')
+    const results = await Promise.all(credentialRefs.map(credentialRef => resolveFreshCodexChatgptAuthCredential({
+      credentialRef,
       store: { readSecret: () => secret, updateSecretValue },
     })))
 

--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/chatgpt-auth.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/chatgpt-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { CodexConfig } from '../../../provider-contracts/provider-base'
 import { readTrustedCodexConfig } from '../../../provider-contracts/provider-base'
@@ -11,8 +11,15 @@ import {
   CODEX_BEDROCK_API_KEY_SECRET_KIND,
   CODEX_CHATGPT_AUTH_SECRET_KIND,
   CODEX_PERSONAL_ACCESS_TOKEN_SECRET_KIND,
+  CodexChatgptAuthReauthRequiredError,
   resolveCodexAppServerAuth,
+  resolveFreshCodexChatgptAuthCredential,
+  setCodexChatgptAuthRefreshFetchForTests,
 } from './chatgpt-auth'
+
+afterEach(() => {
+  setCodexChatgptAuthRefreshFetchForTests(null)
+})
 
 function createSecretMetadata(id: string, kind: string, secret: string) {
   return {
@@ -198,3 +205,89 @@ describe('resolveCodexAppServerAuth', () => {
     })
   })
 })
+
+describe('resolveFreshCodexChatgptAuthCredential', () => {
+  it('single-flights concurrent refreshes and persists refresh-token rotation once', async () => {
+    let secret = JSON.stringify({
+      accessToken: createJwt({ exp: 0 }),
+      refreshToken: 'refresh-token-1',
+      chatgptAccountId: 'account-1',
+      chatgptPlanType: 'plus',
+    })
+    const accessToken = createJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
+    const refresh = vi.fn(async () => new Response(JSON.stringify({
+      access_token: accessToken,
+      refresh_token: 'refresh-token-2',
+    }), { status: 200 }))
+    const updateSecretValue = vi.fn((_credentialRef: string, value: string) => {
+      secret = value
+    })
+    setCodexChatgptAuthRefreshFetchForTests(refresh)
+
+    const results = await Promise.all(Array.from({ length: 6 }).fill(resolveFreshCodexChatgptAuthCredential({
+      credentialRef: 'credential-chatgpt',
+      store: { readSecret: () => secret, updateSecretValue },
+    })))
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(updateSecretValue).toHaveBeenCalledTimes(1)
+    expect(results.map(result => result.accessToken)).toEqual(Array.from({ length: 6 }).fill(accessToken))
+    expect(JSON.parse(secret)).toMatchObject({ accessToken, refreshToken: 'refresh-token-2' })
+  })
+
+  it('maps invalid refresh credentials to reauth-required without erasing the stored secret', async () => {
+    const secret = JSON.stringify({
+      accessToken: createJwt({ exp: 0 }),
+      refreshToken: 'refresh-token-1',
+      chatgptAccountId: 'account-1',
+      chatgptPlanType: 'plus',
+    })
+    const updateSecretValue = vi.fn()
+    setCodexChatgptAuthRefreshFetchForTests(async () => new Response(JSON.stringify({
+      error: { code: 'invalid_grant' },
+    }), { status: 401 }))
+
+    await expect(resolveFreshCodexChatgptAuthCredential({
+      credentialRef: 'credential-chatgpt',
+      store: { readSecret: () => secret, updateSecretValue },
+    })).rejects.toBeInstanceOf(CodexChatgptAuthReauthRequiredError)
+
+    expect(updateSecretValue).not.toHaveBeenCalled()
+  })
+
+  it('does not call refresh while the access token remains outside the refresh window', async () => {
+    const accessToken = createJwt({ exp: Math.floor(Date.now() / 1000) + 3600 })
+    const refresh = vi.fn()
+    setCodexChatgptAuthRefreshFetchForTests(refresh)
+
+    const credential = await resolveFreshCodexChatgptAuthCredential({
+      credentialRef: 'credential-chatgpt',
+      store: {
+        readSecret: () => JSON.stringify({
+          accessToken,
+          refreshToken: 'refresh-token-1',
+          chatgptAccountId: 'account-1',
+          chatgptPlanType: 'plus',
+        }),
+        updateSecretValue: vi.fn(),
+      },
+    })
+
+    expect(credential.accessToken).toBe(accessToken)
+    expect(refresh).not.toHaveBeenCalled()
+  })
+})
+
+function createJwt(input: { exp: number }): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url'),
+    Buffer.from(JSON.stringify({
+      'exp': input.exp,
+      'https://api.openai.com/auth': {
+        chatgpt_account_id: 'account-1',
+        chatgpt_plan_type: 'plus',
+      },
+    })).toString('base64url'),
+    'sig',
+  ].join('.')
+}

--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/chatgpt-auth.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/chatgpt-auth.ts
@@ -3,6 +3,8 @@
  */
 import { readOptionalObjectRecord as readRecord } from '../../../../helpers/json-record'
 import { outboundFetch } from '../../../../lib/outbound-network'
+import type { CredentialAuthDriver, CredentialLifecycleStore } from '../../../provider-auth/credential-lifecycle'
+import { resolveFreshAccessToken } from '../../../provider-auth/credential-lifecycle'
 import type { CodexAuthMode, CodexConfig } from '../../../provider-contracts/provider-base'
 import type { SecretValueWithMetadata } from '../../../secrets/service'
 import type { LoginAccountParams } from '../app-server-protocol/v2/LoginAccountParams'
@@ -18,6 +20,10 @@ export const CODEX_BEDROCK_REGION_ENV = 'AWS_REGION'
 const CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
 const OPENAI_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token'
 const ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 5 * 60
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+let refreshFetchForTests: FetchLike | null = null
 
 export class CodexChatgptAuthReauthRequiredError extends Error {
   readonly code = 'codex_chatgpt_auth_reauth_required'
@@ -36,8 +42,13 @@ export interface CodexChatgptAuthCredential {
   chatgptPlanType: string | null
 }
 
-export interface CodexChatgptAuthDeps {
-  updateSecretValue?: (credentialRef: string, secret: string) => void
+export type CodexChatgptAuthStore = CredentialLifecycleStore
+
+export function setCodexChatgptAuthRefreshFetchForTests(fetchImpl: FetchLike | null): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('Codex ChatGPT auth refresh fetch override is test-only')
+  }
+  refreshFetchForTests = fetchImpl
 }
 
 export type CodexAppServerAuthResolution
@@ -216,14 +227,17 @@ function assertNoNativeCodexAuthModeWithoutCredential(selected: CodexAuthMode | 
   }
 }
 
-export async function ensureCodexChatgptAuthAccessToken(
-  credential: CodexChatgptAuthCredential,
-  deps: CodexChatgptAuthDeps,
-): Promise<CodexChatgptAuthCredential> {
-  if (credential.accessToken && !isAccessTokenExpiring(credential.accessToken)) {
-    return credential
-  }
-  return refreshCodexChatgptAuthCredential(credential, deps)
+export async function resolveFreshCodexChatgptAuthCredential(input: {
+  credentialRef: string
+  store: CodexChatgptAuthStore
+  forceRefresh?: boolean
+}): Promise<CodexChatgptAuthCredential> {
+  return await resolveFreshAccessToken({
+    credentialRef: input.credentialRef,
+    store: input.store,
+    driver: CODEX_CHATGPT_AUTH_DRIVER,
+    forceRefresh: input.forceRefresh,
+  })
 }
 
 export function buildCodexChatgptAuthLoginParams(
@@ -240,15 +254,14 @@ export function buildCodexChatgptAuthLoginParams(
   }
 }
 
-export async function refreshCodexChatgptAuthCredential(
+async function refreshCodexChatgptAuthCredential(
   credential: CodexChatgptAuthCredential,
-  deps: CodexChatgptAuthDeps,
 ): Promise<CodexChatgptAuthCredential> {
   if (!credential.refreshToken) {
     throw new Error('Codex ChatGPT auth refresh requires a refresh token')
   }
 
-  const response = await outboundFetch(OPENAI_OAUTH_TOKEN_URL, {
+  const response = await (refreshFetchForTests ?? outboundFetch)(OPENAI_OAUTH_TOKEN_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -295,15 +308,30 @@ export async function refreshCodexChatgptAuthCredential(
     chatgptAccountId,
     chatgptPlanType,
   }
-  deps.updateSecretValue?.(credential.credentialRef, JSON.stringify({
-    kind: CODEX_CHATGPT_AUTH_SECRET_KIND,
-    accessToken,
-    refreshToken: nextRefreshToken,
-    chatgptAccountId,
-    chatgptPlanType,
-    updatedAt: Date.now(),
-  }))
   return next
+}
+
+const CODEX_CHATGPT_AUTH_DRIVER: CredentialAuthDriver<CodexChatgptAuthCredential> = {
+  id: 'codex-chatgpt-auth',
+  parseCredential: (credentialRef, secret) => {
+    const credential = readCodexChatgptAuthCredential(credentialRef, secret)
+    if (!credential) {
+      throw new Error('Codex ChatGPT credential metadata is invalid')
+    }
+    return credential
+  },
+  hasFreshAccessToken: credential => Boolean(credential.accessToken && !isAccessTokenExpiring(credential.accessToken)),
+  refreshCredential: credential => refreshCodexChatgptAuthCredential(credential),
+  serializeCredential: credential => JSON.stringify({
+    kind: CODEX_CHATGPT_AUTH_SECRET_KIND,
+    accessToken: credential.accessToken,
+    refreshToken: credential.refreshToken,
+    chatgptAccountId: credential.chatgptAccountId,
+    chatgptPlanType: credential.chatgptPlanType,
+    updatedAt: Date.now(),
+  }),
+  isReauthRequired: error => error instanceof CodexChatgptAuthReauthRequiredError,
+  createReauthRequiredError: () => new CodexChatgptAuthReauthRequiredError(),
 }
 
 function parseJsonRecord(raw: string): Record<string, unknown> | null {
@@ -321,8 +349,10 @@ function isReauthRequiredRefreshResponse(status: number, body: string): boolean 
   }
   const parsed = parseJsonRecord(body)
   const error = readRecord(parsed?.error)
-  return readString(error?.code) === 'refresh_token_invalidated'
-    || readString(error?.code) === 'token_expired'
+  const code = readString(error?.code) ?? readString(parsed?.error)
+  return code === 'refresh_token_invalidated'
+    || code === 'token_expired'
+    || code === 'invalid_grant'
     || readString(error?.message)?.toLowerCase().includes('refresh token has been invalidated') === true
     || readString(error?.message)?.toLowerCase().includes('try signing in again') === true
 }

--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/host-lease.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/host-lease.ts
@@ -13,7 +13,7 @@ import type { CodexChatgptAuthCredential } from './chatgpt-auth'
 import {
   buildCodexChatgptAuthLoginParams,
   CodexChatgptAuthReauthRequiredError,
-  ensureCodexChatgptAuthAccessToken,
+  resolveFreshCodexChatgptAuthCredential,
 } from './chatgpt-auth'
 import type { CodexAppServerClientOptions } from './client'
 import { CodexAppServerClient } from './client'
@@ -24,6 +24,7 @@ import {
 } from './host-resource'
 
 export interface CodexAppServerHostLeaseDeps {
+  readSecret: (credentialRef: string) => string
   createAppServerClient?: (options: CodexAppServerClientOptions) => CodexAppServerClientLike
   readCodexPreferences?: () => { useCradleUserAgent: boolean }
   readCodexCliCompatibleIdentity?: () => boolean
@@ -82,6 +83,7 @@ export async function acquireCodexAppServerHostLease(
   try {
     await initializeCodexAppServerHost(lease.resource, {
       chatgptAuth: input.chatgptAuth,
+      readSecret: input.deps.readSecret,
       updateSecretValue: input.deps.updateSecretValue,
       authenticateChatgpt: input.authenticateChatgpt ?? true,
       mapChatgptAuthError: input.deps.mapChatgptAuthError,
@@ -112,6 +114,7 @@ async function initializeCodexAppServerHost(
   resource: CodexAppServerHostResource,
   input: {
     chatgptAuth: CodexChatgptAuthCredential | null
+    readSecret: (credentialRef: string) => string
     updateSecretValue?: (credentialRef: string, secret: string) => void
     authenticateChatgpt: boolean
     mapChatgptAuthError?: (error: CodexChatgptAuthReauthRequiredError) => Error
@@ -125,6 +128,7 @@ async function initializeCodexAppServerHost(
   const chatgptAuth = input.chatgptAuth
   resource.chatgptAuthenticated ??= authenticateCodexAppServerChatgpt(resource.client, {
     chatgptAuth,
+    readSecret: input.readSecret,
     updateSecretValue: input.updateSecretValue,
     mapChatgptAuthError: input.mapChatgptAuthError,
   })
@@ -135,13 +139,18 @@ async function authenticateCodexAppServerChatgpt(
   client: CodexAppServerClientLike,
   input: {
     chatgptAuth: CodexChatgptAuthCredential
+    readSecret: (credentialRef: string) => string
     updateSecretValue?: (credentialRef: string, secret: string) => void
     mapChatgptAuthError?: (error: CodexChatgptAuthReauthRequiredError) => Error
   },
 ): Promise<void> {
   try {
-    const credential = await ensureCodexChatgptAuthAccessToken(input.chatgptAuth, {
-      updateSecretValue: input.updateSecretValue,
+    const credential = await resolveFreshCodexChatgptAuthCredential({
+      credentialRef: input.chatgptAuth.credentialRef,
+      store: {
+        readSecret: input.readSecret,
+        updateSecretValue: input.updateSecretValue ?? missingCredentialLifecycleStore,
+      },
     })
     await client.request('account/login/start', buildCodexChatgptAuthLoginParams(credential))
   }
@@ -151,4 +160,8 @@ async function authenticateCodexAppServerChatgpt(
     }
     throw error
   }
+}
+
+function missingCredentialLifecycleStore(): never {
+  throw new Error('Codex ChatGPT auth requires a credential lifecycle store')
 }

--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/model-list.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/model-list.ts
@@ -4,7 +4,7 @@ import type { CodexAppServerClientLike } from '../types'
 import type { CodexChatgptAuthCredential } from './chatgpt-auth'
 import {
   buildCodexChatgptAuthLoginParams,
-  ensureCodexChatgptAuthAccessToken,
+  resolveFreshCodexChatgptAuthCredential,
 } from './chatgpt-auth'
 import type { CodexAppServerClientOptions } from './client'
 import { CodexAppServerClient } from './client'
@@ -16,14 +16,19 @@ let createClientForTests: ((options?: CodexAppServerClientOptions) => CodexAppSe
 export async function listCodexChatgptModels(input: {
   credential: CodexChatgptAuthCredential
   config?: Record<string, unknown>
+  readSecret: (credentialRef: string) => string
   updateSecretValue?: (credentialRef: string, secret: string) => void
 }): Promise<ModelDescriptor[]> {
   const clientOptions = input.config ? { config: input.config } : undefined
   const client = createClientForTests?.(clientOptions) ?? new CodexAppServerClient(clientOptions)
   try {
     await client.initialize()
-    const credential = await ensureCodexChatgptAuthAccessToken(input.credential, {
-      updateSecretValue: input.updateSecretValue,
+    const credential = await resolveFreshCodexChatgptAuthCredential({
+      credentialRef: input.credential.credentialRef,
+      store: {
+        readSecret: input.readSecret,
+        updateSecretValue: input.updateSecretValue ?? missingCredentialLifecycleStore,
+      },
     })
     await client.request('account/login/start', buildCodexChatgptAuthLoginParams(credential))
     const response = await client.request('model/list', {
@@ -35,6 +40,10 @@ export async function listCodexChatgptModels(input: {
   finally {
     await client.close()
   }
+}
+
+function missingCredentialLifecycleStore(): never {
+  throw new Error('Codex ChatGPT model listing requires a credential lifecycle store')
 }
 
 export async function listCodexApiKeyModels(input: {

--- a/apps/server/src/modules/chat-runtime-providers/codex/provider.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/provider.ts
@@ -347,6 +347,7 @@ export class CodexProvider implements ChatRuntime {
         }, auth),
         serverRequestHandler: request => buildDefaultCodexAppServerRequestResult(request, {
           chatgptAuth,
+          readSecret: this.deps.readSecret,
           updateSecretValue: this.deps.updateSecret,
         }),
       },
@@ -459,6 +460,7 @@ export class CodexProvider implements ChatRuntime {
         env: codexEnv,
         serverRequestHandler: request => buildDefaultCodexAppServerRequestResult(request, {
           chatgptAuth,
+          readSecret: this.deps.readSecret,
           updateSecretValue: this.deps.updateSecret,
         }),
       },
@@ -626,6 +628,7 @@ export class CodexProvider implements ChatRuntime {
         }, auth),
         serverRequestHandler: request => buildDefaultCodexAppServerRequestResult(request, {
           chatgptAuth,
+          readSecret: this.deps.readSecret,
           updateSecretValue: this.deps.updateSecret,
         }),
       },
@@ -936,6 +939,7 @@ export class CodexProvider implements ChatRuntime {
         }, auth),
         serverRequestHandler: request => buildDefaultCodexAppServerRequestResult(request, {
           chatgptAuth,
+          readSecret: this.deps.readSecret,
           updateSecretValue: this.deps.updateSecret,
         }),
       },
@@ -980,6 +984,7 @@ export class CodexProvider implements ChatRuntime {
         }, auth),
         serverRequestHandler: request => buildDefaultCodexAppServerRequestResult(request, {
           chatgptAuth,
+          readSecret: this.deps.readSecret,
           updateSecretValue: this.deps.updateSecret,
         }),
       },
@@ -1035,6 +1040,7 @@ export class CodexProvider implements ChatRuntime {
       createServerRequestHandler: (auth) => {
         const handler: CodexAppServerResourceRequestHandler = request => this.handleCodexServerRequest(input, request, {
           chatgptAuth: readCodexChatgptAuth(auth),
+          readSecret: this.deps.readSecret,
           updateSecretValue: this.deps.updateSecret,
         })
         handler.readThreadId = () => input.runtimeSession.providerSessionId
@@ -1499,6 +1505,7 @@ export class CodexProvider implements ChatRuntime {
     request: Parameters<NonNullable<CodexAppServerClientOptions['serverRequestHandler']>>[0],
     options: {
       chatgptAuth?: CodexChatgptAuthCredential | null
+      readSecret?: (credentialRef: string) => string
       updateSecretValue?: (credentialRef: string, secret: string) => void
     },
   ): Promise<unknown> {
@@ -1682,6 +1689,7 @@ export class CodexProvider implements ChatRuntime {
       chatgptAuth: input.chatgptAuth,
       pinned: input.pinned ?? false,
       deps: {
+        readSecret: this.deps.readSecret,
         createAppServerClient: this.deps.createAppServerClient,
         readCodexPreferences: this.deps.readCodexPreferences,
         readCodexCliCompatibleIdentity: this.deps.readCodexCliCompatibleIdentity,
@@ -1775,6 +1783,7 @@ export class CodexProvider implements ChatRuntime {
               env: input.codexEnv,
               serverRequestHandler: request => buildDefaultCodexAppServerRequestResult(request, {
                 chatgptAuth: input.chatgptAuth,
+                readSecret: this.deps.readSecret,
                 updateSecretValue: this.deps.updateSecret,
               }),
             },
@@ -1839,6 +1848,7 @@ export class CodexProvider implements ChatRuntime {
         env: codexEnv,
         serverRequestHandler: request => buildDefaultCodexAppServerRequestResult(request, {
           chatgptAuth,
+          readSecret: this.deps.readSecret,
           updateSecretValue: this.deps.updateSecret,
         }),
       },
@@ -1879,6 +1889,7 @@ export class CodexProvider implements ChatRuntime {
           env: buildCodexAppServerEnv(codexEnvInput, titleGeneration.auth),
           serverRequestHandler: request => buildDefaultCodexAppServerRequestResult(request, {
             chatgptAuth: titleChatgptAuth,
+            readSecret: this.deps.readSecret,
             updateSecretValue: this.deps.updateSecret,
           }),
         },

--- a/apps/server/src/modules/provider-auth/README.md
+++ b/apps/server/src/modules/provider-auth/README.md
@@ -1,0 +1,7 @@
+# Provider Auth
+
+Owns the generic lifecycle for encrypted provider credentials. Drivers retain
+provider-specific login, token formats, expiry, refresh endpoints, and public
+account projection. The lifecycle reads and updates `agent_credentials` through
+the secrets owner, coalesces in-process refreshes by credential reference, and
+does not cache plaintext credentials after a refresh completes.

--- a/apps/server/src/modules/provider-auth/credential-lifecycle.test.ts
+++ b/apps/server/src/modules/provider-auth/credential-lifecycle.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { resetCredentialLifecycleForTests, resolveFreshAccessToken } from './credential-lifecycle'
+
+interface TestCredential {
+  accessToken: string
+  refreshToken: string
+  fresh: boolean
+}
+
+const driver = {
+  id: 'test-provider',
+  parseCredential: (_credentialRef: string, secret: string): TestCredential =>
+    JSON.parse(secret) as TestCredential,
+  hasFreshAccessToken: (credential: TestCredential): boolean => credential.fresh,
+  refreshCredential: async (credential: TestCredential): Promise<TestCredential> => ({
+    accessToken: 'new-access-token',
+    refreshToken: `${credential.refreshToken}-rotated`,
+    fresh: true,
+  }),
+  serializeCredential: (credential: TestCredential): string => JSON.stringify(credential),
+  isReauthRequired: (): boolean => false,
+  createReauthRequiredError: (): Error => new Error('reauth required'),
+}
+
+afterEach(() => {
+  resetCredentialLifecycleForTests()
+})
+
+describe('resolveFreshAccessToken', () => {
+  it('coalesces concurrent refreshes and atomically persists the rotated credential', async () => {
+    let secret = JSON.stringify({
+      accessToken: 'expired-access-token',
+      refreshToken: 'refresh-1',
+      fresh: false,
+    })
+    const refreshCredential = vi.fn(
+      async (credential: TestCredential): Promise<TestCredential> => ({
+        accessToken: 'new-access-token',
+        refreshToken: `${credential.refreshToken}-rotated`,
+        fresh: true,
+      }),
+    )
+    const updateSecretValue = vi.fn((_credentialRef: string, next: string) => {
+      secret = next
+    })
+    const results = await Promise.all(
+      Array.from({ length: 8 }).fill(resolveFreshAccessToken({
+          credentialRef: 'credential-1',
+          store: { readSecret: () => secret, updateSecretValue },
+          driver: { ...driver, refreshCredential },
+        })),
+    )
+
+    expect(refreshCredential).toHaveBeenCalledTimes(1)
+    expect(updateSecretValue).toHaveBeenCalledTimes(1)
+    expect(results).toEqual(
+      Array.from({ length: 8 }).fill({
+        accessToken: 'new-access-token',
+        refreshToken: 'refresh-1-rotated',
+        fresh: true,
+      }),
+    )
+    expect(JSON.parse(secret)).toEqual(results[0])
+  })
+
+  it('does not refresh a credential outside its refresh window', async () => {
+    const refreshCredential = vi.fn(driver.refreshCredential)
+    const result = await resolveFreshAccessToken({
+      credentialRef: 'credential-1',
+      store: {
+        readSecret: () =>
+          JSON.stringify({
+            accessToken: 'current-access-token',
+            refreshToken: 'refresh-1',
+            fresh: true,
+          }),
+        updateSecretValue: vi.fn(),
+      },
+      driver: { ...driver, refreshCredential },
+    })
+
+    expect(refreshCredential).not.toHaveBeenCalled()
+    expect(result.accessToken).toBe('current-access-token')
+  })
+
+  it('does not overwrite a credential when a recoverable refresh failure occurs', async () => {
+    const updateSecretValue = vi.fn()
+    await expect(
+      resolveFreshAccessToken({
+        credentialRef: 'credential-1',
+        store: {
+          readSecret: () =>
+            JSON.stringify({
+              accessToken: 'expired-access-token',
+              refreshToken: 'refresh-1',
+              fresh: false,
+            }),
+          updateSecretValue,
+        },
+        driver: {
+          ...driver,
+          refreshCredential: async () => {
+            throw new Error('network unavailable')
+          },
+        },
+      }),
+    ).rejects.toThrow('network unavailable')
+
+    expect(updateSecretValue).not.toHaveBeenCalled()
+  })
+})

--- a/apps/server/src/modules/provider-auth/credential-lifecycle.ts
+++ b/apps/server/src/modules/provider-auth/credential-lifecycle.ts
@@ -1,0 +1,97 @@
+/**
+ * Coordinates refreshes for encrypted credentials without retaining a token cache.
+ * Provider-specific token parsing, expiry, refresh, and error semantics stay in
+ * each provider driver.
+ */
+export interface CredentialLifecycleStore {
+  readSecret: (credentialRef: string) => string
+  updateSecretValue: (credentialRef: string, secret: string) => void
+}
+
+export interface CredentialAuthDriver<TCredential> {
+  readonly id: string
+  parseCredential: (credentialRef: string, secret: string) => TCredential
+  hasFreshAccessToken: (credential: TCredential) => boolean
+  refreshCredential: (credential: TCredential) => Promise<TCredential>
+  serializeCredential: (credential: TCredential) => string
+  isReauthRequired: (error: unknown) => boolean
+  createReauthRequiredError: () => Error
+}
+
+export interface ResolveFreshAccessTokenInput<TCredential> {
+  credentialRef: string
+  store: CredentialLifecycleStore
+  driver: CredentialAuthDriver<TCredential>
+  forceRefresh?: boolean
+}
+
+const inFlightRefreshes = new Map<string, Promise<unknown>>()
+
+/**
+ * Reads the durable credential on every call. Expiring credentials share one
+ * refresh per driver/ref pair; the refresh owner re-reads before refreshing so
+ * token rotation by a prior caller cannot be overwritten.
+ */
+export async function resolveFreshAccessToken<TCredential>(
+  input: ResolveFreshAccessTokenInput<TCredential>,
+): Promise<TCredential> {
+  const current = readCredential(input)
+  if (!input.forceRefresh && input.driver.hasFreshAccessToken(current)) {
+    return current
+  }
+
+  const key = `${input.driver.id}:${input.credentialRef}`
+  const existing = inFlightRefreshes.get(key) as Promise<TCredential> | undefined
+  if (existing) {
+    return await existing
+  }
+
+  const refresh = refreshCredential(input)
+  inFlightRefreshes.set(key, refresh)
+  try {
+    return await refresh
+  }
+ finally {
+    if (inFlightRefreshes.get(key) === refresh) {
+      inFlightRefreshes.delete(key)
+    }
+  }
+}
+
+function readCredential<TCredential>(
+  input: ResolveFreshAccessTokenInput<TCredential>,
+): TCredential {
+  return input.driver.parseCredential(
+    input.credentialRef,
+    input.store.readSecret(input.credentialRef),
+  )
+}
+
+async function refreshCredential<TCredential>(
+  input: ResolveFreshAccessTokenInput<TCredential>,
+): Promise<TCredential> {
+  // The caller that won single-flight must observe the latest durable value.
+  const current = readCredential(input)
+  if (!input.forceRefresh && input.driver.hasFreshAccessToken(current)) {
+    return current
+  }
+
+  try {
+    const refreshed = await input.driver.refreshCredential(current)
+    input.store.updateSecretValue(input.credentialRef, input.driver.serializeCredential(refreshed))
+    return refreshed
+  }
+ catch (error) {
+    if (input.driver.isReauthRequired(error)) {
+      throw input.driver.createReauthRequiredError()
+    }
+    throw error
+  }
+}
+
+export function resetCredentialLifecycleForTests(): void {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('Credential lifecycle reset is test-only')
+  }
+  inFlightRefreshes.clear()
+}

--- a/apps/server/src/modules/provider-catalog/catalog.ts
+++ b/apps/server/src/modules/provider-catalog/catalog.ts
@@ -102,6 +102,7 @@ class OpenAICompatibleMetadataProvider implements ProviderMetadataProvider {
         const baseUrl = config.baseUrl?.trim() || null
         return await listCodexChatgptModels({
           credential: chatgptAuth,
+          readSecret: deps.readSecret,
           config: baseUrl
             ? buildCodexExternalModelProviderConfig(
                 normalizeBaseUrl(baseUrl),


### PR DESCRIPTION
## Summary
Introduces a provider-owned credential lifecycle and migrates Codex ChatGPT OAuth refreshes through it. The lifecycle keeps encrypted agent_credentials as the only secret store, single-flights concurrent refreshes by credential, persists rotated refresh tokens atomically, and maps unrecoverable refresh failures to reauth-required. This revision corrects the concurrency test so it creates six independent resolve requests instead of repeating one Promise.

## Test plan
Passed: pnpm exec eslint apps/server/src/modules/chat-runtime-providers/codex/app-server/chatgpt-auth.test.ts
Passed: pnpm --filter @cradle/server exec vitest run src/modules/provider-auth/credential-lifecycle.test.ts src/modules/chat-runtime-providers/codex/app-server/chatgpt-auth.test.ts src/modules/chat-runtime-providers/codex/app-server/bridge.test.ts src/modules/chat-runtime-providers/codex/app-server/account-diagnostics.test.ts src/modules/provider-catalog/catalog.test.ts src/modules/chat-runtime-providers/codex/provider.test.ts (110 tests)
Passed: pnpm --filter @cradle/server exec tsc -p tsconfig.json --noEmit
Known baseline failure: pnpm --filter @cradle/server check:boundaries reports the existing runtime-domain SCC of 25 modules; provider-auth is not in that SCC.

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)