### PR TITLE
fix(codex): summarize app-server error messages

### DIFF
--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/client.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/client.test.ts
@@ -13,6 +13,7 @@ import {
   readCradleCodexClientVersion,
   resolveCodexAppServerHome,
   resolveCodexAppServerLaunch,
+  summarizeCodexAppServerStderr,
 } from './client'
 
 const spawnMock = vi.hoisted(() => vi.fn())
@@ -199,6 +200,23 @@ describe('isCodexAppServerUnknownMethodError', () => {
 })
 
 describe('codexAppServerClient', () => {
+  it('summarizes repeated process diagnostics into actionable core errors', () => {
+    const stderr = [
+      '\u001B[2m2026-08-06T02:01:00.179537Z\u001B[0m \u001B[31mERROR\u001B[0m \u001B[2mrmcp::transport::worker\u001B[0m: worker quit with fatal: Transport channel closed, when UnexpectedServerResponse("HTTP 502: ")',
+      '\u001B[2m2026-08-06T02:01:04.796556Z\u001B[0m \u001B[31mERROR\u001B[0m \u001B[2mrmcp::transport::worker\u001B[0m: worker quit with fatal: Transport channel closed, when UnexpectedServerResponse("HTTP 502: ")',
+      '\u001B[2m2026-08-06T02:01:05.190902Z\u001B[0m \u001B[31mERROR\u001B[0m \u001B[2mcodex_api::endpoint::responses_websocket\u001B[0m: failed to connect to websocket: IO error: tls handshake eof, url: wss://chatgpt.com/backend-api/codex/responses',
+      '\u001B[2m2026-08-06T02:08:30.440279Z\u001B[0m \u001B[31mERROR\u001B[0m \u001B[2mcodex_core::tools::router\u001B[0m: apply_patch verification failed: unrelated tool output',
+    ].join('\n')
+
+    expect(summarizeCodexAppServerStderr(stderr)).toBe(
+      'worker quit with fatal: Transport channel closed, when UnexpectedServerResponse("HTTP 502: "); failed to connect to websocket: IO error: tls handshake eof',
+    )
+  })
+
+  it('returns no process diagnostic suffix when stderr has no useful error lines', () => {
+    expect(summarizeCodexAppServerStderr('notice: shutting down\n')).toBeNull()
+  })
+
   it('passes Cradle context environment into the app-server process', () => {
     managedProcessMock.mockReturnValueOnce(asManagedProcess({
       stdin: new Writable({ write: (_chunk, _encoding, callback) => callback() }),

--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/client.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/client.ts
@@ -52,6 +52,8 @@ export interface CodexAppServerClientOptions {
 
 const CODEX_NATIVE_CLIENT_INFO_FALLBACK_VERSION = '0.0.0'
 const CODEX_APP_SERVER_PATH_ENV = 'CRADLE_CODEX_APP_SERVER_PATH'
+const MAX_EXIT_ERROR_DIAGNOSTICS = 3
+const MAX_STDERR_BUFFER_LENGTH = 64_000
 const codexNativeClientVersionByPath = new Map<string, Promise<string>>()
 
 export function buildCradleCodexAppServerEnv(input: {
@@ -147,7 +149,7 @@ export class CodexAppServerClient {
     }
     this.childStdin = childStdin
     childStderr.on('data', (chunk: Buffer) => {
-      this.stderrText += chunk.toString('utf8')
+      this.stderrText = `${this.stderrText}${chunk.toString('utf8')}`.slice(-MAX_STDERR_BUFFER_LENGTH)
     })
     childStdin.on('error', error => this.terminate(error))
     this.child.once('error', error => this.terminate(error))
@@ -252,7 +254,8 @@ export class CodexAppServerClient {
       return new Error('Codex app-server exited')
     }
     const detail = signal ? `signal ${signal}` : `code ${code ?? 1}`
-    return new Error(`Codex app-server exited with ${detail}: ${this.stderrText}`)
+    const stderrSummary = summarizeCodexAppServerStderr(this.stderrText)
+    return new Error(`Codex app-server exited with ${detail}${stderrSummary ? `: ${stderrSummary}` : ''}`)
   }
 
   private terminate(error: Error): void {
@@ -415,6 +418,40 @@ export class CodexAppServerClient {
       }
     })
   }
+}
+
+/**
+ * Keep process failures actionable without copying the app-server's entire
+ * stderr buffer into the user-facing Error.message. The buffer often contains
+ * the same retry/transport failure hundreds of times, plus unrelated agent
+ * tool output from earlier in the process lifetime.
+ */
+export function summarizeCodexAppServerStderr(stderr: string): string | null {
+  const lines = stripAnsi(stderr)
+    .split(/\r?\n/)
+    .map(normalizeCodexAppServerStderrLine)
+    .filter((line): line is string => line !== null)
+
+  const candidates = lines.filter(line => /fatal|panic|error|failed|transport|websocket|handshake|http\s+\d{3}|server|startup/i.test(line))
+  const infrastructureCandidates = candidates.filter(line => /fatal|panic|transport|websocket|handshake|http\s+\d{3}|server|startup/i.test(line))
+  const selected = (infrastructureCandidates.length > 0 ? infrastructureCandidates : candidates)
+    .filter((line, index, all) => all.findIndex(candidate => candidate.toLowerCase() === line.toLowerCase()) === index)
+    .slice(0, MAX_EXIT_ERROR_DIAGNOSTICS)
+
+  return selected.length > 0 ? selected.join('; ') : null
+}
+
+function normalizeCodexAppServerStderrLine(line: string): string | null {
+  const normalized = line
+    .replace(/^\d{4}-\d{2}-\d{2}T\S+\s+(?:ERROR|WARN|WARNING|INFO|DEBUG|TRACE)\s+\S+:\s*/i, '')
+    .replace(/,?\s*url:\s*\S+/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return normalized.length > 0 ? normalized : null
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001B\[[0-9;]*m/g, '')
 }
 
 export function readCradleCodexClientVersion(env: Record<string, string | undefined> = process.env): string {

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-diagnostics.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-diagnostics.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { createCodexAppServerError, createCodexStreamDiagnostics } from './stream-diagnostics'
+
+describe('codex stream error presentation', () => {
+  it('keeps the protocol error core without exposing the envelope or raw event tree', () => {
+    const error = createCodexAppServerError(
+      {
+        method: 'error',
+        params: {
+          threadId: 'thread-secret',
+          turnId: 'turn-secret',
+          willRetry: false,
+          error: {
+            message: 'Upstream model request failed',
+            additionalDetails: 'The upstream connection was reset.',
+            codexErrorInfo: {
+              responseStreamDisconnected: { httpStatusCode: 502 },
+            },
+          },
+        },
+      },
+      {
+        ...createCodexStreamDiagnostics(),
+        totalEvents: 1,
+        eventTypeCounts: { error: 1 },
+        errorEvents: [{ method: 'error', params: { threadId: 'thread-secret' } }],
+      },
+    )
+
+    expect(error.message).toBe('Upstream model request failed')
+    expect(error.data.details).toBe(
+      'The upstream connection was reset.; error type: Response Stream Disconnected (HTTP 502); events: 1 total, 0 mapped; event types: error:1',
+    )
+    expect(error.data.details).not.toContain('thread-secret')
+    expect(error.data.details).not.toContain('willRetry')
+    expect(error.data.notification).toEqual({
+      method: 'error',
+      params: {
+        threadId: 'thread-secret',
+        turnId: 'turn-secret',
+        willRetry: false,
+        error: {
+          message: 'Upstream model request failed',
+          additionalDetails: 'The upstream connection was reset.',
+          codexErrorInfo: {
+            responseStreamDisconnected: { httpStatusCode: 502 },
+          },
+        },
+      },
+    })
+  })
+})

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-diagnostics.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-diagnostics.ts
@@ -337,6 +337,10 @@ function summarizeCodexFailureDetails(
     if (additionalDetails) {
       parts.push(additionalDetails)
     }
+    const errorInfo = formatCodexErrorInfo(errorParams?.error?.codexErrorInfo)
+    if (errorInfo) {
+      parts.push(`error type: ${errorInfo}`)
+    }
     const statusText = readCodexStatusText(errorParams)
     if (statusText) {
       parts.push(statusText)
@@ -357,6 +361,42 @@ function summarizeCodexFailureDetails(
   parts.push(`events: ${diagnostics.totalEvents} total, ${diagnostics.mappedEvents} mapped`)
   parts.push(`event types: ${formatCounts(diagnostics.eventTypeCounts)}`)
   return parts.length > 0 ? parts.join('; ') : null
+}
+
+/**
+ * ErrorNotification has a deliberately small user-relevant core:
+ * error.message, error.additionalDetails, and error.codexErrorInfo. Keep
+ * protocol envelope fields (threadId, turnId, willRetry) and raw diagnostics
+ * out of the visible failure text.
+ */
+function formatCodexErrorInfo(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  const [entry] = Object.entries(value as Record<string, unknown>)
+  if (!entry) {
+    return null
+  }
+  const [kind, details] = entry
+  const label = kind
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/^./, character => character.toUpperCase())
+  if (!details || typeof details !== 'object' || Array.isArray(details)) {
+    return label
+  }
+  const record = details as Record<string, unknown>
+  const httpStatusCode = typeof record.httpStatusCode === 'number' ? record.httpStatusCode : null
+  const turnKind = typeof record.turnKind === 'string' ? record.turnKind : null
+  if (httpStatusCode !== null) {
+    return `${label} (HTTP ${httpStatusCode})`
+  }
+  if (turnKind) {
+    return `${label} (${turnKind})`
+  }
+  return label
 }
 
 function readCodexStatusText(params: ErrorNotificationParams | undefined): string | null {


### PR DESCRIPTION
## Summary

- summarize Codex app-server process stderr into a small set of deduplicated, actionable diagnostics
- retain the protocol error core, including `message`, `additionalDetails`, and a readable `codexErrorInfo`
- keep protocol envelope fields and the raw event tree out of user-facing error text
- cap the retained stderr buffer and add regression coverage

## Root cause

The process-exit path copied the complete stderr buffer into `Error.message`. Repeated HTTP 502/TLS transport retries and unrelated tool output therefore produced an extremely long error in the UI.

## Validation

- targeted Codex client/stream tests: 39 passed
- targeted ESLint and TypeScript checks passed
- online diff verified: only the four intended Codex error-summary files are included