### PR TITLE
feat(diffs): wire repository-first Diffs UI to app tokens

### DIFF
--- a/apps/web/src/features/diff-review/diff-home-page.tsx
+++ b/apps/web/src/features/diff-review/diff-home-page.tsx
@@ -1,10 +1,9 @@
-import { FolderOpen2Line as FolderOpenIcon, GitCompareLine as DiffIcon } from '@mingcute/react'
-import { useMemo, useState } from 'react'
+import { FolderOpen2Line as FolderOpenIcon } from '@mingcute/react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ResizeHandle } from '~/components/layout/resize-handle'
+import { DiffWorkerProvider } from '~/components/common/diff/diff-runtime'
 import { useRegisterLayoutSlots } from '~/components/layout/use-layout-slots'
-import { Button } from '~/components/ui/button'
 import {
   Empty,
   EmptyDescription,
@@ -12,33 +11,10 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '~/components/ui/empty'
-import { ScrollArea } from '~/components/ui/scroll-area'
-import { Spinner } from '~/components/ui/spinner'
-import { getWorkspaceLocationLabel } from '~/features/workspace/types'
 import { useWorkspaces } from '~/features/workspace/use-workspace'
-import { cn } from '~/lib/cn'
 
+import { DiffsIndexContainer } from './review/diffs-index-container'
 import { WorkspaceDiffsView } from './workspace-diffs-view'
-
-const ASIDE_WIDTH_KEY = 'cradle-diffs:aside-width'
-const ASIDE_WIDTH_DEFAULT = 256
-const ASIDE_WIDTH_MIN = 220
-const ASIDE_WIDTH_MAX = 400
-
-function readAsideWidth(): number {
-  if (typeof window === 'undefined') {
-    return ASIDE_WIDTH_DEFAULT
-  }
-  const raw = window.localStorage.getItem(ASIDE_WIDTH_KEY)
-  if (!raw) {
-    return ASIDE_WIDTH_DEFAULT
-  }
-  const parsed = Number(raw)
-  if (!Number.isFinite(parsed)) {
-    return ASIDE_WIDTH_DEFAULT
-  }
-  return Math.max(ASIDE_WIDTH_MIN, Math.min(ASIDE_WIDTH_MAX, parsed))
-}
 
 export interface DiffHomePageProps {
   workspace?: string
@@ -48,9 +24,15 @@ export interface DiffHomePageProps {
   line?: number
   side?: 'base' | 'head'
   github?: string
-  onWorkspaceSelect: (workspaceId: string) => void
 }
 
+/**
+ * Diffs home.
+ *
+ * Browsing is repository-first via `DiffsIndexContainer`. Opening a review (or
+ * a working-tree / GitHub deep link) drops the index chrome and mounts the
+ * review reading surface full-bleed — the detail View already owns Back.
+ */
 export function DiffHomePage({
   workspace,
   repo,
@@ -59,21 +41,12 @@ export function DiffHomePage({
   line,
   side,
   github,
-  onWorkspaceSelect,
 }: DiffHomePageProps) {
   const { t } = useTranslation('diff-review')
   const { t: tWorkspace } = useTranslation('workspace')
-  const { workspaces, loading } = useWorkspaces()
-  const [asideWidth, setAsideWidth] = useState<number>(readAsideWidth)
+  const { workspaces } = useWorkspaces()
 
-  const persistAsideWidth = (width: number) => {
-    try {
-      window.localStorage.setItem(ASIDE_WIDTH_KEY, String(width))
-    }
-    catch {
-      // ignore storage failures
-    }
-  }
+  const isDetail = Boolean(review || path || github)
 
   const selectedWorkspace = useMemo(() => {
     if (workspace) {
@@ -87,160 +60,52 @@ export function DiffHomePage({
 
   useRegisterLayoutSlots('diff', useMemo(() => ({
     asideWorkspaceId: selectedWorkspace?.id ?? null,
-    hasAside: Boolean(selectedWorkspace),
+    hasAside: Boolean(selectedWorkspace) && isDetail,
     hasBrowserPanel: false,
     hasPanel: false,
-  }), [selectedWorkspace]))
+  }), [isDetail, selectedWorkspace]))
+
+  if (isDetail) {
+    if (!selectedWorkspace) {
+      return (
+        <div className="flex h-full items-center justify-center px-6 bg-background" data-testid="diff-home-page">
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <FolderOpenIcon className="size-5" aria-hidden="true" />
+              </EmptyMedia>
+              <EmptyTitle>{t('home.empty.title')}</EmptyTitle>
+              <EmptyDescription>{tWorkspace('sidebar.projects.empty.description')}</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        </div>
+      )
+    }
+
+    return (
+      <div className="h-full min-w-0 overflow-hidden bg-background" data-testid="diff-home-page">
+        <WorkspaceDiffsView
+          key={selectedWorkspace.id}
+          workspaceId={selectedWorkspace.id}
+          repo={repo}
+          path={path}
+          review={review}
+          line={line}
+          side={side}
+          github={github}
+        />
+      </div>
+    )
+  }
 
   return (
-    <div className="flex h-full min-w-0 overflow-hidden bg-background" data-testid="diff-home-page">
-      <aside
-        className="flex min-w-0 shrink-0 flex-col overflow-hidden border-r border-border/60 bg-muted/20"
-        style={{ width: asideWidth }}
-      >
-        {/* Identity */}
-        <div className="shrink-0 px-4 pt-5 pb-3">
-          <div className="flex items-center gap-2.5">
-            <span className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-muted/60 text-foreground">
-              <DiffIcon className="size-[15px]" aria-hidden="true" />
-            </span>
-            <div className="min-w-0">
-              <h1 className="truncate text-[13px] font-semibold tracking-tight text-foreground">
-                {t('home.title')}
-              </h1>
-              <p className="truncate text-[11px] text-muted-foreground">
-                {t('home.description')}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        {/* Workspaces — inset-grouped list */}
-        <div className="flex items-center justify-between px-5 pb-1.5 pt-2">
-          <span className="text-[11px] font-medium text-muted-foreground">
-            {t('home.workspaces')}
-          </span>
-          {workspaces.length > 0 && (
-            <span className="text-[11px] tabular-nums text-muted-foreground/50">
-              {workspaces.length}
-            </span>
-          )}
-        </div>
-
-        <ScrollArea
-          className="min-h-0 flex-1 px-3 pb-4"
-          contentClassName="min-w-0"
-        >
-          {loading && (
-            <div className="flex items-center gap-2 px-3 py-3 text-[12px] text-muted-foreground">
-              <Spinner className="size-3.5" />
-              <span>{t('home.loading')}</span>
-            </div>
-          )}
-
-          {!loading && workspaces.length === 0 && (
-            <div className="px-3 py-3 text-[12px] text-muted-foreground">
-              {t('home.emptyWorkspaces')}
-            </div>
-          )}
-
-          {!loading && workspaces.length > 0 && (
-            <div className="overflow-hidden rounded-lg border border-border/50 bg-card shadow-xs">
-              <ul role="list" className="divide-y divide-border/40">
-                {workspaces.map((item) => {
-                  const selected = selectedWorkspace?.id === item.id
-                  const locationLabel = getWorkspaceLocationLabel(item)
-                  return (
-                    <li key={item.id} className="relative min-w-0">
-                      {selected && (
-                        <span
-                          aria-hidden
-                          className="absolute left-0 top-1/2 h-5 w-[2px] -translate-y-1/2 rounded-r-full bg-foreground"
-                        />
-                      )}
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        onClick={() => onWorkspaceSelect(item.id)}
-                        className={cn(
-                          'h-auto min-h-[40px] w-full min-w-0 justify-start gap-2.5 rounded-none pl-3.5 pr-3 py-1.5 text-left font-normal whitespace-normal',
-                          'active:scale-[0.99] focus-visible:ring-2 focus-visible:ring-ring/40',
-                          selected
-                            ? 'bg-muted/70'
-                            : 'hover:bg-muted/40',
-                        )}
-                      >
-                        <FolderOpenIcon
-                          className={cn(
-                            'size-[15px] shrink-0',
-                            selected ? 'text-foreground' : 'text-muted-foreground',
-                          )}
-                          aria-hidden="true"
-                        />
-                        <span className="min-w-0 flex-1">
-                          <span
-                            className={cn(
-                              'block truncate text-[12.5px] leading-tight',
-                              selected ? 'font-medium text-foreground' : 'font-medium text-foreground/90',
-                            )}
-                          >
-                            {item.name}
-                          </span>
-                          <span
-                            className="mt-0.5 block truncate font-mono text-[10px] leading-tight text-muted-foreground/50"
-                            title={locationLabel}
-                          >
-                            {locationLabel}
-                          </span>
-                        </span>
-                      </Button>
-                    </li>
-                  )
-                })}
-              </ul>
-            </div>
-          )}
-        </ScrollArea>
-      </aside>
-
-      <ResizeHandle
-        direction="horizontal"
-        value={asideWidth}
-        onChange={setAsideWidth}
-        onChangeEnd={persistAsideWidth}
-        min={ASIDE_WIDTH_MIN}
-        max={ASIDE_WIDTH_MAX}
-        className="h-full"
-      />
-
-      <main className="min-w-0 flex-1 overflow-hidden">
-        {selectedWorkspace
-          ? (
-              <WorkspaceDiffsView
-                key={selectedWorkspace.id}
-                workspaceId={selectedWorkspace.id}
-                repo={repo}
-                path={path}
-                review={review}
-                line={line}
-                side={side}
-                github={github}
-              />
-            )
-          : (
-              <div className="flex h-full items-center justify-center px-6">
-                <Empty>
-                  <EmptyHeader>
-                    <EmptyMedia variant="icon">
-                      <FolderOpenIcon className="size-5" aria-hidden="true" />
-                    </EmptyMedia>
-                    <EmptyTitle>{t('home.empty.title')}</EmptyTitle>
-                    <EmptyDescription>{tWorkspace('sidebar.projects.empty.description')}</EmptyDescription>
-                  </EmptyHeader>
-                </Empty>
-              </div>
-            )}
-      </main>
+    <div className="h-full min-w-0 overflow-hidden bg-background" data-testid="diff-home-page">
+      <DiffWorkerProvider>
+        <DiffsIndexContainer
+          preferredWorkspaceId={workspace}
+          selectedRepositoryKey={repo}
+        />
+      </DiffWorkerProvider>
     </div>
   )
 }

--- a/apps/web/src/features/diff-review/review-detail/agent-rail.tsx
+++ b/apps/web/src/features/diff-review/review-detail/agent-rail.tsx
@@ -47,7 +47,8 @@ interface AgentRailProps {
   }) => Promise<CradleDiffReview>
   onDelete: (agentFixId: string) => void
   onCollapse: () => void
-  width: number
+  /** Omit to fill the parent (e.g. ReviewDetailView overlay sheet). */
+  width?: number
 }
 
 const STATUS_TONE: Record<ReviewAgentFix['status'], string> = {
@@ -127,8 +128,11 @@ export function AgentRail({
 
   return (
     <aside
-      className="flex min-h-0 shrink-0 flex-col border-l border-border/60 bg-background"
-      style={{ width }}
+      className={cn(
+        'flex min-h-0 shrink-0 flex-col bg-background',
+        width === undefined ? 'h-full w-full border-0' : 'border-l border-border/60',
+      )}
+      style={width === undefined ? undefined : { width }}
       data-testid="agent-rail"
     >
       <div className="flex h-9 shrink-0 items-center gap-1.5 border-b border-border/60 px-3">

--- a/apps/web/src/features/diff-review/review-detail/open-threads-rail.tsx
+++ b/apps/web/src/features/diff-review/review-detail/open-threads-rail.tsx
@@ -17,7 +17,8 @@ interface OpenThreadsRailProps {
   resolvePending: boolean
   onAskAgent?: (threadId: string) => void
   onCollapse: () => void
-  width: number
+  /** Omit to fill the parent (e.g. ReviewDetailView overlay sheet). */
+  width?: number
 }
 
 export function OpenThreadsRail({
@@ -35,8 +36,11 @@ export function OpenThreadsRail({
 
   return (
     <aside
-      className="flex min-h-0 shrink-0 flex-col border-l border-border/60 bg-background"
-      style={{ width }}
+      className={cn(
+        'flex min-h-0 shrink-0 flex-col bg-background',
+        width === undefined ? 'h-full w-full border-0' : 'border-l border-border/60',
+      )}
+      style={width === undefined ? undefined : { width }}
       data-testid="open-threads-rail"
     >
       <div className="flex h-9 shrink-0 items-center gap-1.5 border-b border-border/60 px-3">

--- a/apps/web/src/features/diff-review/review-detail/review-detail-page.tsx
+++ b/apps/web/src/features/diff-review/review-detail/review-detail-page.tsx
@@ -1,12 +1,18 @@
-import { GitCompareLine as FileDiffIcon } from '@mingcute/react'
+import {
+  CloseLine as CloseIcon,
+  ExternalLinkLine as ExternalLinkIcon,
+  GitCompareLine as FileDiffIcon,
+} from '@mingcute/react'
 import type { CodeViewItem } from '@pierre/diffs'
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import type { DiffData } from '~/components/common/diff/diff-data'
 import { buildDiffData, emptyDiffData } from '~/components/common/diff/diff-data'
-import { ResizeHandle } from '~/components/layout/resize-handle'
+import { Button } from '~/components/ui/button'
 import { Spinner } from '~/components/ui/spinner'
 
+import { ReviewDetailView } from '../review/review-detail-view'
 import type { CodeViewLineSelection, ThreadAnnotation } from '../shared/diff-items'
 import {
   formatSelectedReviewRange,
@@ -18,9 +24,9 @@ import { useReview } from '../shared/use-review'
 import { AgentRail } from './agent-rail'
 import type { DiffStageHandle } from './diff-stage'
 import { DiffStage } from './diff-stage'
-import { FileListAside } from './file-tree-aside'
+import { GitHubReviewContext } from './github-review-context'
 import { OpenThreadsRail } from './open-threads-rail'
-import { ReviewTopBar } from './review-top-bar'
+import { DisplayPopover, ReviewPopover } from './review-top-bar'
 
 interface ReviewDetailPageProps {
   workspaceId: string
@@ -39,6 +45,7 @@ export function ReviewDetailPage({
   initialLine,
   initialSide,
 }: ReviewDetailPageProps) {
+  const { t } = useTranslation('diff-review')
   const {
     review,
     isLoading,
@@ -72,11 +79,8 @@ export function ReviewDetailPage({
     initialPath && initialLine ? { line: initialLine, side: initialSide ?? 'head' } : null,
   )
 
-  // Panel widths — Linear-style: panels are resizable, the diff stays the protagonist.
-  // Right rail auto-hides when there are no open threads so the diff gets the room.
-  const [fileTreeWidth, setFileTreeWidth] = useState(256)
-  const [threadsRailWidth, setThreadsRailWidth] = useState(320)
-  const [threadsRailCollapsed, setThreadsRailCollapsed] = useState(false)
+  const [overviewCollapsed, setOverviewCollapsed] = useState(false)
+  const [overlayOpen, setOverlayOpen] = useState(false)
   const [railMode, setRailMode] = useState<'threads' | 'agent'>('threads')
 
   const files = useMemo(() => review?.files ?? [], [review?.files])
@@ -210,6 +214,11 @@ export function ReviewDetailPage({
           event.preventDefault()
           setComposerAnchor(null)
           setSelectedLineSelection(null)
+          return
+        }
+        if (overlayOpen) {
+          event.preventDefault()
+          setOverlayOpen(false)
         }
         return
       }
@@ -237,7 +246,15 @@ export function ReviewDetailPage({
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [composerAnchor, diffStyle, preferenceMutation, selectedFileId, selectedLineSelection, visibleFiles])
+  }, [
+    composerAnchor,
+    diffStyle,
+    overlayOpen,
+    preferenceMutation,
+    selectedFileId,
+    selectedLineSelection,
+    visibleFiles,
+  ])
 
   useEffect(() => {
     if (visibleItems.length === 0 || !pendingScrollRef.current) {
@@ -267,7 +284,7 @@ export function ReviewDetailPage({
     }, {
       onSuccess: () => {
         setRailMode('agent')
-        setThreadsRailCollapsed(false)
+        setOverlayOpen(true)
       },
     })
   }
@@ -293,68 +310,119 @@ export function ReviewDetailPage({
     ? files.filter(file => (!collapseGeneratedFiles || !file.isGenerated) && diffData.whitespaceOnlyPaths.has(file.path)).length
     : 0
   const hiddenGeneratedFileCount = collapseGeneratedFiles ? files.filter(file => file.isGenerated).length : 0
+  const hiddenFileCount = hiddenWhitespaceFileCount + hiddenGeneratedFileCount
 
-  const openThreadCount = review.threads.filter(thread => thread.state !== 'resolved').length
-  const showRightRail = !threadsRailCollapsed
+  const canCloseReview = review.status === 'open'
+    && review.sourceKind !== 'local-working-tree'
+    && review.sourceKind !== 'github-pull-request'
+
+  const showOverlay = overlayOpen
+  const agentOpen = showOverlay && railMode === 'agent'
 
   return (
-    <div className="flex h-full w-full min-h-0 flex-col overflow-hidden" data-testid="review-detail-page">
-      <ReviewTopBar
+    <div className="h-full w-full min-h-0" data-testid="review-detail-page">
+      <ReviewDetailView
         review={review}
+        files={visibleFiles}
+        hiddenFileCount={hiddenFileCount}
+        selectedFileId={selectedFileId}
+        onSelectFile={selectFile}
+        onToggleViewed={file => viewedMutation.mutate({ fileId: file.id, viewed: !file.isViewed })}
         diffStyle={diffStyle}
         onDiffStyleChange={(style) => {
           setDiffStyle(style)
           preferenceMutation.mutate({ diffStyle: style })
         }}
-        onPreference={input => preferenceMutation.mutate(input)}
-        preferencePending={preferenceMutation.isPending}
-        onSubmit={(decision, bodyMarkdown) => submitMutation.mutate({ decision, bodyMarkdown })}
-        submitPending={submitMutation.isPending}
-        onMerge={method => mergeMutation.mutate(method)}
-        mergePending={mergeMutation.isPending}
-        onCloseReview={() => closeReviewMutation.mutate(undefined, {
-          onSuccess: () => navigateToReviewsList(workspaceId, repositoryPath),
-        })}
-        closeReviewPending={closeReviewMutation.isPending}
+        overviewCollapsed={overviewCollapsed}
+        onToggleOverview={() => setOverviewCollapsed(value => !value)}
+        onBack={() => navigateToReviewsList(workspaceId, repositoryPath)}
         onRefresh={() => refreshMutation.mutate()}
-        refreshPending={refreshMutation.isPending}
-        isFetching={isFetching}
-        threadsRailCollapsed={threadsRailCollapsed}
-        agentRailActive={!threadsRailCollapsed && railMode === 'agent'}
-        onShowThreadsRail={() => {
+        refreshPending={refreshMutation.isPending || isFetching}
+        onSubmit={decision => submitMutation.mutate({ decision, bodyMarkdown: '' })}
+        submitPending={submitMutation.isPending}
+        threadsOpen={showOverlay}
+        onToggleThreads={() => {
+          if (showOverlay && railMode === 'threads') {
+            setOverlayOpen(false)
+            return
+          }
           setRailMode('threads')
-          setThreadsRailCollapsed(value => railMode === 'threads' ? !value : false)
+          setOverlayOpen(true)
         }}
-        onShowAgentRail={() => {
+        agentOpen={agentOpen}
+        onToggleAgent={() => {
+          if (showOverlay && railMode === 'agent') {
+            setOverlayOpen(false)
+            return
+          }
           setRailMode('agent')
-          setThreadsRailCollapsed(value => railMode === 'agent' ? !value : false)
+          setOverlayOpen(true)
         }}
-        openThreadCount={openThreadCount}
         agentFixCount={review.agentFixes.length}
-      />
-
-      <div className="flex min-h-0 flex-1">
-        <FileListAside
-          visibleFiles={visibleFiles}
-          selectedFileId={selectedFileId}
-          onSelectFile={selectFile}
-          onToggleViewed={file => viewedMutation.mutate({ fileId: file.id, viewed: !file.isViewed })}
-          viewedPending={viewedMutation.isPending}
-          hiddenWhitespaceFileCount={hiddenWhitespaceFileCount}
-          hiddenGeneratedFileCount={hiddenGeneratedFileCount}
-          width={fileTreeWidth}
-        />
-
-        <ResizeHandle
-          direction="horizontal"
-          value={fileTreeWidth}
-          onChange={setFileTreeWidth}
-          min={200}
-          max={420}
-          className="w-1.25 h-full"
-        />
-
-        <main className="flex min-h-0 min-w-0 flex-1 flex-col">
+        extraActions={(
+          <>
+            <DisplayPopover
+              hideWhitespaceOnly={review.preferences.hideWhitespaceOnly}
+              structuralHighlighting={review.preferences.structuralHighlighting}
+              collapseGeneratedFiles={review.preferences.collapseGeneratedFiles}
+              pending={preferenceMutation.isPending}
+              onToggleWhitespace={() => preferenceMutation.mutate({
+                hideWhitespaceOnly: !review.preferences.hideWhitespaceOnly,
+              })}
+              onToggleStructural={() => preferenceMutation.mutate({
+                structuralHighlighting: !review.preferences.structuralHighlighting,
+              })}
+              onToggleGenerated={() => preferenceMutation.mutate({
+                collapseGeneratedFiles: !review.preferences.collapseGeneratedFiles,
+              })}
+            />
+            {review.githubPullRequest && (
+              <GitHubReviewContext
+                pullRequest={review.githubPullRequest}
+                onMerge={method => mergeMutation.mutate(method)}
+                mergePending={mergeMutation.isPending}
+              />
+            )}
+            {review.githubPullRequest && (
+              <Button variant="ghost" size="icon" className="size-7" asChild>
+                <a
+                  href={`https://github.com/${review.githubPullRequest.owner}/${review.githubPullRequest.repo}/pull/${review.githubPullRequest.number}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={t('review.github.open')}
+                  title={t('review.github.open')}
+                >
+                  <ExternalLinkIcon className="size-3.5" />
+                </a>
+              </Button>
+            )}
+            {canCloseReview
+              ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2 text-[12px] text-muted-foreground hover:text-foreground"
+                    onClick={() => closeReviewMutation.mutate(undefined, {
+                      onSuccess: () => navigateToReviewsList(workspaceId, repositoryPath),
+                    })}
+                    disabled={closeReviewMutation.isPending}
+                  >
+                    <CloseIcon className="size-3.5" />
+                    Close
+                  </Button>
+                )
+              : null}
+          </>
+        )}
+        submitControl={(
+          <ReviewPopover
+            pending={submitMutation.isPending}
+            state={review.reviewState}
+            requireBodyForFeedback={review.sourceKind === 'github-pull-request'}
+            onSubmit={(decision, bodyMarkdown) => submitMutation.mutate({ decision, bodyMarkdown })}
+          />
+        )}
+        diffSlot={(
           <DiffStage
             review={review}
             diffData={diffData}
@@ -370,7 +438,12 @@ export function ReviewDetailPage({
             onCreateThread={(input) => {
               createThreadMutation.mutate({
                 fileId: input.fileId,
-                anchor: { fileId: input.anchor.fileId, side: input.anchor.side, startLine: input.anchor.startLine, endLine: input.anchor.endLine },
+                anchor: {
+                  fileId: input.anchor.fileId,
+                  side: input.anchor.side,
+                  startLine: input.anchor.startLine,
+                  endLine: input.anchor.endLine,
+                },
                 bodyMarkdown: input.bodyMarkdown,
               })
               setComposerAnchor(null)
@@ -385,54 +458,42 @@ export function ReviewDetailPage({
             files={files}
             handleRef={handle => stageHandleRef.current = handle}
           />
-        </main>
-
-        {showRightRail && (
-          <>
-            <ResizeHandle
-              direction="horizontal"
-              value={threadsRailWidth}
-              onChange={setThreadsRailWidth}
-              min={240}
-              max={480}
-              inverted
-              className="w-1.25 h-full"
-            />
-            {railMode === 'agent'
-              ? (
-                  <AgentRail
-                    review={review}
-                    selectedAnchor={selectedAgentAnchor}
-                    selectedLabel={selectedAgentLabel}
-                    createPending={createAgentFixMutation.isPending}
-                    startPending={startAgentFixMutation.isPending}
-                    cancelPending={cancelAgentFixMutation.isPending}
-                    rerunPending={rerunAgentFixMutation.isPending}
-                    deletePending={deleteAgentFixMutation.isPending}
-                    onCreate={input => createAgentFixMutation.mutateAsync(input)}
-                    onStart={input => startAgentFixMutation.mutateAsync(input)}
-                    onCancel={agentFixId => cancelAgentFixMutation.mutate(agentFixId)}
-                    onRerun={input => rerunAgentFixMutation.mutateAsync(input)}
-                    onDelete={agentFixId => deleteAgentFixMutation.mutate(agentFixId)}
-                    onCollapse={() => setThreadsRailCollapsed(true)}
-                    width={threadsRailWidth}
-                  />
-                )
-              : (
-                  <OpenThreadsRail
-                    review={review}
-                    files={files}
-                    onJumpToThread={jumpToThread}
-                    onResolve={threadId => resolveThreadMutation.mutate(threadId)}
-                    resolvePending={resolveThreadMutation.isPending}
-                    onAskAgent={askAgentForThread}
-                    onCollapse={() => setThreadsRailCollapsed(true)}
-                    width={threadsRailWidth}
-                  />
-                )}
-          </>
         )}
-      </div>
+        threadsSlot={showOverlay
+          ? (
+              railMode === 'agent'
+                ? (
+                    <AgentRail
+                      review={review}
+                      selectedAnchor={selectedAgentAnchor}
+                      selectedLabel={selectedAgentLabel}
+                      createPending={createAgentFixMutation.isPending}
+                      startPending={startAgentFixMutation.isPending}
+                      cancelPending={cancelAgentFixMutation.isPending}
+                      rerunPending={rerunAgentFixMutation.isPending}
+                      deletePending={deleteAgentFixMutation.isPending}
+                      onCreate={input => createAgentFixMutation.mutateAsync(input)}
+                      onStart={input => startAgentFixMutation.mutateAsync(input)}
+                      onCancel={agentFixId => cancelAgentFixMutation.mutate(agentFixId)}
+                      onRerun={input => rerunAgentFixMutation.mutateAsync(input)}
+                      onDelete={agentFixId => deleteAgentFixMutation.mutate(agentFixId)}
+                      onCollapse={() => setOverlayOpen(false)}
+                    />
+                  )
+                : (
+                    <OpenThreadsRail
+                      review={review}
+                      files={files}
+                      onJumpToThread={jumpToThread}
+                      onResolve={threadId => resolveThreadMutation.mutate(threadId)}
+                      resolvePending={resolveThreadMutation.isPending}
+                      onAskAgent={askAgentForThread}
+                      onCollapse={() => setOverlayOpen(false)}
+                    />
+                  )
+            )
+          : undefined}
+      />
     </div>
   )
 }

--- a/apps/web/src/features/diff-review/review-detail/review-top-bar.tsx
+++ b/apps/web/src/features/diff-review/review-detail/review-top-bar.tsx
@@ -209,7 +209,7 @@ export function ReviewTopBar({
   )
 }
 
-function DisplayPopover({
+export function DisplayPopover({
   hideWhitespaceOnly,
   structuralHighlighting,
   collapseGeneratedFiles,
@@ -251,7 +251,7 @@ function DisplayPopover({
   )
 }
 
-function ReviewPopover({
+export function ReviewPopover({
   pending,
   state,
   requireBodyForFeedback,

--- a/apps/web/src/features/diff-review/review/diffs-index-container.tsx
+++ b/apps/web/src/features/diff-review/review/diffs-index-container.tsx
@@ -1,0 +1,484 @@
+import { useMutation, useQueries, useQueryClient } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  getWorkspacesByWorkspaceIdDiffReviews,
+  getWorkspacesByWorkspaceIdGitRepositories,
+  postWorkspacesByWorkspaceIdDiffReviewsGithubPullRequest,
+} from '~/api-gen/sdk.gen'
+import { Button } from '~/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog'
+import { Input } from '~/components/ui/input'
+import { Spinner } from '~/components/ui/spinner'
+import { toastManager } from '~/components/ui/toast'
+import type { GitRepository } from '~/features/git/shared/types'
+import { useWorkspaces } from '~/features/workspace/use-workspace'
+import { queryRefreshPolicies } from '~/lib/query-refresh-policy'
+import { router } from '~/router'
+
+import {
+  parseGitHubPullRequestReference,
+} from '../github-pull-request-reference'
+import { reviewListQueryKey } from '../shared/diff-items'
+import { navigateToReview, WORKING_TREE_REVIEW_ID } from '../shared/navigation'
+import type { CradleDiffReview } from '../shared/types'
+import type { RepositoryScope } from './diffs-index-view'
+import { DiffsIndexView } from './diffs-index-view'
+
+type DiffReviewKey = keyof typeof import('~/locales/default').default['diff-review']
+
+export interface DiffsIndexContainerProps {
+  /**
+   * When set, only repositories/reviews from this workspace are listed
+   * (embedded `/workspaces/$id/diffs` surface).
+   */
+  workspaceId?: string
+  /** Prefer this workspace when choosing a default repository selection. */
+  preferredWorkspaceId?: string
+  /** Pre-select a repository by local path or `owner/repo` label. */
+  selectedRepositoryKey?: string
+}
+
+interface WorkspaceBundle {
+  workspaceId: string
+  workspaceName: string
+  repositories: GitRepository[]
+  reviews: CradleDiffReview[]
+}
+
+function repositoryScopeId(input: {
+  workspaceId: string
+  hostKind: 'github' | 'local'
+  label: string
+  repositoryPath: string | null
+}): string {
+  if (input.hostKind === 'github') {
+    return `github:${input.label}`
+  }
+  return `local:${input.workspaceId}:${input.repositoryPath ?? '.'}`
+}
+
+function reviewRepositoryKey(review: CradleDiffReview): {
+  hostKind: 'github' | 'local'
+  label: string
+  repositoryPath: string | null
+} {
+  if (review.githubPullRequest) {
+    return {
+      hostKind: 'github',
+      label: `${review.githubPullRequest.owner}/${review.githubPullRequest.repo}`,
+      repositoryPath: review.repositoryPath === '.' ? '.' : review.repositoryPath,
+    }
+  }
+  const path = review.repositoryPath
+  const label = path === '.' || path === ''
+    ? 'Workspace root'
+    : path.includes('/')
+      ? path.slice(path.lastIndexOf('/') + 1)
+      : path
+  return {
+    hostKind: 'local',
+    label,
+    repositoryPath: path === '' ? '.' : path,
+  }
+}
+
+function buildRepositoryScopes(bundles: WorkspaceBundle[]): {
+  repositories: RepositoryScope[]
+  reviewsByRepositoryId: Map<string, CradleDiffReview[]>
+} {
+  const scopes = new Map<string, RepositoryScope>()
+  const reviewsByRepositoryId = new Map<string, CradleDiffReview[]>()
+
+  const ensure = (input: {
+    workspaceId: string
+    hostKind: 'github' | 'local'
+    label: string
+    localRoot: string | null
+    repositoryPath: string | null
+  }): RepositoryScope => {
+    const id = repositoryScopeId(input)
+    const existing = scopes.get(id)
+    if (existing) {
+      // Prefer a concrete checkout path when a later bundle supplies one.
+      if (!existing.localRoot && input.localRoot) {
+        existing.localRoot = input.localRoot
+      }
+      if (existing.repositoryPath == null && input.repositoryPath != null) {
+        existing.repositoryPath = input.repositoryPath
+      }
+      return existing
+    }
+    const created: RepositoryScope = {
+      id,
+      hostKind: input.hostKind,
+      label: input.label,
+      localRoot: input.localRoot,
+      reviewCount: 0,
+      workspaceId: input.workspaceId,
+      repositoryPath: input.repositoryPath,
+    }
+    scopes.set(id, created)
+    reviewsByRepositoryId.set(id, [])
+    return created
+  }
+
+  for (const bundle of bundles) {
+    for (const repository of bundle.repositories) {
+      ensure({
+        workspaceId: bundle.workspaceId,
+        hostKind: 'local',
+        label: repository.name,
+        localRoot: repository.absolutePath,
+        repositoryPath: repository.path === '' ? '.' : repository.path,
+      })
+    }
+
+    for (const review of bundle.reviews) {
+      const key = reviewRepositoryKey(review)
+      const localMatch = bundle.repositories.find((repository) => {
+        const path = repository.path === '' ? '.' : repository.path
+        if (key.hostKind === 'github') {
+          // Fold GitHub reviews onto a same-named local checkout so the index
+          // does not list the same code identity twice.
+          const repoName = key.label.split('/')[1] ?? key.label
+          return repository.name === repoName || repository.name === key.label
+        }
+        return path === key.repositoryPath || repository.name === key.label
+      })
+
+      if (localMatch) {
+        const path = localMatch.path === '' ? '.' : localMatch.path
+        // Always key off the local checkout id so PRs attach to the row that
+        // already represents this working tree.
+        const scope = ensure({
+          workspaceId: bundle.workspaceId,
+          hostKind: 'local',
+          label: localMatch.name,
+          localRoot: localMatch.absolutePath,
+          repositoryPath: path,
+        })
+        if (key.hostKind === 'github') {
+          scope.hostKind = 'github'
+          scope.label = key.label
+        }
+        const list = reviewsByRepositoryId.get(scope.id) ?? []
+        list.push(review)
+        reviewsByRepositoryId.set(scope.id, list)
+        continue
+      }
+
+      const scope = ensure({
+        workspaceId: bundle.workspaceId,
+        hostKind: key.hostKind,
+        label: key.label,
+        localRoot: null,
+        repositoryPath: key.repositoryPath,
+      })
+      const list = reviewsByRepositoryId.get(scope.id) ?? []
+      list.push(review)
+      reviewsByRepositoryId.set(scope.id, list)
+    }
+  }
+
+  for (const [id, reviews] of reviewsByRepositoryId) {
+    const scope = scopes.get(id)
+    if (scope) {
+      scope.reviewCount = reviews.length
+    }
+  }
+
+  const repositories = [...scopes.values()].toSorted((left, right) => {
+    if (right.reviewCount !== left.reviewCount) {
+      return right.reviewCount - left.reviewCount
+    }
+    return left.label.localeCompare(right.label)
+  })
+
+  for (const [id, reviews] of reviewsByRepositoryId) {
+    reviewsByRepositoryId.set(
+      id,
+      [...reviews].toSorted((left, right) => right.updatedAt - left.updatedAt),
+    )
+  }
+
+  return { repositories, reviewsByRepositoryId }
+}
+
+function matchRepositoryKey(
+  repositories: RepositoryScope[],
+  key: string | undefined,
+): string | null {
+  if (!key) {
+    return null
+  }
+  const match = repositories.find(repository => (
+    repository.id === key
+    || repository.label === key
+    || repository.repositoryPath === key
+    || repository.id === `github:${key}`
+    || repository.id.endsWith(`:${key}`)
+  ))
+  return match?.id ?? null
+}
+
+/**
+ * Production container for the repository-first Diffs index.
+ *
+ * Derives `RepositoryScope` from each workspace's git checkouts and reviews
+ * until first-class repository ownership lands on the server.
+ */
+export function DiffsIndexContainer({
+  workspaceId,
+  preferredWorkspaceId,
+  selectedRepositoryKey,
+}: DiffsIndexContainerProps) {
+  const { workspaces, loading: workspacesLoading } = useWorkspaces()
+  const queryClient = useQueryClient()
+  const [selectedRepositoryId, setSelectedRepositoryId] = useState<string | null>(null)
+  const [addPullRequestOpen, setAddPullRequestOpen] = useState(false)
+
+  const scopedWorkspaces = useMemo(() => {
+    if (!workspaceId) {
+      return workspaces
+    }
+    return workspaces.filter(workspace => workspace.id === workspaceId)
+  }, [workspaceId, workspaces])
+
+  const workspaceQueries = useQueries({
+    queries: scopedWorkspaces.map(workspace => ({
+      queryKey: ['diffs-index-bundle', workspace.id] as const,
+      queryFn: async (): Promise<WorkspaceBundle> => {
+        const [reviewsResult, repositoriesResult] = await Promise.all([
+          getWorkspacesByWorkspaceIdDiffReviews({
+            path: { workspaceId: workspace.id },
+            throwOnError: true,
+          }),
+          getWorkspacesByWorkspaceIdGitRepositories({
+            path: { workspaceId: workspace.id },
+            throwOnError: true,
+          }),
+        ])
+        return {
+          workspaceId: workspace.id,
+          workspaceName: workspace.name,
+          reviews: reviewsResult.data ?? [],
+          repositories: repositoriesResult.data ?? [],
+        }
+      },
+      ...queryRefreshPolicies.active,
+      retry: false,
+    })),
+  })
+
+  const bundles = useMemo(
+    () => workspaceQueries.flatMap(query => (query.data ? [query.data] : [])),
+    [workspaceQueries],
+  )
+
+  const loading = workspacesLoading || workspaceQueries.some(query => query.isLoading || query.isPending)
+
+  const { repositories, reviewsByRepositoryId } = useMemo(
+    () => buildRepositoryScopes(bundles),
+    [bundles],
+  )
+
+  useEffect(() => {
+    if (repositories.length === 0) {
+      setSelectedRepositoryId(null)
+      return
+    }
+    const fromKey = matchRepositoryKey(repositories, selectedRepositoryKey)
+    if (fromKey) {
+      setSelectedRepositoryId(fromKey)
+      return
+    }
+    setSelectedRepositoryId((current) => {
+      if (current && repositories.some(repository => repository.id === current)) {
+        return current
+      }
+      const preferredId = preferredWorkspaceId ?? workspaceId
+      const preferred = preferredId
+        ? repositories.find(repository => repository.workspaceId === preferredId)
+        : null
+      return preferred?.id ?? repositories[0]!.id
+    })
+  }, [preferredWorkspaceId, repositories, selectedRepositoryKey, workspaceId])
+
+  const selectedRepository = repositories.find(repository => repository.id === selectedRepositoryId) ?? null
+  const reviews = selectedRepository
+    ? (reviewsByRepositoryId.get(selectedRepository.id) ?? [])
+    : []
+
+  const pullRequestMutation = useMutation({
+    mutationFn: async (input: { workspaceId: string, owner: string, repo: string, number: number }) => {
+      const { data } = await postWorkspacesByWorkspaceIdDiffReviewsGithubPullRequest({
+        path: { workspaceId: input.workspaceId },
+        body: { owner: input.owner, repo: input.repo, number: input.number },
+        throwOnError: true,
+      })
+      return { review: data, workspaceId: input.workspaceId }
+    },
+    onSuccess: ({ review, workspaceId: targetWorkspaceId }) => {
+      void queryClient.invalidateQueries({ queryKey: reviewListQueryKey(targetWorkspaceId) })
+      void queryClient.invalidateQueries({ queryKey: ['diffs-index-bundle', targetWorkspaceId] })
+      navigateToReview(targetWorkspaceId, review.id)
+    },
+    onError: (error: Error) => toastManager.add({
+      type: 'error',
+      title: 'Open pull request failed',
+      description: error.message,
+    }),
+  })
+
+  const selectRepository = (repositoryId: string) => {
+    setSelectedRepositoryId(repositoryId)
+    const repository = repositories.find(item => item.id === repositoryId)
+    if (!repository) {
+      return
+    }
+    const repo = repository.repositoryPath && repository.repositoryPath !== '.'
+      ? repository.repositoryPath
+      : undefined
+
+    if (router.state.location.pathname === '/diff') {
+      void router.navigate({
+        to: '/diff',
+        search: {
+          workspace: repository.workspaceId,
+          repo,
+        },
+      })
+      return
+    }
+
+    void router.navigate({
+      to: '/workspaces/$workspaceId/diffs',
+      params: { workspaceId: repository.workspaceId },
+      search: { repo },
+    })
+  }
+
+  return (
+    <div className="h-full min-h-0 w-full overflow-hidden">
+      <DiffsIndexView
+        repositories={repositories}
+        selectedRepositoryId={selectedRepositoryId}
+        onSelectRepository={selectRepository}
+        reviews={reviews}
+        loading={loading}
+        onOpenReview={(review) => {
+          navigateToReview(review.workspaceId, review.id, {
+            repositoryPath: review.repositoryPath,
+          })
+        }}
+        onOpenWorkingTree={selectedRepository
+          ? () => {
+              navigateToReview(selectedRepository.workspaceId, WORKING_TREE_REVIEW_ID, {
+                repositoryPath: selectedRepository.repositoryPath,
+              })
+            }
+          : undefined}
+        onAddPullRequest={selectedRepository
+          ? () => setAddPullRequestOpen(true)
+          : undefined}
+      />
+
+      {selectedRepository && (
+        <AddPullRequestDialog
+          open={addPullRequestOpen}
+          onOpenChange={setAddPullRequestOpen}
+          pending={pullRequestMutation.isPending}
+          onOpen={(input) => {
+            pullRequestMutation.mutate({
+              workspaceId: selectedRepository.workspaceId,
+              ...input,
+            })
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function AddPullRequestDialog({
+  open,
+  onOpenChange,
+  pending,
+  onOpen,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  pending: boolean
+  onOpen: (input: { owner: string, repo: string, number: number }) => void
+}) {
+  const { t } = useTranslation('diff-review')
+  const [value, setValue] = useState('')
+  const reference = useMemo(() => parseGitHubPullRequestReference(value), [value])
+
+  const reset = () => setValue('')
+  const submit = () => {
+    if (!reference || pending) {
+      return
+    }
+    onOpen(reference)
+    onOpenChange(false)
+    reset()
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next)
+        if (!next) {
+          reset()
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('reviews.pullRequest.title' as DiffReviewKey)}</DialogTitle>
+          <DialogDescription>
+            {t('reviews.pullRequest.placeholder' as DiffReviewKey)}
+          </DialogDescription>
+        </DialogHeader>
+        <Input
+          value={value}
+          onChange={event => setValue(event.target.value)}
+          autoFocus
+          placeholder={t('reviews.pullRequest.placeholder' as DiffReviewKey)}
+          aria-label={t('reviews.pullRequest.title' as DiffReviewKey)}
+          className="h-8 text-[12px]"
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              submit()
+            }
+          }}
+        />
+        {value.trim() && !reference && (
+          <p className="text-[11px] text-destructive">
+            {t('reviews.pullRequest.invalid' as DiffReviewKey)}
+          </p>
+        )}
+        <DialogFooter>
+          <Button variant="ghost" size="sm" className="h-7 text-[12px]" onClick={() => onOpenChange(false)}>
+            {t('reviews.cancel' as DiffReviewKey)}
+          </Button>
+          <Button size="sm" className="h-7 text-[12px]" disabled={!reference || pending} onClick={submit}>
+            {pending && <Spinner className="size-3.5" />}
+            {t('reviews.openAction' as DiffReviewKey)}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/features/diff-review/review/diffs-index-view.tsx
+++ b/apps/web/src/features/diff-review/review/diffs-index-view.tsx
@@ -121,7 +121,7 @@ function ReviewRow({ review, onOpen }: { review: CradleDiffReview, onOpen: () =>
         type="button"
         onClick={onOpen}
         className={cn(
-          'group/row flex h-9 w-full items-center gap-3 px-4 text-left',
+          'group/row flex min-h-12 w-full items-center gap-3 px-4 py-2.5 text-left',
           'border-b border-[var(--rv-line)] transition-colors duration-100',
           'hover:bg-[var(--rv-bg-hover)]',
         )}
@@ -131,18 +131,18 @@ function ReviewRow({ review, onOpen }: { review: CradleDiffReview, onOpen: () =>
         {identity.reference && (
           <span
             data-rv-num
-            className="w-11 shrink-0 font-[var(--rv-font-mono)] text-[11.5px] text-[var(--rv-fg-subtle)]"
+            className="w-12 shrink-0 font-[var(--rv-font-mono)] text-[12px] text-[var(--rv-fg-subtle)]"
           >
             {identity.reference}
           </span>
         )}
 
-        <span className="min-w-0 flex-1 truncate text-[12.5px] text-[var(--rv-fg)]">
+        <span className="min-w-0 flex-1 truncate text-[14px] font-medium leading-snug text-[var(--rv-fg)]">
           {identity.title}
         </span>
 
         {/* Metadata is right-aligned and fixed-width so a long list reads as columns. */}
-        <span className="flex shrink-0 items-center gap-3 text-[11.5px] text-[var(--rv-fg-subtle)]">
+        <span className="flex shrink-0 items-center gap-3.5 text-[12px] text-[var(--rv-fg-subtle)]">
           {openThreads > 0 && (
             <span data-rv-num className="text-[var(--rv-warn)]">
               {openThreads}
@@ -152,8 +152,8 @@ function ReviewRow({ review, onOpen }: { review: CradleDiffReview, onOpen: () =>
 
           {detail && (
             <span className="hidden max-w-[180px] items-center gap-1 lg:flex">
-              <BranchIcon className="size-3 shrink-0" aria-hidden />
-              <span className="truncate font-[var(--rv-font-mono)] text-[11px]">{detail.headRef}</span>
+              <BranchIcon className="size-3.5 shrink-0" aria-hidden />
+              <span className="truncate font-[var(--rv-font-mono)] text-[11.5px]">{detail.headRef}</span>
             </span>
           )}
 

--- a/apps/web/src/features/diff-review/review/diffs-index-view.tsx
+++ b/apps/web/src/features/diff-review/review/diffs-index-view.tsx
@@ -1,19 +1,29 @@
 import './review-surface.css'
 
 import {
+  CheckLine as CheckIcon,
+  CloseLine as FailIcon,
   Folder2Line as LocalRepoIcon,
   GitBranchLine as BranchIcon,
   GithubLine as GithubIcon,
   GitPullRequestLine as PullRequestIcon,
+  LoadingLine as RunningIcon,
   SearchLine as SearchIcon,
+  User2Line as AuthorIcon,
 } from '@mingcute/react'
+import type { ReactNode } from 'react'
 import { useMemo, useState } from 'react'
 
 import { cn } from '~/lib/cn'
 
 import type { CradleDiffReview } from '../shared/types'
 import { ChangeStat, StatusDot } from './review-primitives'
-import { formatRelativeTime, reviewIdentity, reviewStatusBadge } from './review-summary'
+import {
+  formatRelativeTime,
+  reviewChecks,
+  reviewIdentity,
+  reviewStatusBadge,
+} from './review-summary'
 
 /**
  * A repository as the Diffs surface understands it: a code identity that owns
@@ -62,18 +72,52 @@ function matchesTab(review: CradleDiffReview, tab: IndexTab): boolean {
       || review.files.some(file => !file.isViewed))
 }
 
+function sourceKindLabel(sourceKind: CradleDiffReview['sourceKind']): string {
+  switch (sourceKind) {
+    case 'github-pull-request':
+      return 'Pull request'
+    case 'local-working-tree':
+      return 'Working tree'
+    case 'local-branch-compare':
+      return 'Branch compare'
+    case 'local-commit':
+      return 'Commit'
+    case 'agent-change-set':
+      return 'Agent changes'
+    case 'external-import':
+      return 'Imported'
+    default:
+      return 'Review'
+  }
+}
+
+function MetaSep() {
+  return <span aria-hidden className="text-[var(--rv-fg-subtle)]/70">·</span>
+}
+
+function MetaItem({ children, className }: { children: ReactNode, className?: string }) {
+  return (
+    <span className={cn('inline-flex min-w-0 items-center gap-1', className)}>
+      {children}
+    </span>
+  )
+}
+
 function RepositoryRow({ repository, selected, onSelect }: {
   repository: RepositoryScope
   selected: boolean
   onSelect: () => void
 }) {
   const Icon = repository.hostKind === 'github' ? GithubIcon : LocalRepoIcon
+  const secondary = repository.localRoot
+    ?? (repository.hostKind === 'github' ? 'GitHub' : 'Local')
+
   return (
     <li className="relative">
       {selected && (
         <span
           aria-hidden
-          className="absolute inset-y-[5px] left-0 w-[2px] rounded-r-full bg-[var(--rv-accent)]"
+          className="absolute inset-y-[6px] left-0 w-[2px] rounded-r-full bg-[var(--rv-accent)]"
         />
       )}
       <button
@@ -81,26 +125,34 @@ function RepositoryRow({ repository, selected, onSelect }: {
         onClick={onSelect}
         title={repository.localRoot ?? repository.label}
         className={cn(
-          'flex h-[30px] w-full items-center gap-2 pl-3 pr-2.5 text-left transition-colors duration-100',
+          'flex min-h-12 w-full items-center gap-2.5 px-3 py-2 text-left transition-colors duration-100',
           selected ? 'bg-[var(--rv-bg-active)]' : 'hover:bg-[var(--rv-bg-hover)]',
         )}
       >
         <Icon
           className={cn(
-            'size-3.5 shrink-0',
+            'size-4 shrink-0',
             selected ? 'text-[var(--rv-fg)]' : 'text-[var(--rv-fg-subtle)]',
           )}
           aria-hidden
         />
-        <span
-          className={cn(
-            'min-w-0 flex-1 truncate text-[12.5px]',
-            selected ? 'font-medium text-[var(--rv-fg)]' : 'text-[var(--rv-fg-muted)]',
-          )}
-        >
-          {repository.label}
+        <span className="min-w-0 flex-1">
+          <span
+            className={cn(
+              'block truncate text-[13.5px] leading-snug',
+              selected ? 'font-medium text-[var(--rv-fg)]' : 'text-[var(--rv-fg-muted)]',
+            )}
+          >
+            {repository.label}
+          </span>
+          <span
+            className="mt-0.5 block truncate font-[var(--rv-font-mono)] text-[11px] leading-tight text-[var(--rv-fg-subtle)]"
+            title={secondary}
+          >
+            {secondary}
+          </span>
         </span>
-        <span data-rv-num className="shrink-0 text-[11px] text-[var(--rv-fg-subtle)]">
+        <span data-rv-num className="shrink-0 self-start pt-0.5 text-[12px] text-[var(--rv-fg-subtle)]">
           {repository.reviewCount}
         </span>
       </button>
@@ -111,9 +163,14 @@ function RepositoryRow({ repository, selected, onSelect }: {
 function ReviewRow({ review, onOpen }: { review: CradleDiffReview, onOpen: () => void }) {
   const identity = reviewIdentity(review)
   const status = reviewStatusBadge(review)
+  const checks = reviewChecks(review)
   const revision = review.currentRevision
   const detail = review.githubPullRequest?.detail
   const openThreads = review.threads.filter(thread => thread.state !== 'resolved').length
+  const unviewedFiles = review.files.filter(file => !file.isViewed).length
+  const author = detail?.author?.login ?? null
+  const labels = detail?.labels.slice(0, 3) ?? []
+  const extraLabelCount = detail ? Math.max(0, detail.labels.length - labels.length) : 0
 
   return (
     <li>
@@ -121,62 +178,157 @@ function ReviewRow({ review, onOpen }: { review: CradleDiffReview, onOpen: () =>
         type="button"
         onClick={onOpen}
         className={cn(
-          'group/row flex min-h-12 w-full items-center gap-3 px-4 py-2.5 text-left',
+          'group/row flex w-full items-start gap-3 px-4 py-3 text-left',
           'border-b border-[var(--rv-line)] transition-colors duration-100',
           'hover:bg-[var(--rv-bg-hover)]',
         )}
       >
-        <StatusDot tone={status.tone} filled={status.filled} />
+        <StatusDot tone={status.tone} filled={status.filled} className="mt-[7px]" />
 
-        {identity.reference && (
-          <span
-            data-rv-num
-            className="w-12 shrink-0 font-[var(--rv-font-mono)] text-[12px] text-[var(--rv-fg-subtle)]"
-          >
-            {identity.reference}
+        <span className="min-w-0 flex-1">
+          <span className="flex min-w-0 items-baseline gap-2.5">
+            {identity.reference && (
+              <span
+                data-rv-num
+                className="shrink-0 font-[var(--rv-font-mono)] text-[12.5px] text-[var(--rv-fg-subtle)]"
+              >
+                {identity.reference}
+              </span>
+            )}
+            <span className="min-w-0 truncate text-[14px] font-medium leading-snug text-[var(--rv-fg)]">
+              {identity.title}
+            </span>
           </span>
-        )}
 
-        <span className="min-w-0 flex-1 truncate text-[14px] font-medium leading-snug text-[var(--rv-fg)]">
-          {identity.title}
+          {/* Second line carries the scan-worthy facts the single-line row left empty. */}
+          <span className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-[var(--rv-fg-subtle)]">
+            <MetaItem>
+              <span className="text-[var(--rv-fg-muted)]">{status.label}</span>
+            </MetaItem>
+
+            {author && (
+              <>
+                <MetaSep />
+                <MetaItem>
+                  <AuthorIcon className="size-3 shrink-0" aria-hidden />
+                  <span className="truncate">{author}</span>
+                </MetaItem>
+              </>
+            )}
+
+            {!detail && (
+              <>
+                <MetaSep />
+                <MetaItem>{sourceKindLabel(review.sourceKind)}</MetaItem>
+              </>
+            )}
+
+            {detail && (
+              <>
+                <MetaSep />
+                <MetaItem className="max-w-[220px] font-[var(--rv-font-mono)] text-[11.5px]">
+                  <BranchIcon className="size-3 shrink-0" aria-hidden />
+                  <span className="truncate" title={`${detail.headRef} → ${detail.baseRef}`}>
+                    {detail.headRef}
+                    <span className="text-[var(--rv-fg-subtle)]"> → </span>
+                    {detail.baseRef}
+                  </span>
+                </MetaItem>
+              </>
+            )}
+
+            {checks && (
+              <>
+                <MetaSep />
+                <MetaItem
+                  className={cn(
+                    checks.failed > 0 && 'text-[var(--rv-danger)]',
+                    checks.failed === 0 && checks.pending > 0 && 'text-[var(--rv-warn)]',
+                    checks.failed === 0 && checks.pending === 0 && 'text-[var(--rv-open)]',
+                  )}
+                >
+                  {checks.failed > 0
+                    ? <FailIcon className="size-3 shrink-0" aria-hidden />
+                    : checks.pending > 0
+                      ? <RunningIcon className="size-3 shrink-0 animate-spin" aria-hidden />
+                      : <CheckIcon className="size-3 shrink-0" aria-hidden />}
+                  <span data-rv-num>{checks.label}</span>
+                </MetaItem>
+              </>
+            )}
+
+            {openThreads > 0 && (
+              <>
+                <MetaSep />
+                <MetaItem className="text-[var(--rv-warn)]">
+                  <span data-rv-num>
+                    {openThreads}
+                    {openThreads === 1 ? ' unresolved' : ' unresolved'}
+                  </span>
+                </MetaItem>
+              </>
+            )}
+
+            {unviewedFiles > 0 && review.files.length > 0 && (
+              <>
+                <MetaSep />
+                <MetaItem>
+                  <span data-rv-num>
+                    {unviewedFiles}
+                    {' / '}
+                    {review.files.length}
+                    {' unviewed'}
+                  </span>
+                </MetaItem>
+              </>
+            )}
+
+            {labels.map(label => (
+              <span
+                key={label.name}
+                className={cn(
+                  'inline-flex h-[18px] items-center gap-1 rounded-[4px] px-1.5',
+                  'border border-[var(--rv-line)] text-[10.5px] text-[var(--rv-fg-muted)]',
+                )}
+              >
+                <span
+                  aria-hidden
+                  className="size-[6px] rounded-full"
+                  style={{ background: `#${label.color}` }}
+                />
+                {label.name}
+              </span>
+            ))}
+            {extraLabelCount > 0 && (
+              <span data-rv-num className="text-[11px] text-[var(--rv-fg-subtle)]">
+                +
+                {extraLabelCount}
+              </span>
+            )}
+          </span>
         </span>
 
-        {/* Metadata is right-aligned and fixed-width so a long list reads as columns. */}
-        <span className="flex shrink-0 items-center gap-3.5 text-[12px] text-[var(--rv-fg-subtle)]">
-          {openThreads > 0 && (
-            <span data-rv-num className="text-[var(--rv-warn)]">
-              {openThreads}
-              {' unresolved'}
-            </span>
-          )}
-
-          {detail && (
-            <span className="hidden max-w-[180px] items-center gap-1 lg:flex">
-              <BranchIcon className="size-3.5 shrink-0" aria-hidden />
-              <span className="truncate font-[var(--rv-font-mono)] text-[11.5px]">{detail.headRef}</span>
-            </span>
-          )}
-
+        <span className="flex shrink-0 flex-col items-end gap-1.5 pt-0.5 text-[12px] text-[var(--rv-fg-subtle)]">
           {revision && (
-            <>
-              <span data-rv-num className="hidden w-14 text-right sm:inline">
+            <ChangeStat
+              additions={revision.additions}
+              deletions={revision.deletions}
+              className="justify-end text-[12px]"
+            />
+          )}
+          <span className="flex items-center gap-2">
+            {revision && (
+              <span data-rv-num>
                 {revision.fileCount}
                 {revision.fileCount === 1 ? ' file' : ' files'}
               </span>
-              <ChangeStat
-                additions={revision.additions}
-                deletions={revision.deletions}
-                className="w-24 justify-end"
-              />
-            </>
-          )}
-
-          <span
-            data-rv-num
-            className="w-20 text-right"
-            title={new Date(review.updatedAt * 1000).toLocaleString()}
-          >
-            {formatRelativeTime(review.updatedAt)}
+            )}
+            <span
+              data-rv-num
+              title={new Date(review.updatedAt * 1000).toLocaleString()}
+            >
+              {formatRelativeTime(review.updatedAt)}
+            </span>
           </span>
         </span>
       </button>
@@ -240,7 +392,7 @@ export function DiffsIndexView({
       className="flex h-full min-h-0 w-full overflow-hidden"
     >
       <aside
-        className="flex w-[var(--rv-rail-w)] shrink-0 flex-col border-r border-[var(--rv-line)] bg-[var(--rv-bg-subtle)]"
+        className="flex w-[280px] shrink-0 flex-col border-r border-[var(--rv-line)] bg-[var(--rv-bg-subtle)]"
         aria-label="Repositories"
       >
         <div className="flex h-[var(--rv-topbar-h)] shrink-0 items-center px-4">

--- a/apps/web/src/features/diff-review/review/diffs-index-view.tsx
+++ b/apps/web/src/features/diff-review/review/diffs-index-view.tsx
@@ -19,9 +19,9 @@ import { formatRelativeTime, reviewIdentity, reviewStatusBadge } from './review-
  * A repository as the Diffs surface understands it: a code identity that owns
  * its reviews, whether or not it is checked out locally.
  *
- * This mirrors the server's repository record. Reviews group under it instead of
- * under a workspace, which is what stops a pull request for someone else's
- * repository from appearing inside an unrelated project.
+ * Until the server's repository record is wired end-to-end, containers derive
+ * this from workspace git checkouts plus review/GitHub identities, and carry
+ * `workspaceId` / `repositoryPath` so navigation stays reachable.
  */
 export interface RepositoryScope {
   id: string
@@ -31,6 +31,10 @@ export interface RepositoryScope {
   /** Absolute checkout path, when this repository is checked out locally. */
   localRoot: string | null
   reviewCount: number
+  /** Workspace that can materialize reviews for this repository today. */
+  workspaceId: string
+  /** Relative path within the workspace; null for remote-only GitHub identities. */
+  repositoryPath: string | null
 }
 
 type IndexTab = 'all' | 'open' | 'mine' | 'closed'

--- a/apps/web/src/features/diff-review/review/review-detail-view.tsx
+++ b/apps/web/src/features/diff-review/review/review-detail-view.tsx
@@ -8,6 +8,7 @@ import {
   DownLine as ExpandIcon,
   GithubLine as GithubIcon,
   Refresh2Line as RefreshIcon,
+  RobotLine as AgentIcon,
 } from '@mingcute/react'
 import type { ReactNode } from 'react'
 
@@ -71,10 +72,24 @@ export interface ReviewDetailViewProps {
   submitPending?: boolean
   threadsOpen: boolean
   onToggleThreads: () => void
+  /** Optional agent-rail toggle; when omitted the control is hidden. */
+  agentOpen?: boolean
+  onToggleAgent?: () => void
+  agentFixCount?: number
+  /**
+   * Extra header controls (display prefs, GitHub merge, close, …) rendered
+   * before the primary submit control. Keeps the View free of product mutations.
+   */
+  extraActions?: ReactNode
+  /**
+   * Replaces the default Approve button when the container needs the full
+   * review popover (approve / request changes / comment).
+   */
+  submitControl?: ReactNode
   railWidth?: number
   /** The diff itself, supplied by the container so this View stays runtime-free. */
   diffSlot: ReactNode
-  /** Open-thread list rendered as an overlay sheet, not a permanent column. */
+  /** Open-thread / agent list rendered as an overlay sheet, not a permanent column. */
   threadsSlot?: ReactNode
 }
 
@@ -105,6 +120,11 @@ export function ReviewDetailView({
   submitPending = false,
   threadsOpen,
   onToggleThreads,
+  agentOpen = false,
+  onToggleAgent,
+  agentFixCount = 0,
+  extraActions,
+  submitControl,
   railWidth = 248,
   diffSlot,
   threadsSlot,
@@ -175,14 +195,16 @@ export function ReviewDetailView({
             <RefreshIcon className={cn('size-4', refreshPending && 'animate-spin')} aria-hidden />
           </IconAction>
 
+          {extraActions}
+
           <button
             type="button"
             onClick={onToggleThreads}
-            aria-pressed={threadsOpen}
+            aria-pressed={threadsOpen && !agentOpen}
             className={cn(
               'inline-flex h-7 items-center gap-1.5 rounded-[var(--rv-radius)] px-2',
               'text-[11.5px] font-medium transition-colors duration-100',
-              threadsOpen
+              threadsOpen && !agentOpen
                 ? 'bg-[var(--rv-bg-active)] text-[var(--rv-fg)]'
                 : 'text-[var(--rv-fg-muted)] hover:bg-[var(--rv-bg-hover)] hover:text-[var(--rv-fg)]',
             )}
@@ -191,21 +213,41 @@ export function ReviewDetailView({
             <span data-rv-num>{openThreads}</span>
           </button>
 
+          {onToggleAgent && (
+            <button
+              type="button"
+              onClick={onToggleAgent}
+              aria-pressed={agentOpen}
+              className={cn(
+                'inline-flex h-7 items-center gap-1.5 rounded-[var(--rv-radius)] px-2',
+                'text-[11.5px] font-medium transition-colors duration-100',
+                agentOpen
+                  ? 'bg-[var(--rv-bg-active)] text-[var(--rv-fg)]'
+                  : 'text-[var(--rv-fg-muted)] hover:bg-[var(--rv-bg-hover)] hover:text-[var(--rv-fg)]',
+              )}
+            >
+              <AgentIcon className="size-3.5" aria-hidden />
+              <span data-rv-num>{agentFixCount}</span>
+            </button>
+          )}
+
           <span aria-hidden className="mx-1 h-4 w-px bg-[var(--rv-line)]" />
 
-          <button
-            type="button"
-            onClick={() => onSubmit('approve')}
-            disabled={submitPending}
-            className={cn(
-              'inline-flex h-7 items-center rounded-[var(--rv-radius)] px-2.5',
-              'bg-[var(--rv-accent)] text-[11.5px] font-medium text-[var(--rv-accent-fg)]',
-              'transition-opacity duration-100 hover:opacity-90',
-              'disabled:pointer-events-none disabled:opacity-50',
-            )}
-          >
-            Approve
-          </button>
+          {submitControl ?? (
+            <button
+              type="button"
+              onClick={() => onSubmit('approve')}
+              disabled={submitPending}
+              className={cn(
+                'inline-flex h-7 items-center rounded-[var(--rv-radius)] px-2.5',
+                'bg-[var(--rv-accent)] text-[11.5px] font-medium text-[var(--rv-accent-fg)]',
+                'transition-opacity duration-100 hover:opacity-90',
+                'disabled:pointer-events-none disabled:opacity-50',
+              )}
+            >
+              Approve
+            </button>
+          )}
         </div>
       </header>
 
@@ -238,7 +280,7 @@ export function ReviewDetailView({
               'motion-safe:animate-in motion-safe:slide-in-from-right-2 motion-safe:duration-150',
             )}
             role="complementary"
-            aria-label="Review threads"
+            aria-label={agentOpen ? 'Agent fixes' : 'Review threads'}
           >
             {threadsSlot}
           </div>

--- a/apps/web/src/features/diff-review/review/review-detail-view.tsx
+++ b/apps/web/src/features/diff-review/review/review-detail-view.tsx
@@ -11,6 +11,7 @@ import {
   RobotLine as AgentIcon,
 } from '@mingcute/react'
 import type { ReactNode } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { cn } from '~/lib/cn'
 
@@ -101,6 +102,10 @@ export interface ReviewDetailViewProps {
  * that is permanently squeezed between two panels is the thing reviewers
  * actually complain about — the code should get the width by default and give
  * it up only when you ask for something else.
+ *
+ * The overview band scrolls away with the page. The file rail + diff stick to
+ * the scrollport once it is gone, so a deep read is just those two columns
+ * under the top bar — the title migrates into the bar via intersection.
  */
 export function ReviewDetailView({
   review,
@@ -133,6 +138,85 @@ export function ReviewDetailView({
   const status = reviewStatusBadge(review)
   const openThreads = review.threads.filter(thread => thread.state !== 'resolved').length
 
+  const overviewSentinelRef = useRef<HTMLDivElement | null>(null)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const readingPairRef = useRef<HTMLDivElement | null>(null)
+  const [overviewInView, setOverviewInView] = useState(true)
+
+  useEffect(() => {
+    if (overviewCollapsed) {
+      setOverviewInView(false)
+      return
+    }
+
+    const outer = scrollRef.current
+    const sentinel = overviewSentinelRef.current
+    if (!outer || !sentinel) {
+      return
+    }
+
+    const syncFromScroll = () => {
+      // Once the overview has left the scrollport, promote the title into the
+      // top bar. scrollTop is the reliable signal; intersection alone can lag
+      // behind sticky layout.
+      setOverviewInView(outer.scrollTop < Math.max(8, sentinel.offsetHeight * 0.15))
+    }
+
+    syncFromScroll()
+    outer.addEventListener('scroll', syncFromScroll, { passive: true })
+    return () => outer.removeEventListener('scroll', syncFromScroll)
+  }, [overviewCollapsed])
+
+  useEffect(() => {
+    const outer = scrollRef.current
+    const pair = readingPairRef.current
+    if (!outer || !pair || overviewCollapsed) {
+      return
+    }
+
+    const nestedScrollTop = (): number => {
+      let top = 0
+      for (const node of pair.querySelectorAll('*')) {
+        if (!(node instanceof HTMLElement)) {
+          continue
+        }
+        if (node.scrollHeight > node.clientHeight + 1) {
+          top = Math.max(top, node.scrollTop)
+        }
+      }
+      return top
+    }
+
+    /**
+     * CodeView owns its own overflow. While the overview can still move, wheel
+     * over the sticky pair would otherwise never lift the band — so prefer the
+     * outer scroller until the overview is gone, and reclaim upward wheels once
+     * the nested diff is back at its top.
+     */
+    const onWheel = (event: WheelEvent) => {
+      const maxOuter = outer.scrollHeight - outer.clientHeight
+      if (maxOuter <= 0) {
+        return
+      }
+
+      if (event.deltaY > 0 && outer.scrollTop < maxOuter - 0.5) {
+        event.preventDefault()
+        outer.scrollTop = Math.min(maxOuter, outer.scrollTop + event.deltaY)
+        return
+      }
+
+      if (event.deltaY < 0 && outer.scrollTop > 0.5 && nestedScrollTop() <= 0) {
+        event.preventDefault()
+        outer.scrollTop = Math.max(0, outer.scrollTop + event.deltaY)
+      }
+    }
+
+    pair.addEventListener('wheel', onWheel, { passive: false })
+    return () => pair.removeEventListener('wheel', onWheel)
+  }, [overviewCollapsed])
+
+  const showTitleInBar = overviewCollapsed || !overviewInView
+
   return (
     <div
       data-review-surface
@@ -162,28 +246,30 @@ export function ReviewDetailView({
             </span>
           )}
 
-          {/* When the overview is hidden the bar becomes the title, so the page
-              never loses its subject while scrolling deep into a diff. */}
-          {overviewCollapsed && (
+          {/* Title lives in the bar once the overview has scrolled (or been
+              collapsed) away — the page never loses its subject mid-diff. */}
+          {showTitleInBar && (
             <>
               <span aria-hidden className="shrink-0 text-[var(--rv-fg-subtle)]">/</span>
               <StatusDot tone={status.tone} filled={status.filled} />
               <span className="min-w-0 truncate text-[12.5px] font-medium text-[var(--rv-fg)]">
                 {identity.title}
               </span>
-              <button
-                type="button"
-                onClick={onToggleOverview}
-                title="Show details"
-                aria-label="Show details"
-                className={cn(
-                  'inline-flex size-6 shrink-0 items-center justify-center rounded-[4px]',
-                  'text-[var(--rv-fg-subtle)] transition-colors duration-100',
-                  'hover:bg-[var(--rv-bg-hover)] hover:text-[var(--rv-fg)]',
-                )}
-              >
-                <ExpandIcon className="size-3.5" aria-hidden />
-              </button>
+              {overviewCollapsed && (
+                <button
+                  type="button"
+                  onClick={onToggleOverview}
+                  title="Show details"
+                  aria-label="Show details"
+                  className={cn(
+                    'inline-flex size-6 shrink-0 items-center justify-center rounded-[4px]',
+                    'text-[var(--rv-fg-subtle)] transition-colors duration-100',
+                    'hover:bg-[var(--rv-bg-hover)] hover:text-[var(--rv-fg)]',
+                  )}
+                >
+                  <ExpandIcon className="size-3.5" aria-hidden />
+                </button>
+              )}
             </>
           )}
         </div>
@@ -251,40 +337,57 @@ export function ReviewDetailView({
         </div>
       </header>
 
-      <ReviewOverview
-        review={review}
-        collapsed={overviewCollapsed}
-        onToggleCollapsed={onToggleOverview}
-      />
-
-      <div className="relative flex min-h-0 flex-1">
-        <ReviewFileRail
-          files={files}
-          selectedFileId={selectedFileId}
-          onSelectFile={onSelectFile}
-          onToggleViewed={onToggleViewed}
-          hiddenFileCount={hiddenFileCount}
-          width={railWidth}
-        />
-
-        <main data-rv-code className="min-h-0 min-w-0 flex-1 bg-[var(--rv-bg)]">
-          {diffSlot}
-        </main>
-
-        {threadsOpen && threadsSlot && (
-          <div
-            className={cn(
-              'absolute inset-y-0 right-0 z-20 w-[340px] max-w-[80%]',
-              'border-l border-[var(--rv-edge)] bg-[var(--rv-bg-raised)]',
-              'shadow-[var(--rv-shadow-pop)]',
-              'motion-safe:animate-in motion-safe:slide-in-from-right-2 motion-safe:duration-150',
-            )}
-            role="complementary"
-            aria-label={agentOpen ? 'Agent fixes' : 'Review threads'}
-          >
-            {threadsSlot}
+      {/* Overview scrolls away; the sticky reading pair fills the scrollport. */}
+      <div
+        ref={scrollRef}
+        className="min-h-0 flex-1 overflow-y-auto overscroll-contain [container-type:size]"
+        data-testid="review-detail-scroll"
+      >
+        {!overviewCollapsed && (
+          <div ref={overviewSentinelRef}>
+            <ReviewOverview
+              review={review}
+              collapsed={false}
+              onToggleCollapsed={onToggleOverview}
+            />
           </div>
         )}
+
+        <div
+          ref={readingPairRef}
+          className={cn(
+            'sticky top-0 z-10 flex h-[100cqh] min-h-0',
+            'bg-[var(--rv-bg)]',
+          )}
+        >
+          <ReviewFileRail
+            files={files}
+            selectedFileId={selectedFileId}
+            onSelectFile={onSelectFile}
+            onToggleViewed={onToggleViewed}
+            hiddenFileCount={hiddenFileCount}
+            width={railWidth}
+          />
+
+          <main data-rv-code className="relative min-h-0 min-w-0 flex-1 bg-[var(--rv-bg)]">
+            {diffSlot}
+
+            {threadsOpen && threadsSlot && (
+              <div
+                className={cn(
+                  'absolute inset-y-0 right-0 z-20 w-[340px] max-w-[80%]',
+                  'border-l border-[var(--rv-edge)] bg-[var(--rv-bg-raised)]',
+                  'shadow-[var(--rv-shadow-pop)]',
+                  'motion-safe:animate-in motion-safe:slide-in-from-right-2 motion-safe:duration-150',
+                )}
+                role="complementary"
+                aria-label={agentOpen ? 'Agent fixes' : 'Review threads'}
+              >
+                {threadsSlot}
+              </div>
+            )}
+          </main>
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/features/diff-review/review/review-primitives.tsx
+++ b/apps/web/src/features/diff-review/review/review-primitives.tsx
@@ -6,9 +6,9 @@ import { cn } from '~/lib/cn'
  * The small shared vocabulary of the Diffs surface: a status dot, a hairline
  * pill, an added/removed stat pair, and a quiet icon button.
  *
- * These are deliberately local to Diffs rather than pulled from `components/ui`
- * — the review surface runs on its own token set (`review-surface.css`) and at a
- * denser scale than the rest of the app.
+ * Local to Diffs rather than `components/ui` so the reading surface can stay
+ * denser than the rest of the app. Colors come from the app token system via
+ * the thin `--rv-*` aliases in `review-surface.css`.
  */
 
 export type ReviewStatusTone = 'open' | 'merged' | 'closed' | 'draft' | 'warn' | 'danger' | 'neutral'

--- a/apps/web/src/features/diff-review/review/review-surface.css
+++ b/apps/web/src/features/diff-review/review/review-surface.css
@@ -1,182 +1,64 @@
 /**
- * Design tokens for the Cradle Diffs surface.
+ * Diffs surface chrome — layout rhythm + Pierre bridge only.
  *
- * Deliberately self-contained: the review surface does not inherit the app's
- * shared component palette, so the diff reads as a dense, quiet reading
- * environment rather than a form. Scope every token to `[data-review-surface]`
- * so nothing here leaks into the rest of the app.
- *
- * Neutrals carry a faint blue-violet bias toward the accent so greys read as
- * chosen rather than inherited. Diff tints are expressed as alpha over the
- * surface so they sit *under* syntax highlighting instead of fighting it.
+ * Color, type, radius, and shadow come from the app token system in
+ * `apps/web/src/styles.css` (`--background`, `--foreground`, `--primary`, …).
+ * Legacy `--rv-*` names remain as thin aliases so the dense review Views keep
+ * reading through `var(--rv-…)` without owning a second palette.
  */
 
 [data-review-surface] {
   /* Ground */
-  --rv-bg: #ffffff;
-  --rv-bg-subtle: #fbfbfc;
-  --rv-bg-inset: #f5f5f7;
-  --rv-bg-raised: #ffffff;
-  --rv-bg-hover: rgb(16 16 24 / 4%);
-  --rv-bg-active: rgb(16 16 24 / 7%);
+  --rv-bg: var(--background);
+  --rv-bg-subtle: color-mix(in srgb, var(--muted) 55%, var(--background));
+  --rv-bg-inset: var(--muted);
+  --rv-bg-raised: var(--card);
+  --rv-bg-hover: var(--muted);
+  --rv-bg-active: var(--accent);
 
-  /* Hairlines. `line` is the default 1px rule; `edge` separates major regions. */
-  --rv-line: rgb(16 16 24 / 8%);
-  --rv-edge: rgb(16 16 24 / 12%);
+  /* Hairlines */
+  --rv-line: var(--border);
+  --rv-edge: color-mix(in srgb, var(--border) 100%, var(--foreground) 8%);
 
   /* Type */
-  --rv-fg: #101014;
-  --rv-fg-muted: #62636b;
-  --rv-fg-subtle: #8b8c95;
+  --rv-fg: var(--foreground);
+  --rv-fg-muted: var(--muted-foreground);
+  --rv-fg-subtle: var(--text-tertiary);
 
-  /* One accent, spent sparingly: selection, focus, active nav. */
-  --rv-accent: #5b5bd6;
-  --rv-accent-fg: #ffffff;
-  --rv-accent-wash: rgb(91 91 214 / 10%);
+  /* Accent — app primary, spent sparingly for selection / focus / CTA */
+  --rv-accent: var(--primary);
+  --rv-accent-fg: var(--primary-foreground);
+  --rv-accent-wash: color-mix(in srgb, var(--primary) 12%, transparent);
 
-  /* Semantic state — separate from the accent hue. */
-  --rv-add: #16794c;
-  --rv-add-wash: rgb(22 163 100 / 10%);
-  --rv-add-gutter: rgb(22 163 100 / 18%);
-  --rv-del: #b42318;
-  --rv-del-wash: rgb(217 45 32 / 9%);
-  --rv-del-gutter: rgb(217 45 32 / 16%);
-  --rv-warn: #a15c07;
-  --rv-danger: #d92d20;
-  --rv-open: #3d8f5b;
-  --rv-merged: #7d5bd6;
-  --rv-closed: #8b8c95;
-  --rv-draft: #8b8c95;
+  /* Diff + status semantics */
+  --rv-add: var(--success-foreground);
+  --rv-add-wash: color-mix(in srgb, var(--success) 14%, transparent);
+  --rv-add-gutter: color-mix(in srgb, var(--success) 22%, transparent);
+  --rv-del: var(--destructive-foreground);
+  --rv-del-wash: color-mix(in srgb, var(--destructive) 14%, transparent);
+  --rv-del-gutter: color-mix(in srgb, var(--destructive) 22%, transparent);
+  --rv-warn: var(--warning-foreground);
+  --rv-danger: var(--destructive);
+  --rv-open: var(--success-foreground);
+  --rv-merged: var(--info-foreground);
+  --rv-closed: var(--text-tertiary);
+  --rv-draft: var(--text-tertiary);
 
-  /* Geometry — Vercel-ish crisp radii, no pill-everything. */
-  --rv-radius: 6px;
-  --rv-radius-lg: 10px;
-  --rv-shadow-raised: 0 1px 2px rgb(16 16 24 / 5%), 0 0 0 1px var(--rv-line);
-  --rv-shadow-pop: 0 8px 24px -6px rgb(16 16 24 / 14%), 0 0 0 1px var(--rv-edge);
+  /* Geometry — follow app radius / shadow scales */
+  --rv-radius: var(--radius-md);
+  --rv-radius-lg: var(--radius-lg);
+  --rv-shadow-raised: var(--shadow-xs);
+  --rv-shadow-pop: var(--shadow-md);
 
-  /* Rhythm */
+  /* Rhythm unique to the review reading surface */
   --rv-topbar-h: 44px;
   --rv-rail-w: 248px;
   --rv-meta-w: 264px;
   --rv-code-line-h: 18px;
 
-  --rv-font-ui: 'Geist Variable', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
-  --rv-font-mono: ui-monospace, 'SF Mono', 'Geist Mono', 'JetBrains Mono', Menlo, monospace;
-}
+  --rv-font-ui: var(--font-sans);
+  --rv-font-mono: var(--font-mono);
 
-@media (prefers-color-scheme: dark) {
-  [data-review-surface] {
-    --rv-bg: #08090a;
-    --rv-bg-subtle: #0c0d0f;
-    --rv-bg-inset: #111214;
-    --rv-bg-raised: #101113;
-    --rv-bg-hover: rgb(255 255 255 / 5%);
-    --rv-bg-active: rgb(255 255 255 / 8%);
-
-    --rv-line: rgb(255 255 255 / 9%);
-    --rv-edge: rgb(255 255 255 / 14%);
-
-    --rv-fg: #f5f6f8;
-    --rv-fg-muted: #8b9099;
-    --rv-fg-subtle: #5f636b;
-
-    --rv-accent: #7c7cff;
-    --rv-accent-fg: #0b0b12;
-    --rv-accent-wash: rgb(124 124 255 / 16%);
-
-    --rv-add: #4ac57f;
-    --rv-add-wash: rgb(46 194 116 / 13%);
-    --rv-add-gutter: rgb(46 194 116 / 22%);
-    --rv-del: #ff7b70;
-    --rv-del-wash: rgb(248 81 73 / 13%);
-    --rv-del-gutter: rgb(248 81 73 / 22%);
-    --rv-warn: #e0a12a;
-    --rv-danger: #ff6b60;
-    --rv-open: #4ac57f;
-    --rv-merged: #a48bff;
-    --rv-closed: #6d7178;
-    --rv-draft: #6d7178;
-
-    --rv-shadow-raised: 0 1px 2px rgb(0 0 0 / 40%), 0 0 0 1px var(--rv-line);
-    --rv-shadow-pop: 0 12px 32px -8px rgb(0 0 0 / 64%), 0 0 0 1px var(--rv-edge);
-  }
-}
-
-/* The app's own theme toggle must win over the OS preference, both directions. */
-:root[data-theme='dark'] [data-review-surface],
-.dark [data-review-surface] {
-  --rv-bg: #08090a;
-  --rv-bg-subtle: #0c0d0f;
-  --rv-bg-inset: #111214;
-  --rv-bg-raised: #101113;
-  --rv-bg-hover: rgb(255 255 255 / 5%);
-  --rv-bg-active: rgb(255 255 255 / 8%);
-
-  --rv-line: rgb(255 255 255 / 9%);
-  --rv-edge: rgb(255 255 255 / 14%);
-
-  --rv-fg: #f5f6f8;
-  --rv-fg-muted: #8b9099;
-  --rv-fg-subtle: #5f636b;
-
-  --rv-accent: #7c7cff;
-  --rv-accent-fg: #0b0b12;
-  --rv-accent-wash: rgb(124 124 255 / 16%);
-
-  --rv-add: #4ac57f;
-  --rv-add-wash: rgb(46 194 116 / 13%);
-  --rv-add-gutter: rgb(46 194 116 / 22%);
-  --rv-del: #ff7b70;
-  --rv-del-wash: rgb(248 81 73 / 13%);
-  --rv-del-gutter: rgb(248 81 73 / 22%);
-  --rv-warn: #e0a12a;
-  --rv-danger: #ff6b60;
-  --rv-open: #4ac57f;
-  --rv-merged: #a48bff;
-  --rv-closed: #6d7178;
-  --rv-draft: #6d7178;
-
-  --rv-shadow-raised: 0 1px 2px rgb(0 0 0 / 40%), 0 0 0 1px var(--rv-line);
-  --rv-shadow-pop: 0 12px 32px -8px rgb(0 0 0 / 64%), 0 0 0 1px var(--rv-edge);
-}
-
-:root[data-theme='light'] [data-review-surface] {
-  --rv-bg: #ffffff;
-  --rv-bg-subtle: #fbfbfc;
-  --rv-bg-inset: #f5f5f7;
-  --rv-bg-raised: #ffffff;
-  --rv-bg-hover: rgb(16 16 24 / 4%);
-  --rv-bg-active: rgb(16 16 24 / 7%);
-
-  --rv-line: rgb(16 16 24 / 8%);
-  --rv-edge: rgb(16 16 24 / 12%);
-
-  --rv-fg: #101014;
-  --rv-fg-muted: #62636b;
-  --rv-fg-subtle: #8b8c95;
-
-  --rv-accent: #5b5bd6;
-  --rv-accent-fg: #ffffff;
-  --rv-accent-wash: rgb(91 91 214 / 10%);
-
-  --rv-add: #16794c;
-  --rv-add-wash: rgb(22 163 100 / 10%);
-  --rv-add-gutter: rgb(22 163 100 / 18%);
-  --rv-del: #b42318;
-  --rv-del-wash: rgb(217 45 32 / 9%);
-  --rv-del-gutter: rgb(217 45 32 / 16%);
-  --rv-warn: #a15c07;
-  --rv-danger: #d92d20;
-  --rv-open: #3d8f5b;
-  --rv-merged: #7d5bd6;
-  --rv-closed: #8b8c95;
-  --rv-draft: #8b8c95;
-
-  --rv-shadow-raised: 0 1px 2px rgb(16 16 24 / 5%), 0 0 0 1px var(--rv-line);
-  --rv-shadow-pop: 0 8px 24px -6px rgb(16 16 24 / 14%), 0 0 0 1px var(--rv-edge);
-}
-
-[data-review-surface] {
   background: var(--rv-bg);
   color: var(--rv-fg);
   font-family: var(--rv-font-ui);
@@ -189,12 +71,12 @@
 }
 
 [data-review-surface] :focus-visible {
-  outline: 2px solid var(--rv-accent);
+  outline: 2px solid var(--ring);
   outline-offset: 1px;
   border-radius: 3px;
 }
 
-/* Pierre's CodeView paints its own chrome; align it to the surface tokens. */
+/* Pierre's CodeView paints its own chrome; align it to app diff washes. */
 [data-review-surface] [data-rv-code] {
   --pierre-diff-addition-bg: var(--rv-add-wash);
   --pierre-diff-deletion-bg: var(--rv-del-wash);

--- a/apps/web/src/features/diff-review/review/stories/diffs-index-view.stories.tsx
+++ b/apps/web/src/features/diff-review/review/stories/diffs-index-view.stories.tsx
@@ -7,9 +7,9 @@ import { DiffsIndexView } from '../diffs-index-view'
 import { reviewFixture, workingTreeReviewFixture } from '../fixtures/review-fixtures'
 
 const repositories: RepositoryScope[] = [
-  { id: 'repo_cradle', hostKind: 'github', label: 'wibus-wee/cradle-app', localRoot: '/Users/wibus/dev/cradle-app', reviewCount: 6 },
-  { id: 'repo_streamdown', hostKind: 'github', label: 'wibus-wee/streamdown', localRoot: null, reviewCount: 2 },
-  { id: 'repo_scratch', hostKind: 'local', label: 'scratch', localRoot: '/Users/wibus/dev/scratch', reviewCount: 1 },
+  { id: 'repo_cradle', hostKind: 'github', label: 'wibus-wee/cradle-app', localRoot: '/Users/wibus/dev/cradle-app', reviewCount: 6, workspaceId: 'ws_cradle_app', repositoryPath: '.' },
+  { id: 'repo_streamdown', hostKind: 'github', label: 'wibus-wee/streamdown', localRoot: null, reviewCount: 2, workspaceId: 'ws_cradle_app', repositoryPath: null },
+  { id: 'repo_scratch', hostKind: 'local', label: 'scratch', localRoot: '/Users/wibus/dev/scratch', reviewCount: 1, workspaceId: 'ws_scratch', repositoryPath: '.' },
 ]
 
 /** A handful of reviews spanning states so the tab counts and columns are exercised. */

--- a/apps/web/src/features/diff-review/workspace-diffs-view.tsx
+++ b/apps/web/src/features/diff-review/workspace-diffs-view.tsx
@@ -8,8 +8,8 @@ import { DiffWorkerProvider } from '~/components/common/diff/diff-runtime'
 import { useRegisterLayoutSlots } from '~/components/layout/use-layout-slots'
 import { Spinner } from '~/components/ui/spinner'
 import { parseGitHubPullRequestReference } from '~/features/diff-review/github-pull-request-reference'
+import { DiffsIndexContainer } from '~/features/diff-review/review/diffs-index-container'
 import { ReviewDetailPage } from '~/features/diff-review/review-detail/review-detail-page'
-import { ReviewsListPage } from '~/features/diff-review/reviews-list-page'
 import { navigateToReview, WORKING_TREE_REVIEW_ID } from '~/features/diff-review/shared/navigation'
 
 export interface WorkspaceDiffsViewProps {
@@ -51,10 +51,14 @@ export function WorkspaceDiffsView({
     hasPanel: false,
   }), [workspaceId]))
 
+  const isBrowsing = !review && !path && !github
+
   return (
     <DiffWorkerProvider>
       <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background">
-        <BetaNotice title={t('beta.title')} description={t('beta.description')} />
+        {!isBrowsing && (
+          <BetaNotice title={t('beta.title')} description={t('beta.description')} />
+        )}
         <div className="min-h-0 flex-1 overflow-hidden">
           <WorkspaceDiffsContent
             workspaceId={workspaceId}
@@ -112,7 +116,13 @@ function WorkspaceDiffsContent({
     )
   }
 
-  return <ReviewsListPage workspaceId={workspaceId} repositoryPath={repo} />
+  return (
+    <DiffsIndexContainer
+      workspaceId={workspaceId}
+      preferredWorkspaceId={workspaceId}
+      selectedRepositoryKey={repo}
+    />
+  )
 }
 
 function GitHubPullRequestDeepLink({ workspaceId, reference }: { workspaceId: string, reference: string }) {

--- a/apps/web/src/routes/diff.tsx
+++ b/apps/web/src/routes/diff.tsx
@@ -29,7 +29,6 @@ export const Route = createFileRoute('/diff')({
 })
 
 function DiffRoute() {
-  const navigate = Route.useNavigate()
   const { workspace, repo, path, review, line, side, github } = Route.useSearch()
 
   return (
@@ -41,13 +40,6 @@ function DiffRoute() {
       line={line}
       side={side}
       github={github}
-      onWorkspaceSelect={(workspaceId) => {
-        void navigate({
-          search: {
-            workspace: workspaceId,
-          },
-        })
-      }}
     />
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

The new Diffs UI (`DiffsIndexView` / `ReviewDetailView`) lived only in Storybook with a private `--rv-*` color palette, while production still rendered the older workspace-first list and top-bar detail chrome. The prototype could not ship until it used the app token system and was mounted on the real `/diff` routes with existing review mutations.

## Summary

- Replaced the Diffs surface private palette in `review-surface.css` with thin `--rv-*` aliases onto the app token system (`--background`, `--foreground`, `--primary`, `--success`, etc.), deleting the hardcoded light/dark hex forks.
- Mounted `DiffsIndexView` via a new `DiffsIndexContainer` as the Diffs home (repository-first, derived from workspace git checkouts + reviews until server repository ownership lands).
- Rewired `ReviewDetailPage` to render through `ReviewDetailView`, keeping DiffStage, threads/agent overlays, approve/request-changes/comment, merge, preferences, and close.
- `/diff` browsing is now the new index full-bleed; opening a review drops index chrome and shows the reading surface with Back.

## Test plan

- [x] `pnpm --filter @cradle/web exec tsc --noEmit`
- [x] ESLint on touched Diffs files
- [ ] Manual: open `/diff`, select a repository, open a review, toggle threads/agent overlay, submit a review decision
- [ ] Manual: theme toggle / custom theme profile — Diffs surface follows app tokens
- [ ] Manual: Working tree CTA opens the working-tree review detail

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is denied or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** Integrate the unfinished Diffs UI prototypes into the product; remove their private token system and use the current app token system.
- **Constraints / non-goals:** Do not invent Cradle ownership of Claude Agent turn lifecycle. Do not casually add DB migrations for the draft `repositories` schema. Working-tree stage/unstage/commit APIs do not exist yet — `WorkingTreeView` stays Storybook-only; the Working tree CTA opens the existing working-tree review detail.
- **Decision rationale:** Keep `--rv-*` as aliases (not a second palette) so dense Views keep reading through existing class names while colors come from `styles.css`. Derive `RepositoryScope` from live git + reviews instead of waiting on unexported repository tables.
- **Deliberately not done:** Branch-compare / open-commit entry points from the old list header; full `WorkingTreeView` staging UI; server-side repository ownership schema/API.
- **Unknowns / confidence:** Repository coalescing (local checkout + GitHub PR) is heuristic by repo name; may need remote-url matching later.

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [x] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d47fa48b-ff76-4e42-a502-70aace4e3063?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d47fa48b-ff76-4e42-a502-70aace4e3063&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

