### PR TITLE
fix(tui): coalesce terminal websocket reconnects

### DIFF
--- a/apps/web/src/features/tui/pty-channel.test.ts
+++ b/apps/web/src/features/tui/pty-channel.test.ts
@@ -169,4 +169,52 @@ describe('createPtyChannel', () => {
 
     channel.close()
   })
+
+  it('coalesces concurrent connection attempts', async () => {
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+    const channel = createPtyChannel({
+      socketPath: '/pty/session-1',
+      onSnapshot: vi.fn(),
+      onOutput: vi.fn(),
+      onExit: vi.fn(),
+    })
+
+    await Promise.all([channel.connect(), channel.connect(), channel.connect()])
+
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    channel.close()
+  })
+
+  it('ignores stale socket events after a newer connection replaces it', async () => {
+    vi.useFakeTimers()
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+    const channel = createPtyChannel({
+      socketPath: '/pty/session-1',
+      reconnectDelayMs: 250,
+      onSnapshot: vi.fn(),
+      onOutput: vi.fn(),
+      onExit: vi.fn(),
+    })
+
+    await channel.connect()
+    const firstSocket = FakeWebSocket.instances[0]!
+    firstSocket.open()
+    firstSocket.close()
+    vi.advanceTimersByTime(250)
+    await Promise.resolve()
+
+    const secondSocket = FakeWebSocket.instances[1]!
+    secondSocket.open()
+    firstSocket.emitMessage(JSON.stringify({
+      type: 'snapshot',
+      seq: 1,
+      buffer: 'stale',
+      running: true,
+    }))
+    firstSocket.close()
+
+    expect(channel.getLastSeq()).toBeNull()
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    channel.close()
+  })
 })

--- a/apps/web/src/features/tui/pty-channel.ts
+++ b/apps/web/src/features/tui/pty-channel.ts
@@ -53,6 +53,7 @@ const WebSocketMessageSchema = z.object({
 export function createPtyChannel(rawOptions: PtyChannelOptions): PtyChannel {
   const options = PtyChannelOptionsSchema.parse(rawOptions)
   let socket: WebSocket | null = null
+  let connecting: Promise<void> | null = null
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let pingTimer: ReturnType<typeof setInterval> | null = null
   let closedManually = false
@@ -174,38 +175,65 @@ export function createPtyChannel(rawOptions: PtyChannelOptions): PtyChannel {
       return
     }
 
-    const url = await getAuthenticatedServerWebSocketUrl(
-      options.socketPath,
-      lastSeq === null ? undefined : { fromSeq: lastSeq },
-    )
-    socket = new WebSocket(url)
+    if (connecting) {
+      return connecting
+    }
 
-    socket.addEventListener('open', () => {
-      clearReconnectTimer()
-      startPingLoop()
-      flushPendingMessages()
-      options.onOpen?.()
-    })
-
-    socket.addEventListener('message', (event) => {
-      const message = WebSocketMessageSchema.safeParse(event)
-      if (!message.success) {
-        emitError('INVALID_SERVER_EVENT', 'Received malformed terminal socket message.')
+    connecting = (async () => {
+      const url = await getAuthenticatedServerWebSocketUrl(
+        options.socketPath,
+        lastSeq === null ? undefined : { fromSeq: lastSeq },
+      )
+      if (closedManually) {
         return
       }
-      handleMessage(message.data.data)
+
+      const nextSocket = new WebSocket(url)
+      socket = nextSocket
+
+      nextSocket.addEventListener('open', () => {
+        if (socket !== nextSocket) {
+          return
+        }
+        clearReconnectTimer()
+        startPingLoop()
+        flushPendingMessages()
+        options.onOpen?.()
+      })
+
+      nextSocket.addEventListener('message', (event) => {
+        if (socket !== nextSocket) {
+          return
+        }
+        const message = WebSocketMessageSchema.safeParse(event)
+        if (!message.success) {
+          emitError('INVALID_SERVER_EVENT', 'Received malformed terminal socket message.')
+          return
+        }
+        handleMessage(message.data.data)
+      })
+
+      nextSocket.addEventListener('error', () => {
+        if (socket !== nextSocket) {
+          return
+        }
+        emitError('SOCKET_ERROR', getI18n().t('common:pty.socketConnectionError'))
+      })
+
+      nextSocket.addEventListener('close', () => {
+        if (socket !== nextSocket) {
+          return
+        }
+        stopPingLoop()
+        socket = null
+        options.onClose?.()
+        scheduleReconnect()
+      })
+    })().finally(() => {
+      connecting = null
     })
 
-    socket.addEventListener('error', () => {
-      emitError('SOCKET_ERROR', getI18n().t('common:pty.socketConnectionError'))
-    })
-
-    socket.addEventListener('close', () => {
-      stopPingLoop()
-      socket = null
-      options.onClose?.()
-      scheduleReconnect()
-    })
+    return connecting
   }
 
   return {


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Prevent PTY TUI flicker caused by overlapping WebSocket connection attempts and stale socket lifecycle events. The channel now coalesces in-flight ticket/socket creation and ignores events from sockets that are no longer current; focused regression coverage covers concurrent connects and stale reconnect events.

## Summary

Prevent PTY TUI flicker caused by overlapping WebSocket connection attempts and stale socket lifecycle events. The channel now coalesces in-flight ticket/socket creation and ignores events from sockets that are no longer current; focused regression coverage covers concurrent connects and stale reconnect events.

## Test plan

git diff --check; TypeScript typecheck against the current main checkout passed. The focused Vitest/lint commands were attempted but the managed worktree lacks installed workspace dependencies (missing @cradle/plugin-sdk and eslint-config-hyoban), so they could not start.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is declined or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** See Problem / pressure. Detailed directive transcript not attached (author-side sharing consent pending).
- **Constraints / non-goals:** N/A
- **Decision rationale:** N/A
- **Deliberately not done:** N/A
- **Unknowns / confidence:** N/A

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)