### PR TITLE
fix(composer): preserve drafts after rejected Work submits

### DIFF
--- a/apps/web/src/features/chat/composer/composer-submit.test.ts
+++ b/apps/web/src/features/chat/composer/composer-submit.test.ts
@@ -1,0 +1,85 @@
+import type { FileUIPart } from 'ai'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ComposerAction } from './composer-state'
+import type { PromptEditorController } from './prompt-editor'
+import { submitAndClearDraft } from './composer-submit'
+
+function createPromptEditor(initialText: string): PromptEditorController {
+  let text = initialText
+  return {
+    appendText: vi.fn(),
+    canNavigateHistory: vi.fn(() => false),
+    clear: vi.fn(() => {
+      text = ''
+    }),
+    focus: vi.fn(),
+    getContextParts: vi.fn(() => []),
+    getText: vi.fn(() => text),
+    insertFileMention: vi.fn(),
+    insertIntentMention: vi.fn(),
+    insertPluginMention: vi.fn(),
+    insertSkillMention: vi.fn(),
+    insertText: vi.fn(),
+    replaceFileTriggerWithText: vi.fn(),
+    replaceRangeWithText: vi.fn(),
+    setPlaceholder: vi.fn(),
+    setDraft: vi.fn(),
+    setText: vi.fn((nextText: string) => {
+      text = nextText
+    }),
+  }
+}
+
+function submitDraft({
+  onResult,
+  promptEditor,
+  submit,
+}: {
+  onResult: (outcome: { accepted: boolean, restored: boolean }) => void
+  promptEditor: PromptEditorController
+  submit: () => Promise<boolean>
+}) {
+  submitAndClearDraft({
+    appendFileParts: vi.fn<(fileParts: FileUIPart[]) => void>(),
+    clearAttachments: vi.fn(),
+    contextParts: [],
+    dispatch: vi.fn<(action: ComposerAction) => void>(),
+    files: [],
+    onResult,
+    promptEditor,
+    submit,
+    text: 'Keep this objective',
+  })
+}
+
+describe('submitAndClearDraft', () => {
+  it('restores the draft when an async submit is rejected', async () => {
+    const promptEditor = createPromptEditor('Keep this objective')
+    const onResult = vi.fn()
+
+    submitDraft({
+      onResult,
+      promptEditor,
+      submit: async () => false,
+    })
+
+    expect(promptEditor.getText()).toBe('')
+    await vi.waitFor(() => expect(promptEditor.getText()).toBe('Keep this objective'))
+    expect(onResult).toHaveBeenCalledWith({ accepted: false, restored: true })
+  })
+
+  it('reports accepted async submits without restoring the draft', async () => {
+    const promptEditor = createPromptEditor('Keep this objective')
+    const onResult = vi.fn()
+
+    submitDraft({
+      onResult,
+      promptEditor,
+      submit: async () => true,
+    })
+
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledWith({ accepted: true, restored: false }))
+    expect(promptEditor.getText()).toBe('')
+  })
+})

--- a/apps/web/src/features/chat/composer/composer-submit.test.ts
+++ b/apps/web/src/features/chat/composer/composer-submit.test.ts
@@ -2,8 +2,8 @@ import type { FileUIPart } from 'ai'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ComposerAction } from './composer-state'
-import type { PromptEditorController } from './prompt-editor'
 import { submitAndClearDraft } from './composer-submit'
