### PR TITLE
fix: prepare daily E2E runtime artifacts

### DIFF
--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -43,6 +43,14 @@ jobs:
         with:
           node-version: 22
 
+      # The server imports @cradle/plugin-sdk from dist/ and discovers plugin
+      # runtime entries from each plugin's dist/ directory.
+      - name: Build plugin SDK
+        run: pnpm --filter @cradle/plugin-sdk build
+
+      - name: Build workspace plugins
+        run: pnpm --filter "./plugins/*" build
+
       # ── Install Playwright ────────────────────────────────────────────────
       - name: Install Playwright browsers
         timeout-minutes: 15
@@ -79,7 +87,11 @@ jobs:
         env:
           NODE_ENV: test
           CRADLE_CREDENTIAL_SECRET: e2e-test-secret
+          CRADLE_E2E_VERBOSE: "1"
+          CRADLE_LOG_SYNC: "1"
         run: |
+          # Preserve the real Cucumber exit status when tee-ing the log.
+          set -o pipefail
           mkdir -p e2e/artifacts
           # Daily gate: full active priority suite (@P0 or @P1). Override via workflow_dispatch.
           TAGS="${{ github.event.inputs.tags || '@P0 or @P1' }}"
@@ -89,6 +101,13 @@ jobs:
             --format junit:e2e/artifacts/cucumber-junit.xml
             --tags "$TAGS")
           "${CMD[@]}" 2>&1 | tee e2e/artifacts/cucumber-output.log
+
+          # A bootstrap failure in a Cucumber worker can otherwise produce a
+          # misleading successful run with zero executed scenarios.
+          if grep -q '^0 scenarios' e2e/artifacts/cucumber-summary.txt; then
+            echo "::error::Cucumber completed without executing any scenarios."
+            exit 1
+          fi
 
       - name: Summarize E2E result
         if: always()


### PR DESCRIPTION
## What changed

- Build `@cradle/plugin-sdk` before starting the E2E suite.
- Build all workspace plugins so their `dist/` runtime entries exist.
- Enable server bootstrap diagnostics with `CRADLE_E2E_VERBOSE` and `CRADLE_LOG_SYNC`.
- Enable `pipefail` so `tee` cannot hide the Cucumber exit status.
- Fail explicitly when Cucumber reports zero executed scenarios.

## Why

Run `30878859057` timed out waiting for the managed server health endpoint and produced `0 scenarios / 0 steps`. The daily workflow did not build the SDK or plugin runtime artifacts, while the server imports the SDK from `dist/`. Its child-process stderr was also suppressed, and the `cucumber | tee` pipeline could report success even when the test process failed.

## Validation

- Verified the PR diff contains only `.github/workflows/e2e-daily.yml`.
- The next Actions run should confirm the missing runtime artifact issue and expose any remaining server bootstrap error in the job log.