### PR TITLE
fix(recall): broaden recall_query when-to-use without token bloat

### DIFF
--- a/apps/server/src/modules/agent-tools/tools/recall/recall-query.ts
+++ b/apps/server/src/modules/agent-tools/tools/recall/recall-query.ts
@@ -61,7 +61,7 @@ function registerRecallQueryTool(server: McpServer): void {
     {
       title: 'Recall Query',
       description:
-        'Search prior Cradle execution evidence and memories, returning citable JSON from the current workspace. Use when the user asks what happened before, how a decision or bug was handled, what a prior chat concluded, or to find related failures, runs, messages, or file history. Typical requests include "how did we handle this before", "did we discuss this earlier", "why did this fail", "find the earlier decision", and "what changed in this file". Read-only: helper filters may narrow the runtime-bound workspace scope but cannot broaden it.',
+        'Search this workspace\'s prior chat/execution evidence; returns citable JSON. Use when past context may matter—even if the user never says "before". Prefer a quick check over guessing past decisions. Read-only; not a code-search substitute.',
       inputSchema: {
         code: z
           .string()

--- a/resources/skills/cradle-cli/SKILL.md
+++ b/resources/skills/cradle-cli/SKILL.md
@@ -304,7 +304,7 @@ cradle chronicle privacy redact --text "Sensitive text to preview"
 
 ## Recall Evidence Retrieval
 
-Use the session-bound `recall_query` MCP tool to retrieve citable evidence from prior Cradle execution when the user asks about an earlier decision, conversation, failure, run, or file change. Use `recall_attune` only after the user explicitly asks to save, update, or forget a durable, evidence-backed memory; its proposal still requires user approval.
+Use the session-bound `recall_query` MCP tool when this workspace's past chat or execution context may matter—even if the user never says "before". Prefer a quick recall check over guessing a prior decision, agreement, or attempt. Use `recall_attune` only after the user explicitly asks to save, update, or forget a durable, evidence-backed memory; its proposal still requires user approval.
 
 Read [the Recall reference](references/recall.md) before writing Recall CodeAct or explaining its scope and approval behavior. Do not inject Recall automatically as pre-turn context.
 

--- a/resources/skills/cradle-cli/references/recall.md
+++ b/resources/skills/cradle-cli/references/recall.md
@@ -1,10 +1,10 @@
 # Recall evidence retrieval
 
-Use Recall to answer questions about prior work with evidence from the active Cradle workspace. It is a session-bound, runtime-provided MCP capability; it is not a global database search and it does not replace the `cradle` CLI for ordinary Cradle operations.
+Use Recall when this workspace's past chat or execution evidence may matter—not only when the user explicitly asks about history. It is a session-bound, runtime-provided MCP capability; it is not a global database search and it does not replace the `cradle` CLI for ordinary Cradle operations.
 
 ## Query prior evidence
 
-Call `recall_query` when the user asks what happened earlier, how a decision or bug was handled, what a previous chat concluded, why something failed, or what changed in a file. The tool accepts JavaScript CodeAct that exports a default function and returns JSON-compatible data.
+Call `recall_query` when past chat or execution context in this workspace may matter—even if the user never says "before" or "earlier". Prefer a quick check over guessing a prior decision, agreement, attempt, failure, or file-related history. The tool accepts JavaScript CodeAct that exports a default function and returns JSON-compatible data.
 
 ```js
 export default async function () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

`recall_query` under-triggered: agent-facing copy framed it as “only when the user asks what happened before,” so agents waited for explicit history language instead of checking when past workspace chat/execution context was plausible. Long example-heavy tool descriptions also taxed every-turn tokens.

## Summary

- Shortened `recall_query` MCP tool description to: use when past context may matter (even without “before”); prefer a quick check over guessing; read-only; not code search.
- Aligned `resources/skills/cradle-cli` skill + recall reference (`.agents` / `.claude` are symlinks to the same source).
- Left `recall_attune` strict (explicit user request + approval).

## Test plan

- Confirmed no tests assert the old description string (`rg` over repo).
- Pre-commit `eslint --fix` via lint-staged on the TS change.
- Manual subagent simulation earlier: with the short proactive description, agent called recall when user said prior agreement existed / might matter.
- Skipped full server test suite (description-only change).

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is denied or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** Broaden recall_query when-to-use so agents check when past context may matter; keep description short for tokens; update all recall agent-facing copies and push.
- **Constraints / non-goals:** Do not loosen recall_attune; do not auto-inject recall into harness; avoid long example lists in the always-loaded tool description.
- **Decision rationale:** Discovery trigger lives in MCP tool + cradle-cli skill/reference; plans/capability specs are design docs and were left alone.
- **Deliberately not done:** No dedicated `.agents/skills/recall` skill; no runtime/behavior changes; no attune description edits.
- **Unknowns / confidence:** Production call-rate impact not measured; subagent sims are suggestive only.

### Sharing consent (author side)

- [x] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41ac7d22-0b18-48c7-8199-58c88920a6e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41ac7d22-0b18-48c7-8199-58c88920a6e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