+import type { PromptEditorController } from './prompt-editor'
 
 function createPromptEditor(initialText: string): PromptEditorController {
   let text = initialText

--- a/apps/web/src/features/chat/composer/composer-submit.ts
+++ b/apps/web/src/features/chat/composer/composer-submit.ts
@@ -11,6 +11,11 @@ import type { PromptEditorController } from './prompt-editor'
 
 export type ComposerSendResult = SendMessageResult | boolean
 
+export interface ComposerSubmitOutcome {
+  accepted: boolean
+  restored: boolean
+}
+
 export type ComposerSendHandler = (
   text: string,
   files: FileUIPart[],
@@ -94,6 +99,7 @@ export function submitAndClearDraft({
   promptEditor,
   submit,
   text,
+  onResult,
 }: {
   appendFileParts: (fileParts: FileUIPart[]) => void
   clearAttachments: () => void
@@ -104,6 +110,7 @@ export function submitAndClearDraft({
   promptEditor: PromptEditorController | null
   submit: ComposerSendHandler
   text: string
+  onResult?: (outcome: ComposerSubmitOutcome) => void
 }) {
   let result: ComposerSendResult | Promise<ComposerSendResult>
   try {
@@ -113,27 +120,33 @@ export function submitAndClearDraft({
   }
   catch (error) {
     reportComposerSubmitError(error)
+    onResult?.({ accepted: false, restored: false })
     return
   }
 
   if (result === false) {
+    onResult?.({ accepted: false, restored: false })
     return
   }
 
   clearSubmittedDraft({ clearAttachments, dispatch, promptEditor })
-
-  if (isComposerSendPromise(result)) {
-    void result
-      .then((resolved) => {
-        if (resolved === false) {
-          restoreSubmittedDraft({ appendFileParts, contextParts, dispatch, files, promptEditor, text })
-        }
-      })
-      .catch((error) => {
-        reportComposerSubmitError(error)
-        restoreSubmittedDraft({ appendFileParts, contextParts, dispatch, files, promptEditor, text })
-      })
+  if (!isComposerSendPromise(result)) {
+    onResult?.({ accepted: true, restored: false })
+    return
   }
+
+  void result
+    .then((resolved) => {
+      if (resolved === false) {
+        restoreSubmittedDraft({ appendFileParts, contextParts, dispatch, files, promptEditor, text })
+      }
+      onResult?.({ accepted: resolved !== false, restored: resolved === false })
+    })
+    .catch((error) => {
+      reportComposerSubmitError(error)
+      restoreSubmittedDraft({ appendFileParts, contextParts, dispatch, files, promptEditor, text })
+      onResult?.({ accepted: false, restored: true })
+    })
 }
 
 export function readBangCommandDraft(text: string): string | null {

--- a/apps/web/src/features/chat/composer/containers/draft-chat-composer-container.tsx
+++ b/apps/web/src/features/chat/composer/containers/draft-chat-composer-container.tsx
@@ -382,7 +382,7 @@ function DraftChatComposerContent({
           contextParts,
           submitOptions,
         ))
-      .then(() => true)
+      .then(result => result !== false)
       .finally(() => {
         setSending(false)
       })

--- a/apps/web/src/features/chat/composer/views/composer-view.tsx
+++ b/apps/web/src/features/chat/composer/views/composer-view.tsx
@@ -68,7 +68,11 @@ import { useComposerAttachments } from '../composer-attachment-state'
 import type { PendingAppshotAttachment } from '../composer-attachments'
 import { ComposerAttachmentInput, ComposerAttachmentList } from '../composer-attachments'
 import { composerReducer, INITIAL_COMPOSER_STATE } from '../composer-state'
-import type { ComposerSendHandler, ComposerSendResult } from '../composer-submit'
+import type {
+  ComposerSendHandler,
+  ComposerSendResult,
+  ComposerSubmitOutcome,
+} from '../composer-submit'
 import {
   isComposerSendPromise,
   readBangCommandDraft,
@@ -369,10 +373,27 @@ export function ComposerView({
   const handleAttachmentPaste = attachmentController.handlePaste
   const promptEditorRef = useRef<PromptEditorController>(null)
   const [pastedTexts, setPastedTexts] = useState<ComposerPastedText[]>([])
+  const preserveDraftOnPendingSubmitRef = useRef(false)
   const historyIndexRef = useRef<number | null>(null)
   const historyDraftRef = useRef<ComposerDraft | null>(null)
   const historyAppliedTextRef = useRef<string | null>(null)
   const actionTargetRef = useRef<HTMLDivElement>(null)
+  const handleSubmitResult = useCallback((outcome: ComposerSubmitOutcome) => {
+    preserveDraftOnPendingSubmitRef.current = false
+
+    if (!outcome.accepted && !outcome.restored) {
+      return
+    }
+
+    if (outcome.accepted && surfaceId) {
+      clearSyncedDraft()
+    }
+    if (outcome.accepted || outcome.restored) {
+      setPastedTexts([])
+      historyIndexRef.current = null
+      historyDraftRef.current = null
+    }
+  }, [clearSyncedDraft, surfaceId])
   const setActionTargetElement = useCallback(
     (element: HTMLDivElement | null) => {
       actionTargetRef.current = element
@@ -630,6 +651,7 @@ export function ComposerView({
         }
 
         dispatch({ type: 'slash/selected', inputValue: currentState.inputValue, command: null })
+        preserveDraftOnPendingSubmitRef.current = true
         submitAndClearDraft({
           appendFileParts: appendComposerFileParts,
           clearAttachments: clearComposerAttachments,
@@ -639,6 +661,7 @@ export function ComposerView({
           promptEditor: promptEditorRef.current,
           submit,
           text: submitText,
+          onResult: handleSubmitResult,
         })
         requestAnimationFrame(() => promptEditorRef.current?.focus())
         return
@@ -671,6 +694,7 @@ export function ComposerView({
       clearComposerAttachments,
       composerAttachments,
       disabled,
+      handleSubmitResult,
       isSending,
       onSlashCommandAction,
       sendDisabled,
@@ -731,6 +755,7 @@ export function ComposerView({
         }
       }
 
+      preserveDraftOnPendingSubmitRef.current = true
       submitAndClearDraft({
         appendFileParts: appendComposerFileParts,
         clearAttachments: clearComposerAttachments,
@@ -741,14 +766,8 @@ export function ComposerView({
         promptEditor: promptEditorRef.current,
         submit: submitHandler,
         text,
+        onResult: handleSubmitResult,
       })
-      // Clear persisted draft on send
-      if (surfaceId) {
-        clearSyncedDraft()
-      }
-      setPastedTexts([])
-      historyIndexRef.current = null
-      historyDraftRef.current = null
     },
     [
       allowEmptySend,
@@ -764,9 +783,8 @@ export function ComposerView({
       sendBlocked,
       sendDisabled,
       submit,
-      clearSyncedDraft,
+      handleSubmitResult,
       pastedTexts,
-      surfaceId,
     ],
   )
 
@@ -998,7 +1016,7 @@ export function ComposerView({
   useEffect(() => {
     onDraftChange?.(state.inputValue)
     onDraftPartsChange?.(state.inputValue, state.contextParts)
-    if (!suspendDraftPersistence) {
+    if (!suspendDraftPersistence && !preserveDraftOnPendingSubmitRef.current) {
       handleDraftPartsChange(state.inputValue, state.contextParts, composerAttachments, pastedTexts)
     }
   }, [


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Propagate rejected Work creation results through Draft Composer and preserve the submitted draft while the async request is pending. Failed or thrown Work creation now restores the objective and attachments/context, while successful submission is the only path that clears persisted composer state. Fixed the test import order reported by CI lint.

## Summary

Propagate rejected Work creation results through Draft Composer and preserve the submitted draft while the async request is pending. Failed or thrown Work creation now restores the objective and attachments/context, while successful submission is the only path that clears persisted composer state. Fixed the test import order reported by CI lint.

## Test plan

`pnpm lint` passed. Targeted `pnpm --filter @cradle/web exec vitest run src/features/chat/composer/composer-submit.test.ts --config vite.config.ts --environment jsdom` passed (2 tests). `git show --check HEAD` passed.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is declined or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** See Problem / pressure. Detailed directive transcript not attached (author-side sharing consent pending).
- **Constraints / non-goals:** N/A
- **Decision rationale:** N/A
- **Deliberately not done:** N/A
- **Unknowns / confidence:** N/A

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)