### PR TITLE
fix(auth): allow ticket-authenticated WebSocket upgrades

### DIFF
--- a/apps/server/src/http/auth.test.ts
+++ b/apps/server/src/http/auth.test.ts
@@ -109,6 +109,31 @@ describe('hTTP auth plugin', () => {
     })).toBe(false)
   })
 
+  it('lets the global auth hook pre-validate, but not consume, WebSocket tickets', async () => {
+    resetWebSocketTicketsForTests()
+    const { ticket } = issueWebSocketTicket('/protected')
+    const app = createTestApp({ authRequired: true, authToken: 'secret-token' })
+
+    const response = await app.handle(new Request(`http://localhost/protected?ticket=${ticket}`, {
+      headers: { upgrade: 'websocket' },
+    }))
+
+    expect(response.status).toBe(200)
+    expect(verifyWebSocketRequestToken(new Request(`http://localhost/protected?ticket=${ticket}`), {
+      config: { authRequired: true, authToken: 'secret-token' },
+    })).toBe(true)
+  })
+
+  it('does not bypass HTTP auth for a ticket without a WebSocket upgrade', async () => {
+    resetWebSocketTicketsForTests()
+    const { ticket } = issueWebSocketTicket('/protected')
+    const app = createTestApp({ authRequired: true, authToken: 'secret-token' })
+
+    const response = await app.handle(new Request(`http://localhost/protected?ticket=${ticket}`))
+
+    expect(response.status).toBe(401)
+  })
+
   it('rejects a WebSocket ticket issued for a different audience', () => {
     resetWebSocketTicketsForTests()
     const { ticket } = issueWebSocketTicket('/sync')

--- a/apps/server/src/http/auth.ts
+++ b/apps/server/src/http/auth.ts
@@ -6,7 +6,7 @@ import { loadServerAuthConfig } from '../config/server-config'
 import { AppError } from '../errors/app-error'
 import { issueBrowserAuthSession, verifyBrowserAuthSession } from './browser-auth-session'
 import { OPENAPI_DOCS_PATH, OPENAPI_JSON_ALIAS_PATH, OPENAPI_JSON_PATH } from './openapi'
-import { consumeWebSocketTicket, issueWebSocketTicket } from './websocket-ticket'
+import { consumeWebSocketTicket, hasWebSocketTicket, issueWebSocketTicket } from './websocket-ticket'
 
 export const CRADLE_TOKEN_HEADER = 'x-cradle-token'
 export const CRADLE_RELAY_TOKEN_HEADER = 'x-cradle-relay-token'
@@ -20,6 +20,12 @@ interface AuthConfig {
 interface VerifyRequestTokenOptions {
   token?: string | null
   config?: AuthConfig
+}
+
+interface VerifyWebSocketRequestTokenOptions {
+  config?: AuthConfig
+  audience?: string
+  consume?: boolean
 }
 
 function readAuthConfig(): AuthConfig {
@@ -99,7 +105,7 @@ export function verifyRequestToken(
 
 export function verifyWebSocketRequestToken(
   request: Request,
-  options: Pick<VerifyRequestTokenOptions, 'config'> & { audience?: string } = {},
+  options: VerifyWebSocketRequestTokenOptions = {},
 ): boolean {
   const url = new URL(request.url)
   const config = options.config ?? readAuthConfig()
@@ -107,7 +113,13 @@ export function verifyWebSocketRequestToken(
     return true
   }
   const ticket = url.searchParams.get('ticket')
-  return Boolean(ticket && consumeWebSocketTicket(ticket, options.audience ?? url.pathname))
+  if (!ticket) {
+    return false
+  }
+  const audience = options.audience ?? url.pathname
+  return options.consume === false
+    ? hasWebSocketTicket(ticket, audience)
+    : consumeWebSocketTicket(ticket, audience)
 }
 
 export function createAuthPlugin(config: AuthConfig = readAuthConfig()) {
@@ -125,6 +137,17 @@ export function createAuthPlugin(config: AuthConfig = readAuthConfig()) {
         && eventTicket
         && consumeWebSocketTicket(eventTicket, `sse:${pathname}`)
       ) {
+        return undefined
+      }
+
+      if (
+        request.method === 'GET'
+        && request.headers.get('upgrade')?.toLowerCase() === 'websocket'
+        && verifyWebSocketRequestToken(request, { config, audience: pathname, consume: false })
+      ) {
+        // Native browser WebSocket upgrades cannot send Authorization headers.
+        // Leave ticket consumption to the matched WebSocket route so this global
+        // hook does not consume the single-use ticket before route validation.
         return undefined
       }
 

--- a/apps/server/src/http/websocket-ticket.ts
+++ b/apps/server/src/http/websocket-ticket.ts
@@ -42,8 +42,13 @@ export function issueWebSocketTicket(audience: string, now = Date.now()): {
 
 export function consumeWebSocketTicket(ticket: string, audience: string, now = Date.now()): boolean {
   const digest = digestTicket(ticket)
-  const record = tickets.get(digest)
+  const valid = hasWebSocketTicket(ticket, audience, now)
   tickets.delete(digest)
+  return valid
+}
+
+export function hasWebSocketTicket(ticket: string, audience: string, now = Date.now()): boolean {
+  const record = tickets.get(digestTicket(ticket))
   return Boolean(record && record.expiresAt > now && record.audience === audience)
 }
 


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Fixes 401 failures on native PTY and sync WebSocket upgrades when server auth is enabled. The global auth hook now pre-validates an audience-bound ticket without consuming it, leaving single-use consumption to the matched WebSocket route; ordinary HTTP requests remain protected. Adds regression coverage for upgrade-only handling.

## Summary

Fixes 401 failures on native PTY and sync WebSocket upgrades when server auth is enabled. The global auth hook now pre-validates an audience-bound ticket without consuming it, leaving single-use consumption to the matched WebSocket route; ordinary HTTP requests remain protected. Adds regression coverage for upgrade-only handling.

## Test plan

Passed server auth tests (13); PTY WebSocket integration tests (4) with ambient auth variables unset; web PTY channel tests (5); scoped ESLint; server TypeScript check; git diff --check.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is declined or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** See Problem / pressure. Detailed directive transcript not attached (author-side sharing consent pending).
- **Constraints / non-goals:** N/A
- **Decision rationale:** N/A
- **Deliberately not done:** N/A
- **Unknowns / confidence:** N/A

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)