### PR TITLE
fix(github-ci): keep CI awaits resumable without branch protection access

### DIFF
--- a/apps/server/src/modules/session-await/sources/github-ci.ts
+++ b/apps/server/src/modules/session-await/sources/github-ci.ts
@@ -654,17 +654,31 @@ export const githubCISource: SessionAwaitSource = {
         }
 
         const workspacePatterns = getMatchingBypassPatterns(row.workspaceId, `${target.owner}/${target.repo}`)
+        const hasBypassRules = perAwaitBypassed.length > 0 || workspacePatterns.length > 0
         let requiredContexts: string[]
-        try {
-          requiredContexts = target.baseBranch
-            ? (await fetchBranchProtection(target.owner, target.repo, target.baseBranch))
-                ?.required_status_checks
-?.contexts ?? []
-            : []
+        if (!hasBypassRules || !target.baseBranch) {
+          requiredContexts = []
         }
-        catch {
-          results.push({ awaitId: row.id, matched: false, transientError: 'GitHub branch protection API unavailable' })
-          continue
+        else {
+          try {
+            requiredContexts = (await fetchBranchProtection(target.owner, target.repo, target.baseBranch))
+              ?.required_status_checks
+?.contexts ?? []
+          }
+          catch (err) {
+            if (!(err instanceof GitHubApiError && err.status === 403)) {
+              results.push({ awaitId: row.id, matched: false, transientError: 'GitHub branch protection API unavailable' })
+              continue
+            }
+
+            // Branch protection is only needed to decide whether a bypass rule
+            // may remove a signal. If the connected GitHub App cannot read it,
+            // fail closed and keep every visible signal in the aggregate.
+            requiredContexts = [
+              ...aggregate.checkRuns.map(run => run.name),
+              ...aggregate.statuses.map(status => status.context),
+            ]
+          }
         }
         aggregate = filterBypassedCI(aggregate, perAwaitBypassed, workspacePatterns, new Set(requiredContexts))
 

--- a/apps/server/tests/session-await-github.test.ts
+++ b/apps/server/tests/session-await-github.test.ts
@@ -636,7 +636,7 @@ describe('gitHub session-await sources', () => {
     })
   })
 
-  it('keeps the await pending when branch-protection lookup is temporarily unavailable', async () => {
+  it('completes the await when branch-protection lookup is unavailable without bypass rules', async () => {
     installGitHubFetch({
       '/repos/acme/app/pulls/42': {
         number: 42,
@@ -675,8 +675,9 @@ describe('gitHub session-await sources', () => {
 
     expect(result).toEqual({
       awaitId: 'await-1',
-      matched: false,
-      transientError: 'GitHub branch protection API unavailable',
+      matched: true,
+      resumeText: 'GitHub checks passed. All 1 checks/statuses succeeded.',
+      resumePayloadJson: expect.stringContaining('"allSuccess":true'),
     })
   })
 


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Fix GitHub CI Session Await handling for GitHub Apps that cannot read branch protection. Normal awaits no longer request optional branch-protection metadata, and bypass-enabled awaits fail closed by retaining all visible CI signals when GitHub returns 403. This lets completed PR checks resume the waiting session instead of remaining pending indefinitely.

## Summary

Fix GitHub CI Session Await handling for GitHub Apps that cannot read branch protection. Normal awaits no longer request optional branch-protection metadata, and bypass-enabled awaits fail closed by retaining all visible CI signals when GitHub returns 403. This lets completed PR checks resume the waiting session instead of remaining pending indefinitely.

## Test plan

git diff --check; targeted `pnpm --filter @cradle/server exec vitest run tests/session-await-github.test.ts` blocked because local node_modules is incomplete (`unplugin-swc`, `vite-tsconfig-paths`); server typecheck blocked by missing workspace dependencies; lint hook blocked by missing `eslint-config-hyoban`.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is declined or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** See Problem / pressure. Detailed directive transcript not attached (author-side sharing consent pending).
- **Constraints / non-goals:** N/A
- **Decision rationale:** N/A
- **Deliberately not done:** N/A
- **Unknowns / confidence:** N/A

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)