### PR TITLE
fix(desktop): restore CRADLE_AUTH_TOKEN for network access mode

### DIFF
--- a/apps/desktop/src/main/server-process.ts
+++ b/apps/desktop/src/main/server-process.ts
@@ -280,7 +280,7 @@ async function spawnServer(opts: {
   bootstrapWatchdog?: ServerBootstrapWatchdog
   onBootstrapEvent?: (event: ServerBootstrapEvent) => void
 }): Promise<void> {
-  const { host, port, dataDir, credentialSecret } = opts
+  const { host, port, dataDir, credentialSecret, serverAuthToken } = opts
 
   // In dev, use tsx to run the TS source directly
   // In production, run the compiled server entry
@@ -311,7 +311,8 @@ async function spawnServer(opts: {
     CRADLE_DATA_DIR: dataDir,
     CRADLE_VERSION: app.getVersion(),
     CRADLE_CREDENTIAL_SECRET: credentialSecret,
-    // CRADLE_AUTH_TOKEN: serverAuthToken,
+    // Non-loopback binds (network access mode) require this; local mode also uses it for auth.
+    CRADLE_AUTH_TOKEN: serverAuthToken,
     CRADLE_DESKTOP_PID: String(process.pid),
     CRADLE_PLUGINS_DIR: pluginsDir,
     CRADLE_PLUGINS_SOURCE_KIND: pluginsSourceKind,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Desktop network access mode binds the owned server to `0.0.0.0`. Server config fail-closes unless `CRADLE_AUTH_TOKEN` is set for non-loopback hosts.

A previous integration commit commented out the env injection while Desktop continued to:

- generate/persist `server-auth-token`
- pass it to the renderer via `--server-auth-token`
- pass it into `spawnServer({ serverAuthToken })`

…but never set `CRADLE_AUTH_TOKEN` on the child. Bootstrap then failed with:

`CRADLE_AUTH_TOKEN is required when CRADLE_HOST is not loopback`

## Fix

Restore `CRADLE_AUTH_TOKEN: serverAuthToken` in `spawnServer` env construction.

## Test plan

- [ ] With inbound `serverAccessMode: network`, launch Desktop and confirm the owned server becomes ready
- [ ] Confirm local-only mode still starts
- [ ] Confirm renderer still receives `--server-auth-token` and can authenticate when auth is required

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c157645b-277b-4cf0-b4e9-796161918547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c157645b-277b-4cf0-b4e9-796161918547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

