### PR TITLE
fix(mobile): stop background energy drain

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.native.tsx
+++ b/apps/mobile/app/(tabs)/_layout.native.tsx
@@ -1,5 +1,5 @@
 import { Stack } from 'expo-router'
 
 export default function NativeTabsLayout() {
-  return <Stack screenOptions={{ headerShown: false }} />
+  return <Stack screenOptions={{ freezeOnBlur: true, headerShown: false }} />
 }

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack } from 'expo-router'
 
 export default function TabsLayout() {
-  return <Stack screenOptions={{ headerShown: false }} />
+  return <Stack screenOptions={{ freezeOnBlur: true, headerShown: false }} />
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,6 +1,4 @@
-import {
-  GeistMono_400Regular,
-} from '@expo-google-fonts/geist-mono/400Regular'
+import { GeistMono_400Regular } from '@expo-google-fonts/geist-mono/400Regular'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useFonts } from 'expo-font'
 import { Stack } from 'expo-router'
@@ -10,19 +8,23 @@ import { useColorScheme } from 'react-native'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 
 import { ConnectionProvider } from '@/features/connection/connection-store'
+import { AppLifecycleProvider } from '@/lib/app-lifecycle-provider'
 import { useTheme } from '@/theme/use-theme'
 
 export default function RootLayout() {
   const scheme = useColorScheme()
   const theme = useTheme()
-  const [queryClient] = useState(() => new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: 1,
-        staleTime: 10_000,
-      },
-    },
-  }))
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: 1,
+            staleTime: 10_000,
+          },
+        },
+      }),
+  )
   const [fontsLoaded] = useFonts({
     GeistMono_400Regular,
   })
@@ -34,31 +36,37 @@ export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <QueryClientProvider client={queryClient}>
-        <ConnectionProvider>
-          <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
-          <Stack
-            screenOptions={{
-              contentStyle: { backgroundColor: theme.surface },
-              headerBackButtonDisplayMode: 'minimal',
-              headerShadowVisible: false,
-              headerStyle: { backgroundColor: theme.surface },
-              headerTintColor: theme.foreground,
-            }}
-          >
-            <Stack.Screen name="index" options={{ headerShown: false }} />
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            <Stack.Screen name="connection/server" options={{ title: 'Server' }} />
-            <Stack.Screen name="connection/token" options={{ title: 'Authentication' }} />
-            <Stack.Screen name="workspace/[workspaceId]" options={{ title: 'Project' }} />
-            <Stack.Screen name="work/[workId]" options={{ presentation: 'modal', title: 'Work info' }} />
-            <Stack.Screen name="session/[sessionId]" options={{ title: 'Conversation' }} />
-            <Stack.Screen name="usage" options={{ title: 'Usage' }} />
-            <Stack.Screen
-              name="pull-request/[owner]/[repo]/[number]"
-              options={{ title: 'Pull request' }}
-            />
-          </Stack>
-        </ConnectionProvider>
+        <AppLifecycleProvider queryClient={queryClient}>
+          <ConnectionProvider>
+            <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
+            <Stack
+              screenOptions={{
+                contentStyle: { backgroundColor: theme.surface },
+                freezeOnBlur: true,
+                headerBackButtonDisplayMode: 'minimal',
+                headerShadowVisible: false,
+                headerStyle: { backgroundColor: theme.surface },
+                headerTintColor: theme.foreground,
+              }}
+            >
+              <Stack.Screen name="index" options={{ headerShown: false }} />
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen name="connection/server" options={{ title: 'Server' }} />
+              <Stack.Screen name="connection/token" options={{ title: 'Authentication' }} />
+              <Stack.Screen name="workspace/[workspaceId]" options={{ title: 'Project' }} />
+              <Stack.Screen
+                name="work/[workId]"
+                options={{ presentation: 'modal', title: 'Work info' }}
+              />
+              <Stack.Screen name="session/[sessionId]" options={{ title: 'Conversation' }} />
+              <Stack.Screen name="usage" options={{ title: 'Usage' }} />
+              <Stack.Screen
+                name="pull-request/[owner]/[repo]/[number]"
+                options={{ title: 'Pull request' }}
+              />
+            </Stack>
+          </ConnectionProvider>
+        </AppLifecycleProvider>
       </QueryClientProvider>
     </SafeAreaProvider>
   )

--- a/apps/mobile/src/features/chat/ChatComposer.tsx
+++ b/apps/mobile/src/features/chat/ChatComposer.tsx
@@ -3,7 +3,7 @@ import { MenuView } from '@expo/ui/community/menu'
 import type { FileUIPart } from 'ai'
 import * as ImagePicker from 'expo-image-picker'
 import { Plus, Send, X } from 'lucide-react-native'
-import { useMemo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import {
   ActivityIndicator,
   Image,
@@ -42,7 +42,7 @@ export interface ChatComposerProps {
   runtimeSettings?: RuntimeSettings
 }
 
-export function ChatComposer({
+function ChatComposerContent({
   capabilities,
   isSending,
   isStreaming,
@@ -55,31 +55,52 @@ export function ChatComposer({
   const [files, setFiles] = useState<FileUIPart[]>([])
   const [continuationMode, setContinuationMode] = useState<'queue' | 'steer'>('queue')
   const [isPicking, setIsPicking] = useState(false)
-  const interactionMode = runtimeSettings?.runtimeSettings.interactionMode === 'plan' ? 'plan' : 'build'
+  const interactionMode
+    = runtimeSettings?.runtimeSettings.interactionMode === 'plan' ? 'plan' : 'build'
   const composerMenuActions: MenuAction[] = [
     { id: 'photo', image: 'photo.on.rectangle', title: 'Add photo' },
-    { id: 'build', image: 'hammer', state: interactionMode === 'build' ? 'on' : 'off', title: 'Build' },
-    { id: 'plan', image: 'list.bullet.rectangle', state: interactionMode === 'plan' ? 'on' : 'off', title: 'Plan' },
+    {
+      id: 'build',
+      image: 'hammer',
+      state: interactionMode === 'build' ? 'on' : 'off',
+      title: 'Build',
+    },
+    {
+      id: 'plan',
+      image: 'list.bullet.rectangle',
+      state: interactionMode === 'plan' ? 'on' : 'off',
+      title: 'Plan',
+    },
   ]
   const slashQuery = text.match(/(?:^|\s)\/([\w-]*)$/)?.[1] ?? null
   const mentionQuery = text.match(/(?:^|\s)@([\w-]*)$/)?.[1] ?? null
   const slashCommands = useMemo(
-    () => (capabilities?.slashCommands ?? [])
-      .filter(command => slashQuery !== null && command.name.toLowerCase().startsWith(slashQuery.toLowerCase()))
-      .slice(0, 5),
+    () =>
+      (capabilities?.slashCommands ?? [])
+        .filter(
+          command =>
+            slashQuery !== null && command.name.toLowerCase().startsWith(slashQuery.toLowerCase()),
+        )
+        .slice(0, 5),
     [capabilities?.slashCommands, slashQuery],
   )
   const skills = useMemo(
-    () => (capabilities?.skills ?? [])
-      .filter(skill => mentionQuery !== null && skill.toLowerCase().startsWith(mentionQuery.toLowerCase()))
-      .slice(0, 5),
+    () =>
+      (capabilities?.skills ?? [])
+        .filter(
+          skill =>
+            mentionQuery !== null && skill.toLowerCase().startsWith(mentionQuery.toLowerCase()),
+        )
+        .slice(0, 5),
     [capabilities?.skills, mentionQuery],
   )
   const suggestionsVisible = slashCommands.length > 0 || skills.length > 0
 
   const submit = () => {
     const nextText = text.trim()
-    if ((!nextText && files.length === 0) || isSending) { return }
+    if ((!nextText && files.length === 0) || isSending) {
+      return
+    }
     onSend({ continuationMode, files, text: nextText })
     setText('')
     setFiles([])
@@ -87,7 +108,9 @@ export function ChatComposer({
   }
 
   const pickPhoto = async () => {
-    if (isPicking) { return }
+    if (isPicking) {
+      return
+    }
     setIsPicking(true)
     try {
       const result = await ImagePicker.launchImageLibraryAsync({
@@ -96,16 +119,22 @@ export function ChatComposer({
         mediaTypes: ['images'],
         quality: 0.9,
       })
-      if (result.canceled) { return }
+      if (result.canceled) {
+        return
+      }
       const nextFiles = result.assets.flatMap((asset) => {
-        if (!asset.base64) { return [] }
+        if (!asset.base64) {
+          return []
+        }
         const mediaType = asset.mimeType ?? 'image/jpeg'
-        return [{
-          filename: asset.fileName ?? `photo-${Date.now()}.jpg`,
-          mediaType,
-          type: 'file' as const,
-          url: `data:${mediaType};base64,${asset.base64}`,
-        }]
+        return [
+          {
+            filename: asset.fileName ?? `photo-${Date.now()}.jpg`,
+            mediaType,
+            type: 'file' as const,
+            url: `data:${mediaType};base64,${asset.base64}`,
+          },
+        ]
       })
       setFiles(current => [...current, ...nextFiles])
     }
@@ -120,32 +149,40 @@ export function ChatComposer({
   }
 
   return (
-    <View
-      style={[styles.frame, { backgroundColor: theme.chrome }]}
-    >
+    <View style={[styles.frame, { backgroundColor: theme.chrome }]}>
       {isStreaming && (
-          <View style={[styles.continuation, { backgroundColor: theme.muted }]}>
-            {(['queue', 'steer'] as const).map(mode => (
-              <PressableScale
-                accessibilityLabel={`${mode} next message`}
-                accessibilityRole="button"
-                key={mode}
-                onPress={() => setContinuationMode(mode)}
+        <View style={[styles.continuation, { backgroundColor: theme.muted }]}>
+          {(['queue', 'steer'] as const).map(mode => (
+            <PressableScale
+              accessibilityLabel={`${mode} next message`}
+              accessibilityRole="button"
+              key={mode}
+              onPress={() => setContinuationMode(mode)}
+              style={[
+                styles.continuationOption,
+                continuationMode === mode && { backgroundColor: theme.surface },
+              ]}
+            >
+              <Text
                 style={[
-                  styles.continuationOption,
-                  continuationMode === mode && { backgroundColor: theme.surface },
+                  styles.continuationText,
+                  { color: continuationMode === mode ? theme.foreground : theme.mutedForeground },
                 ]}
               >
-                <Text style={[styles.continuationText, { color: continuationMode === mode ? theme.foreground : theme.mutedForeground }]}>
-                  {mode === 'queue' ? 'Queue' : 'Steer'}
-                </Text>
-              </PressableScale>
-            ))}
-          </View>
+                {mode === 'queue' ? 'Queue' : 'Steer'}
+              </Text>
+            </PressableScale>
+          ))}
+        </View>
       )}
 
       {suggestionsVisible && (
-        <View style={[styles.suggestions, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+        <View
+          style={[
+            styles.suggestions,
+            { backgroundColor: theme.surface, borderColor: theme.border },
+          ]}
+        >
           {slashCommands.map(command => (
             <PressableScale
               accessibilityLabel={`Insert ${command.name}`}
@@ -154,8 +191,13 @@ export function ChatComposer({
               onPress={() => insertSuggestion(command.name, 'slash')}
               style={styles.suggestion}
             >
-              <Text style={[styles.suggestionTitle, { color: theme.foreground }]}>{`/${command.name}`}</Text>
-              <Text numberOfLines={1} style={[styles.suggestionDescription, { color: theme.mutedForeground }]}>
+              <Text style={[styles.suggestionTitle, { color: theme.foreground }]}>
+                {`/${command.name}`}
+              </Text>
+              <Text
+                numberOfLines={1}
+                style={[styles.suggestionDescription, { color: theme.mutedForeground }]}
+              >
                 {command.description}
               </Text>
             </PressableScale>
@@ -168,22 +210,31 @@ export function ChatComposer({
               onPress={() => insertSuggestion(skill, 'mention')}
               style={styles.suggestion}
             >
-              <Text style={[styles.suggestionTitle, { color: theme.foreground }]}>{`@${skill}`}</Text>
-              <Text style={[styles.suggestionDescription, { color: theme.mutedForeground }]}>Skill</Text>
+              <Text style={[styles.suggestionTitle, { color: theme.foreground }]}>
+                {`@${skill}`}
+              </Text>
+              <Text style={[styles.suggestionDescription, { color: theme.mutedForeground }]}>
+                Skill
+              </Text>
             </PressableScale>
           ))}
         </View>
       )}
 
       {files.length > 0 && (
-        <ScrollView contentContainerStyle={styles.attachments} horizontal showsHorizontalScrollIndicator={false}>
+        <ScrollView
+          contentContainerStyle={styles.attachments}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+        >
           {files.map(file => (
             <View key={file.url} style={[styles.attachment, { backgroundColor: theme.surface }]}>
               <Image source={{ uri: file.url }} style={styles.attachmentImage} />
               <PressableScale
                 accessibilityLabel={`Remove ${file.filename ?? 'photo'}`}
                 accessibilityRole="button"
-                onPress={() => setFiles(current => current.filter(item => item.url !== file.url))}
+                onPress={() =>
+                  setFiles(current => current.filter(item => item.url !== file.url))}
                 style={[styles.removeAttachment, { backgroundColor: theme.overlay }]}
               >
                 <X color="#fff" size={12} />
@@ -226,8 +277,18 @@ export function ChatComposer({
           style={styles.addMenu}
           title="Composer options"
         >
-          <View accessibilityLabel="Composer options" accessibilityRole="button" style={styles.addButton}>
-            {isPicking ? <ActivityIndicator color={theme.mutedForeground} size="small" /> : <Plus color={theme.tertiaryForeground} size={20} />}
+          <View
+            accessibilityLabel="Composer options"
+            accessibilityRole="button"
+            style={styles.addButton}
+          >
+            {isPicking
+            ? (
+              <ActivityIndicator color={theme.mutedForeground} size="small" />
+            )
+            : (
+              <Plus color={theme.tertiaryForeground} size={20} />
+            )}
           </View>
         </MenuView>
         <TextInput
@@ -237,7 +298,13 @@ export function ChatComposer({
           multiline
           onChangeText={setText}
           onSubmitEditing={submit}
-          placeholder={isStreaming ? (continuationMode === 'steer' ? 'Steer the response…' : 'Add to queue…') : 'Message…'}
+          placeholder={
+            isStreaming
+              ? continuationMode === 'steer'
+                ? 'Steer the response…'
+                : 'Add to queue…'
+              : 'Message…'
+          }
           placeholderTextColor={theme.mutedForeground}
           selectionColor={theme.info}
           style={[styles.input, { color: theme.foreground }]}
@@ -249,16 +316,31 @@ export function ChatComposer({
           disabled={(!text.trim() && files.length === 0) || isSending}
           haptic
           onPress={submit}
-          style={[styles.sendButton, { backgroundColor: text.trim() || files.length > 0 ? theme.primary : theme.muted }]}
+          style={[
+            styles.sendButton,
+            { backgroundColor: text.trim() || files.length > 0 ? theme.primary : theme.muted },
+          ]}
         >
           {isSending
-            ? <ActivityIndicator color={theme.primaryForeground} size="small" />
-            : <Send color={text.trim() || files.length > 0 ? theme.primaryForeground : theme.mutedForeground} size={16} strokeWidth={2.4} />}
+          ? (
+            <ActivityIndicator color={theme.primaryForeground} size="small" />
+          )
+          : (
+            <Send
+              color={
+                text.trim() || files.length > 0 ? theme.primaryForeground : theme.mutedForeground
+              }
+              size={16}
+              strokeWidth={2.4}
+            />
+          )}
         </PressableScale>
       </View>
     </View>
   )
 }
+
+export const ChatComposer = memo(ChatComposerContent)
 
 const styles = StyleSheet.create({
   addButton: {

--- a/apps/mobile/src/features/chat/ChatContainer.tsx
+++ b/apps/mobile/src/features/chat/ChatContainer.tsx
@@ -2,7 +2,7 @@ import type { InfiniteData } from '@tanstack/react-query'
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query'
 import type { UIMessage } from 'ai'
 import { Stack } from 'expo-router'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type {
   GetChatSessionsBySessionIdCapabilitiesResponse,
@@ -15,85 +15,100 @@ import type {
 import { ErrorState, LoadingState } from '@/components/ui/states'
 import { useConnection } from '@/features/connection/connection-context'
 import { cradleRequest, cradleStreamResponse } from '@/lib/api'
+import { useRouteIsActive } from '@/lib/app-lifecycle-context'
 import { errorMessage } from '@/lib/errors'
 
-import {
-  readChatHistoryCache,
-  writeChatHistoryCache,
-} from './chat-history-cache'
+import { readChatHistoryCache, writeChatHistoryCache } from './chat-history-cache'
 import { consumeChatMessageStream } from './chat-stream'
 import type { ChatSubmitInput } from './ChatComposer'
 import { ChatView } from './ChatView'
 
 export function ChatContainer({ sessionId }: { sessionId: string }) {
   const { connection } = useConnection()
+  const isRouteActive = useRouteIsActive()
   const activeStreamRef = useRef<AbortController | null>(null)
+  const routeActiveRef = useRef(isRouteActive)
   const streamingMessageIdRef = useRef<string | null>(null)
   const [isLiveStreaming, setIsLiveStreaming] = useState(false)
   const [liveMessage, setLiveMessage] = useState<UIMessage | null>(null)
   const [pendingUser, setPendingUser] = useState<{ id: string | null, text: string } | null>(null)
   const [sendError, setSendError] = useState<string | null>(null)
   const [detailMessageId, setDetailMessageId] = useState<string | null>(null)
-  const [cachedHistory, setCachedHistory] = useState<InfiniteData<GetChatSessionsBySessionIdMessagePreviewsResponse, string | null> | null>(null)
+  const [cachedHistory, setCachedHistory] = useState<InfiniteData<
+    GetChatSessionsBySessionIdMessagePreviewsResponse,
+    string | null
+  > | null>(null)
+  routeActiveRef.current = isRouteActive
   const historyQueryKey = useMemo(
     () => ['chat-message-previews', connection?.url, sessionId] as const,
     [connection?.url, sessionId],
   )
   const sessionQuery = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['chat-session', connection?.url, sessionId],
-    queryFn: () => cradleRequest<GetSessionsResponse[number]>(
-      connection!,
-      `/sessions/${encodeURIComponent(sessionId)}`,
-    ),
+    queryFn: ({ signal }) =>
+      cradleRequest<GetSessionsResponse[number]>(
+        connection!,
+        `/sessions/${encodeURIComponent(sessionId)}`,
+        { signal },
+      ),
     refetchOnMount: 'always',
   })
   const historyQuery = useInfiniteQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     initialPageParam: null as string | null,
     queryKey: historyQueryKey,
-    queryFn: ({ pageParam }) => {
+    queryFn: ({ pageParam, signal }) => {
       const cursor = pageParam ? `&cursor=${encodeURIComponent(pageParam)}` : ''
       return cradleRequest<GetChatSessionsBySessionIdMessagePreviewsResponse>(
         connection!,
         `/chat/sessions/${encodeURIComponent(sessionId)}/message-previews?limit=50${cursor}`,
+        { signal },
       )
     },
     getNextPageParam: lastPage => lastPage.nextCursor ?? undefined,
     refetchOnMount: 'always',
   })
   const runtimeStatusQuery = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['chat-runtime-status', connection?.url, sessionId],
-    queryFn: () => cradleRequest<GetChatSessionsBySessionIdRuntimeStatusResponse>(
-      connection!,
-      `/chat/sessions/${encodeURIComponent(sessionId)}/runtime-status`,
-    ),
-    refetchInterval: data => data.state.data?.status === 'idle' ? false : 5_000,
+    queryFn: ({ signal }) =>
+      cradleRequest<GetChatSessionsBySessionIdRuntimeStatusResponse>(
+        connection!,
+        `/chat/sessions/${encodeURIComponent(sessionId)}/runtime-status`,
+        { signal },
+      ),
+    refetchInterval: data => (data.state.data?.status === 'idle' ? false : 10_000),
   })
   const capabilitiesQuery = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['chat-capabilities', connection?.url, sessionId],
-    queryFn: () => cradleRequest<GetChatSessionsBySessionIdCapabilitiesResponse>(
-      connection!,
-      `/chat/sessions/${encodeURIComponent(sessionId)}/capabilities`,
-    ),
+    queryFn: ({ signal }) =>
+      cradleRequest<GetChatSessionsBySessionIdCapabilitiesResponse>(
+        connection!,
+        `/chat/sessions/${encodeURIComponent(sessionId)}/capabilities`,
+        { signal },
+      ),
   })
   const runtimeSettingsQuery = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['chat-runtime-settings', connection?.url, sessionId],
-    queryFn: () => cradleRequest<GetChatSessionsBySessionIdRuntimeSettingsResponse>(
-      connection!,
-      `/chat/sessions/${encodeURIComponent(sessionId)}/runtime-settings`,
-    ),
+    queryFn: ({ signal }) =>
+      cradleRequest<GetChatSessionsBySessionIdRuntimeSettingsResponse>(
+        connection!,
+        `/chat/sessions/${encodeURIComponent(sessionId)}/runtime-settings`,
+        { signal },
+      ),
   })
   const detailQuery = useQuery({
-    enabled: Boolean(connection && detailMessageId),
+    enabled: Boolean(connection && detailMessageId) && isRouteActive,
     queryKey: ['chat-message-detail', connection?.url, sessionId, detailMessageId],
-    queryFn: () => cradleRequest<GetChatSessionsBySessionIdMessagesByMessageIdResponse>(
-      connection!,
-      `/chat/sessions/${encodeURIComponent(sessionId)}/messages/${encodeURIComponent(detailMessageId!)}`,
-    ),
+    queryFn: ({ signal }) =>
+      cradleRequest<GetChatSessionsBySessionIdMessagesByMessageIdResponse>(
+        connection!,
+        `/chat/sessions/${encodeURIComponent(sessionId)}/messages/${encodeURIComponent(detailMessageId!)}`,
+        { signal },
+      ),
   })
   const refetchHistory = historyQuery.refetch
   const refetchRuntimeStatus = runtimeStatusQuery.refetch
@@ -115,33 +130,46 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
   }, [connection, sessionId])
 
   useEffect(() => {
-    const queryHistoryData = historyQuery.data as InfiniteData<GetChatSessionsBySessionIdMessagePreviewsResponse, string | null> | undefined
+    const queryHistoryData = historyQuery.data as
+      | InfiniteData<GetChatSessionsBySessionIdMessagePreviewsResponse, string | null>
+      | undefined
     if (connection && queryHistoryData) {
       void writeChatHistoryCache(connection.url, sessionId, queryHistoryData)
     }
   }, [connection, historyQuery.data, sessionId])
 
-  const queryHistoryData = historyQuery.data as InfiniteData<GetChatSessionsBySessionIdMessagePreviewsResponse, string | null> | undefined
+  const queryHistoryData = historyQuery.data as
+    | InfiniteData<GetChatSessionsBySessionIdMessagePreviewsResponse, string | null>
+    | undefined
   const historyData = queryHistoryData ?? cachedHistory
-  const messages = [...(historyData?.pages ?? [])]
-    .reverse()
-    .flatMap(page => page.rows)
+  const messages = useMemo(
+    () => [...(historyData?.pages ?? [])].reverse().flatMap(page => page.rows),
+    [historyData],
+  )
   const sessionStatus = runtimeStatusQuery.data?.status ?? sessionQuery.data?.status
-  const streamingMessageId = messages
-    .findLast(row => row.role === 'assistant' && row.status === 'streaming')
-    ?.messageId ?? null
+  const streamingMessageId
+    = messages.findLast(row => row.role === 'assistant' && row.status === 'streaming')?.messageId
+      ?? null
   streamingMessageIdRef.current = streamingMessageId
 
-  useEffect(() => () => {
-    activeStreamRef.current?.abort()
-  }, [])
+  useEffect(
+    () => () => {
+      activeStreamRef.current?.abort()
+    },
+    [],
+  )
 
   useEffect(() => {
-    if (
-      !connection
-      || sessionStatus !== 'streaming'
-      || activeStreamRef.current
-    ) {
+    if (isRouteActive) {
+      return
+    }
+    activeStreamRef.current?.abort()
+    activeStreamRef.current = null
+    setIsLiveStreaming(false)
+  }, [isRouteActive])
+
+  useEffect(() => {
+    if (!connection || !isRouteActive || sessionStatus !== 'streaming' || activeStreamRef.current) {
       return
     }
 
@@ -155,11 +183,12 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
       `/chat/sessions/${encodeURIComponent(sessionId)}/stream`,
       { signal: controller.signal },
     )
-      .then(response => consumeChatMessageStream({
-        messageId: streamingMessageIdRef.current ?? `assistant-${sessionId}`,
-        onMessage: setLiveMessage,
-        response,
-      }))
+      .then(response =>
+        consumeChatMessageStream({
+          messageId: streamingMessageIdRef.current ?? `assistant-${sessionId}`,
+          onMessage: setLiveMessage,
+          response,
+        }))
       .catch((error: Error) => {
         if (!controller.signal.aborted) {
           setSendError(errorMessage(error))
@@ -185,7 +214,7 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
       }
       setIsLiveStreaming(false)
     }
-  }, [connection, refetchHistory, refetchRuntimeStatus, sessionId, sessionStatus])
+  }, [connection, isRouteActive, refetchHistory, refetchRuntimeStatus, sessionId, sessionStatus])
 
   const send = useMutation({
     mutationFn: async ({ files, text }: ChatSubmitInput) => {
@@ -206,8 +235,8 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
             signal: controller.signal,
           },
         )
-        const assistantMessageId = response.headers.get('x-cradle-assistant-message-id')
-          ?? `assistant-${sessionId}`
+        const assistantMessageId
+          = response.headers.get('x-cradle-assistant-message-id') ?? `assistant-${sessionId}`
         setPendingUser({
           id: response.headers.get('x-cradle-user-message-id'),
           text,
@@ -225,12 +254,16 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
         setIsLiveStreaming(false)
       }
     },
-    onError: error => setSendError(errorMessage(error)),
+    onError: (error) => {
+      if (routeActiveRef.current) {
+        setSendError(errorMessage(error))
+      }
+    },
     onSettled: async () => {
-      const [result] = await Promise.all([
-        refetchHistory(),
-        refetchRuntimeStatus(),
-      ])
+      if (!routeActiveRef.current) {
+        return
+      }
+      const [result] = await Promise.all([refetchHistory(), refetchRuntimeStatus()])
       if (result.isSuccess) {
         setLiveMessage(null)
         setPendingUser(null)
@@ -239,11 +272,11 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
   })
 
   const queue = useMutation({
-    mutationFn: ({ files, text }: ChatSubmitInput) => cradleRequest(
-      connection!,
-      `/chat/sessions/${encodeURIComponent(sessionId)}/queue`,
-      { method: 'POST', body: { files, text } },
-    ),
+    mutationFn: ({ files, text }: ChatSubmitInput) =>
+      cradleRequest(connection!, `/chat/sessions/${encodeURIComponent(sessionId)}/queue`, {
+        method: 'POST',
+        body: { files, text },
+      }),
     onError: error => setSendError(errorMessage(error)),
     onSuccess: () => {
       void refetchRuntimeStatus()
@@ -252,11 +285,11 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
   })
 
   const steer = useMutation({
-    mutationFn: ({ files, text }: ChatSubmitInput) => cradleRequest(
-      connection!,
-      `/chat/sessions/${encodeURIComponent(sessionId)}/steer`,
-      { method: 'POST', body: { files, text } },
-    ),
+    mutationFn: ({ files, text }: ChatSubmitInput) =>
+      cradleRequest(connection!, `/chat/sessions/${encodeURIComponent(sessionId)}/steer`, {
+        method: 'POST',
+        body: { files, text },
+      }),
     onError: error => setSendError(errorMessage(error)),
     onSuccess: () => {
       void refetchRuntimeStatus()
@@ -265,37 +298,70 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
   })
 
   const updateRuntimeSettings = useMutation({
-    mutationFn: (interactionMode: 'default' | 'plan') => cradleRequest(
-      connection!,
-      `/chat/sessions/${encodeURIComponent(sessionId)}/runtime-settings`,
-      { method: 'PATCH', body: { interactionMode } },
-    ),
+    mutationFn: (interactionMode: 'default' | 'plan') =>
+      cradleRequest(
+        connection!,
+        `/chat/sessions/${encodeURIComponent(sessionId)}/runtime-settings`,
+        { method: 'PATCH', body: { interactionMode } },
+      ),
     onError: error => setSendError(errorMessage(error)),
     onSuccess: () => void runtimeSettingsQuery.refetch(),
   })
 
   const cancel = useMutation({
-    mutationFn: () => cradleRequest(
-      connection!,
-      `/chat/sessions/${encodeURIComponent(sessionId)}/cancel`,
-      { method: 'POST' },
-    ),
+    mutationFn: () =>
+      cradleRequest(connection!, `/chat/sessions/${encodeURIComponent(sessionId)}/cancel`, {
+        method: 'POST',
+      }),
     onSettled: () => {
       void refetchRuntimeStatus()
       void refetchHistory()
     },
   })
 
+  const cancelRun = cancel.mutate
+  const queueMessage = queue.mutate
+  const sendMessage = send.mutate
+  const steerMessage = steer.mutate
+  const updateInteractionMode = updateRuntimeSettings.mutate
+  const runtimeIsActive
+    = isLiveStreaming
+      || sessionStatus === 'streaming'
+      || sessionStatus === 'waitingForUserInput'
+      || sessionStatus === 'waitingForToolApproval'
+  const handleCancel = useCallback(() => cancelRun(), [cancelRun])
+  const handleModeChange = useCallback(
+    (mode: 'build' | 'plan') => updateInteractionMode(mode === 'plan' ? 'plan' : 'default'),
+    [updateInteractionMode],
+  )
+  const handleSend = useCallback(
+    (input: ChatSubmitInput) => {
+      if (!runtimeIsActive) {
+        sendMessage(input)
+      }
+      else if (input.continuationMode === 'steer') {
+        steerMessage(input)
+      }
+      else {
+        queueMessage(input)
+      }
+    },
+    [queueMessage, runtimeIsActive, sendMessage, steerMessage],
+  )
+
   const error = sessionQuery.error ?? (!historyData ? historyQuery.error : null)
-  if (error) { return <ErrorState title="Could not open conversation" description={errorMessage(error)} /> }
-  if (sessionQuery.isPending || (!historyData && historyQuery.isPending)) { return <LoadingState /> }
-  if (!sessionQuery.data) { return <ErrorState title="Conversation not found" /> }
+  if (error) {
+    return <ErrorState title="Could not open conversation" description={errorMessage(error)} />
+  }
+  if (sessionQuery.isPending || (!historyData && historyQuery.isPending)) {
+    return <LoadingState />
+  }
+  if (!sessionQuery.data) {
+    return <ErrorState title="Conversation not found" />
+  }
   const activeRun = runtimeStatusQuery.data?.activeRun ?? undefined
   const hasEarlier = Boolean(historyQuery.hasNextPage ?? historyData?.pages.at(-1)?.nextCursor)
-  const isStreaming = isLiveStreaming
-    || sessionStatus === 'streaming'
-    || sessionStatus === 'waitingForUserInput'
-    || sessionStatus === 'waitingForToolApproval'
+  const isStreaming = runtimeIsActive
   const queuedCount = runtimeStatusQuery.data?.queue.pending ?? 0
   return (
     <>
@@ -308,19 +374,9 @@ export function ChatContainer({ sessionId }: { sessionId: string }) {
         isStreaming={isStreaming}
         liveMessage={liveMessage}
         messages={messages}
-        onCancel={() => cancel.mutate()}
-        onModeChange={mode => updateRuntimeSettings.mutate(mode === 'plan' ? 'plan' : 'default')}
-        onSend={(input) => {
-          if (!isStreaming) {
-            send.mutate(input)
-          }
- else if (input.continuationMode === 'steer') {
-            steer.mutate(input)
-          }
- else {
-            queue.mutate(input)
-          }
-        }}
+        onCancel={handleCancel}
+        onModeChange={handleModeChange}
+        onSend={handleSend}
         pendingUser={pendingUser}
         queuedCount={queuedCount}
         sendError={sendError}

--- a/apps/mobile/src/features/chat/ChatMessage.tsx
+++ b/apps/mobile/src/features/chat/ChatMessage.tsx
@@ -1,9 +1,6 @@
 import type { UIMessage } from 'ai'
-import {
-  isReasoningUIPart,
-  isTextUIPart,
-  isToolUIPart,
-} from 'ai'
+/* eslint-disable react/no-array-index-key -- AI SDK text parts have no protocol id and their position is stable. */
+import { isReasoningUIPart, isTextUIPart, isToolUIPart } from 'ai'
 import { Check, CircleAlert, Wrench } from 'lucide-react-native'
 import { memo } from 'react'
 import { ActivityIndicator, Platform, StyleSheet, Text, View } from 'react-native'
@@ -14,30 +11,18 @@ import { PressableScale } from '@/components/ui/pressable-scale'
 import { radius, spacing } from '@/theme/tokens'
 import { useTheme } from '@/theme/use-theme'
 
-import { ChatActivitySheet } from './ChatActivitySheet'
-
 interface ChatMessageProps {
   errorText?: string | null
-  activityError?: string | null
-  activityMessage?: UIMessage
-  isActivityLoading?: boolean
   message: UIMessage
-  onActivityClose?: () => void
-  onActivityPress?: () => void
+  onActivityPress?: (messageId: string) => void
   status?: 'streaming' | 'complete' | 'aborted' | 'failed'
-  showActivitySheet?: boolean
 }
 
 function ChatMessageContent({
-  activityError = null,
-  activityMessage,
   errorText = null,
-  isActivityLoading = false,
   message,
-  onActivityClose,
   onActivityPress,
   status = 'complete',
-  showActivitySheet = false,
 }: ChatMessageProps) {
   const theme = useTheme()
 
@@ -48,89 +33,115 @@ function ChatMessageContent({
       .join('')
     return (
       <View style={[styles.userBubble, { backgroundColor: theme.muted }]}>
-        <Text selectable style={[styles.userText, { color: theme.foreground }]}>{text}</Text>
+        <Text selectable style={[styles.userText, { color: theme.foreground }]}>
+          {text}
+        </Text>
       </View>
     )
   }
 
-  const activityParts = message.parts.filter(part => isReasoningUIPart(part) || isToolUIPart(part))
+  const activityParts = message.parts.filter(
+    part => isReasoningUIPart(part) || isToolUIPart(part),
+  )
   const toolParts = message.parts.filter(isToolUIPart)
-  const running = toolParts.some(part => part.state === 'input-streaming'
-    || part.state === 'input-available'
-    || part.state === 'approval-requested')
-  const failed = toolParts.some(part => part.state === 'output-error' || part.state === 'output-denied')
+  const running = toolParts.some(
+    part =>
+      part.state === 'input-streaming'
+      || part.state === 'input-available'
+      || part.state === 'approval-requested',
+  )
+  const failed = toolParts.some(
+    part => part.state === 'output-error' || part.state === 'output-denied',
+  )
 
   return (
     <View style={styles.assistantMessage}>
       {message.parts.map((part, index) => {
         if (isTextUIPart(part)) {
-          if (!part.text) { return null }
-          return Platform.OS === 'ios'
-            // Text parts have no protocol id; their position is stable for the life of a message.
-            // eslint-disable-next-line react/no-array-index-key
-            ? <NativeMarkdown key={`text-${index}`} markdown={part.text} streaming={status === 'streaming'} />
-            : (
-                <Markdown
-                  // Text parts have no protocol id; their position is stable for the life of a message.
-                  // eslint-disable-next-line react/no-array-index-key
-                  key={`text-${index}`}
-                  style={{
-                    body: {
-                      color: theme.foreground,
-                      fontSize: 14,
-                      lineHeight: 22,
-                      marginBottom: 0,
-                      marginTop: 0,
-                    },
-                    bullet_list: {
-                      marginBottom: spacing.sm,
-                      marginTop: spacing.xs,
-                    },
-                    code_inline: {
-                      backgroundColor: theme.muted,
-                      borderRadius: radius.sm,
-                      color: theme.foreground,
-                      fontFamily: 'GeistMono_400Regular',
-                      fontSize: 12,
-                      paddingHorizontal: spacing.xs,
-                    },
-                    fence: {
-                      backgroundColor: theme.muted,
-                      borderColor: theme.border,
-                      borderRadius: radius.md,
-                      color: theme.foreground,
-                      fontFamily: 'GeistMono_400Regular',
-                      fontSize: 11,
-                      lineHeight: 17,
-                      marginVertical: spacing.sm,
-                      padding: spacing.sm,
-                    },
-                    heading1: {
-                      color: theme.foreground,
-                      fontSize: 18,
-                      lineHeight: 24,
-                      marginBottom: spacing.sm,
-                      marginTop: spacing.md,
-                    },
-                    heading2: {
-                      color: theme.foreground,
-                      fontSize: 16,
-                      lineHeight: 22,
-                      marginBottom: spacing.sm,
-                      marginTop: spacing.md,
-                    },
-                    link: {
-                      color: theme.info,
-                    },
-                    paragraph: {
-                      marginBottom: spacing.sm,
-                      marginTop: 0,
-                    },
-                  }}
-                >
-                  {part.text}
-                </Markdown>
-              )
+          if (!part.text) {
+            return null
+          }
+          // Text parts have no protocol id; their position is stable for the life of a message.
+          if (Platform.OS === 'ios') {
+            return (
+              <NativeMarkdown
+                key={`text-${index}`}
+                markdown={part.text}
+                streaming={status === 'streaming'}
+              />
+            )
+          }
+          if (status === 'streaming') {
+            return (
+              <Text
+                key={`text-${index}`}
+                style={[styles.streamingText, { color: theme.foreground }]}
+              >
+                {part.text}
+              </Text>
+            )
+          }
+
+          return (
+            <Markdown
+              key={`text-${index}`}
+              style={{
+                body: {
+                  color: theme.foreground,
+                  fontSize: 14,
+                  lineHeight: 22,
+                  marginBottom: 0,
+                  marginTop: 0,
+                },
+                bullet_list: {
+                  marginBottom: spacing.sm,
+                  marginTop: spacing.xs,
+                },
+                code_inline: {
+                  backgroundColor: theme.muted,
+                  borderRadius: radius.sm,
+                  color: theme.foreground,
+                  fontFamily: 'GeistMono_400Regular',
+                  fontSize: 12,
+                  paddingHorizontal: spacing.xs,
+                },
+                fence: {
+                  backgroundColor: theme.muted,
+                  borderColor: theme.border,
+                  borderRadius: radius.md,
+                  color: theme.foreground,
+                  fontFamily: 'GeistMono_400Regular',
+                  fontSize: 11,
+                  lineHeight: 17,
+                  marginVertical: spacing.sm,
+                  padding: spacing.sm,
+                },
+                heading1: {
+                  color: theme.foreground,
+                  fontSize: 18,
+                  lineHeight: 24,
+                  marginBottom: spacing.sm,
+                  marginTop: spacing.md,
+                },
+                heading2: {
+                  color: theme.foreground,
+                  fontSize: 16,
+                  lineHeight: 22,
+                  marginBottom: spacing.sm,
+                  marginTop: spacing.md,
+                },
+                link: {
+                  color: theme.info,
+                },
+                paragraph: {
+                  marginBottom: spacing.sm,
+                  marginTop: 0,
+                },
+              }}
+            >
+              {part.text}
+            </Markdown>
+          )
         }
 
         if (isReasoningUIPart(part)) {
@@ -149,15 +160,21 @@ function ChatMessageContent({
           accessibilityLabel="Open activity feed"
           accessibilityRole="button"
           disabled={!onActivityPress}
-          onPress={onActivityPress}
+          onPress={onActivityPress ? () => onActivityPress(message.id) : undefined}
           style={[styles.activitySummary, { backgroundColor: theme.surfaceInset }]}
         >
           <View style={styles.activityIcon}>
             {running
-              ? <ActivityIndicator color={theme.tertiaryForeground} size="small" />
+              ? (
+              <ActivityIndicator color={theme.tertiaryForeground} size="small" />
+            )
               : failed
-                ? <CircleAlert color={theme.destructive} size={15} />
-                : <Check color={theme.success} size={15} />}
+                ? (
+              <CircleAlert color={theme.destructive} size={15} />
+            )
+                : (
+              <Check color={theme.success} size={15} />
+            )}
           </View>
           <Wrench color={theme.tertiaryForeground} size={14} />
           <Text style={[styles.activityLabel, { color: theme.tertiaryForeground }]}>
@@ -168,7 +185,10 @@ function ChatMessageContent({
       )}
 
       {status === 'streaming' && (
-        <Text accessibilityLabel="Streaming response" style={[styles.cursor, { color: theme.foreground }]}>
+        <Text
+          accessibilityLabel="Streaming response"
+          style={[styles.cursor, { color: theme.foreground }]}
+        >
           {'\u258C'}
         </Text>
       )}
@@ -178,14 +198,6 @@ function ChatMessageContent({
       {status === 'failed' && errorText && (
         <Text style={[styles.terminalStatus, { color: theme.destructive }]}>{errorText}</Text>
       )}
-
-      <ChatActivitySheet
-        error={activityError}
-        isLoading={isActivityLoading}
-        message={activityMessage ?? message}
-        onClose={onActivityClose ?? (() => {})}
-        visible={showActivitySheet}
-      />
     </View>
   )
 }
@@ -227,6 +239,10 @@ const styles = StyleSheet.create({
   terminalStatus: {
     fontSize: 12,
     lineHeight: 18,
+  },
+  streamingText: {
+    fontSize: 14,
+    lineHeight: 22,
   },
   userBubble: {
     alignSelf: 'flex-end',

--- a/apps/mobile/src/features/chat/ChatView.tsx
+++ b/apps/mobile/src/features/chat/ChatView.tsx
@@ -1,6 +1,6 @@
 import type { UIMessage } from 'ai'
 import { Square } from 'lucide-react-native'
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import type { NativeSyntheticEvent, NativeTouchEvent } from 'react-native'
 import {
   ActivityIndicator,
@@ -25,6 +25,7 @@ import { durationLabel } from '@/lib/format'
 import { spacing } from '@/theme/tokens'
 import { useTheme } from '@/theme/use-theme'
 
+import { ChatActivitySheet } from './ChatActivitySheet'
 import type { ChatSubmitInput } from './ChatComposer'
 import { ChatComposer } from './ChatComposer'
 import { ChatMessage } from './ChatMessage'
@@ -94,31 +95,51 @@ export function ChatView({
   })
   const listTouchStartRef = useRef({ pageX: 0, pageY: 0 })
   const listTouchMovedRef = useRef(false)
-  const durableIds = new Set(messages.map(row => row.messageId))
-  const showPendingUser = pendingUser
-    && (!pendingUser.id || !durableIds.has(pendingUser.id))
-  const showLiveMessage = liveMessage && !durableIds.has(liveMessage.id)
-  const items: TranscriptItem[] = [
-    ...messages.map(row => ({ kind: 'message' as const, row })),
-    ...(showPendingUser && pendingUser
-      ? [{
-          kind: 'pending' as const,
-          id: pendingUser.id ?? 'pending-user',
-          message: {
-            id: pendingUser.id ?? 'pending-user',
-            parts: [{ text: pendingUser.text, type: 'text' as const }],
-            role: 'user' as const,
-          },
-        }]
-      : []),
-    ...(showLiveMessage && liveMessage
-      ? [{ kind: 'live' as const, id: liveMessage.id, message: liveMessage }]
-      : []),
-  ]
-
-  const displayItems = [...items].reverse()
+  const items = useMemo<TranscriptItem[]>(() => {
+    const durableIds = new Set(messages.map(row => row.messageId))
+    const showPendingUser = pendingUser && (!pendingUser.id || !durableIds.has(pendingUser.id))
+    const showLiveMessage = liveMessage && !durableIds.has(liveMessage.id)
+    return [
+      ...messages.map(row => ({ kind: 'message' as const, row })),
+      ...(showPendingUser && pendingUser
+        ? [
+            {
+              kind: 'pending' as const,
+              id: pendingUser.id ?? 'pending-user',
+              message: {
+                id: pendingUser.id ?? 'pending-user',
+                parts: [{ text: pendingUser.text, type: 'text' as const }],
+                role: 'user' as const,
+              },
+            },
+          ]
+        : []),
+      ...(showLiveMessage && liveMessage
+        ? [{ kind: 'live' as const, id: liveMessage.id, message: liveMessage }]
+        : []),
+    ]
+  }, [liveMessage, messages, pendingUser])
+  const displayItems = useMemo(() => [...items].reverse(), [items])
+  const activityMessage = useMemo(() => {
+    if (!detailMessageId) {
+      return undefined
+    }
+    if (detailMessage?.id === detailMessageId) {
+      return detailMessage
+    }
+    const item = items.find(
+      candidate =>
+        (candidate.kind === 'message' ? candidate.row.messageId : candidate.id) === detailMessageId,
+    )
+    if (!item) {
+      return undefined
+    }
+    return item.kind === 'message' ? (item.row.message as UIMessage) : item.message
+  }, [detailMessage, detailMessageId, items])
   const handleEndReached = () => {
-    if (hasEarlier && !isLoadingEarlier) { onLoadEarlier() }
+    if (hasEarlier && !isLoadingEarlier) {
+      onLoadEarlier()
+    }
   }
   const handleListTouchStart = (event: NativeSyntheticEvent<NativeTouchEvent>) => {
     listTouchStartRef.current = {
@@ -130,10 +151,14 @@ export function ChatView({
   const handleListTouchMove = (event: NativeSyntheticEvent<NativeTouchEvent>) => {
     const dx = event.nativeEvent.pageX - listTouchStartRef.current.pageX
     const dy = event.nativeEvent.pageY - listTouchStartRef.current.pageY
-    if (Math.hypot(dx, dy) > 8) { listTouchMovedRef.current = true }
+    if (Math.hypot(dx, dy) > 8) {
+      listTouchMovedRef.current = true
+    }
   }
   const handleListTouchEnd = () => {
-    if (!listTouchMovedRef.current) { Keyboard.dismiss() }
+    if (!listTouchMovedRef.current) {
+      Keyboard.dismiss()
+    }
     listTouchMovedRef.current = false
   }
 
@@ -151,19 +176,29 @@ export function ChatView({
             keyboardDismissMode="none"
             keyboardShouldPersistTaps="always"
             ListHeaderComponent={(
-              <Animated.View pointerEvents="none" style={[styles.keyboardSpacer, { height: keyboardInset }]} />
+              <Animated.View
+                pointerEvents="none"
+                style={[styles.keyboardSpacer, { height: keyboardInset }]}
+              />
             )}
-            keyExtractor={item => `${item.kind}-${item.kind === 'message' ? item.row.messageId : item.id}`}
+            keyExtractor={item =>
+              `${item.kind}-${item.kind === 'message' ? item.row.messageId : item.id}`}
             ListEmptyComponent={(
-              <Text style={[styles.emptyText, { color: theme.mutedForeground }]}>Start the conversation</Text>
+              <Text style={[styles.emptyText, { color: theme.mutedForeground }]}>
+                Start the conversation
+              </Text>
             )}
-            ListFooterComponent={hasEarlier
-              ? (
-                  <View style={styles.earlierHeader}>
-                    {isLoadingEarlier && <ActivityIndicator color={theme.mutedForeground} size="small" />}
-                  </View>
+            ListFooterComponent={
+              hasEarlier
+                ? (
+                <View style={styles.earlierHeader}>
+                  {isLoadingEarlier && (
+                    <ActivityIndicator color={theme.mutedForeground} size="small" />
+                  )}
+                </View>
               )
-              : null}
+                : null
+            }
             maintainVisibleContentPosition={{ minIndexForVisible: 0 }}
             onEndReached={handleEndReached}
             onEndReachedThreshold={0.2}
@@ -172,39 +207,40 @@ export function ChatView({
             onTouchStart={handleListTouchStart}
             renderItem={({ item }) => {
               if (item.kind === 'message') {
-                const message = liveMessage?.id === item.row.messageId
-                  ? liveMessage
-                  : detailMessage?.id === item.row.messageId
-                    ? detailMessage
-                    : item.row.message as UIMessage
+                const message
+                  = liveMessage?.id === item.row.messageId
+                    ? liveMessage
+                    : detailMessage?.id === item.row.messageId
+                      ? detailMessage
+                      : (item.row.message as UIMessage)
                 return (
                   <ChatMessage
-                    activityError={detailMessageId === item.row.messageId ? messageDetailError : null}
-                    activityMessage={detailMessageId === item.row.messageId ? detailMessage : undefined}
                     errorText={item.row.errorText}
-                    isActivityLoading={detailMessageId === item.row.messageId && isLoadingMessageDetail}
                     message={message}
-                    onActivityClose={() => onRequestMessageDetail(null)}
-                    onActivityPress={() => onRequestMessageDetail(item.row.messageId)}
-                    showActivitySheet={detailMessageId === item.row.messageId}
+                    onActivityPress={onRequestMessageDetail}
                     status={liveMessage?.id === item.row.messageId ? 'streaming' : item.row.status}
                   />
                 )
               }
               return (
                 <ChatMessage
-                  activityError={detailMessageId === item.id ? messageDetailError : null}
-                  activityMessage={detailMessageId === item.id ? detailMessage : undefined}
-                  isActivityLoading={detailMessageId === item.id && isLoadingMessageDetail}
                   message={item.message}
-                  onActivityClose={() => onRequestMessageDetail(null)}
-                  onActivityPress={item.kind === 'live' ? () => onRequestMessageDetail(item.id) : undefined}
-                  status={item.kind === 'live' ? (isStreaming ? 'streaming' : 'complete') : undefined}
-                  showActivitySheet={detailMessageId === item.id}
+                  onActivityPress={item.kind === 'live' ? onRequestMessageDetail : undefined}
+                  status={
+                    item.kind === 'live' ? (isStreaming ? 'streaming' : 'complete') : undefined
+                  }
                 />
               )
             }}
             scrollEventThrottle={32}
+          />
+
+          <ChatActivitySheet
+            error={messageDetailError}
+            isLoading={isLoadingMessageDetail}
+            message={activityMessage}
+            onClose={() => onRequestMessageDetail(null)}
+            visible={detailMessageId !== null}
           />
 
           <Animated.View
@@ -239,8 +275,12 @@ export function ChatView({
                   style={[styles.stopButton, { backgroundColor: theme.muted }]}
                 >
                   {isCancelling
-                    ? <ActivityIndicator color={theme.foreground} size="small" />
-                    : <Square color={theme.foreground} fill={theme.foreground} size={11} />}
+                  ? (
+                    <ActivityIndicator color={theme.foreground} size="small" />
+                  )
+                  : (
+                    <Square color={theme.foreground} fill={theme.foreground} size={11} />
+                  )}
                 </PressableScale>
               </View>
             )}

--- a/apps/mobile/src/features/chat/chat-stream.ts
+++ b/apps/mobile/src/features/chat/chat-stream.ts
@@ -25,7 +25,7 @@ interface ConsumeChatMessageStreamOptions {
   response: Response
 }
 
-const STREAM_RENDER_INTERVAL_MS = 50
+const STREAM_RENDER_INTERVAL_MS = 125
 
 export async function consumeChatMessageStream({
   messageId,

--- a/apps/mobile/src/features/projects/ProjectsContainer.tsx
+++ b/apps/mobile/src/features/projects/ProjectsContainer.tsx
@@ -7,6 +7,7 @@ import { ErrorState, LoadingState } from '@/components/ui/states'
 import { useConnection } from '@/features/connection/connection-context'
 import { useCreateWork } from '@/features/work/use-create-work'
 import { cradleRequest } from '@/lib/api'
+import { useRouteIsActive } from '@/lib/app-lifecycle-context'
 import { errorMessage } from '@/lib/errors'
 
 import { ProjectsView } from './ProjectsView'
@@ -14,14 +15,15 @@ import { ProjectsView } from './ProjectsView'
 export function ProjectsContainer() {
   const { connection } = useConnection()
   const create = useCreateWork()
+  const isRouteActive = useRouteIsActive()
   const [isRefreshing, setIsRefreshing] = useState(false)
   const query = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['projects', connection?.url],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const [workspaces, sessions] = await Promise.all([
-        cradleRequest<GetWorkspacesResponse>(connection!, '/workspaces'),
-        cradleRequest<GetSessionsResponse>(connection!, '/sessions/?archived=false'),
+        cradleRequest<GetWorkspacesResponse>(connection!, '/workspaces', { signal }),
+        cradleRequest<GetSessionsResponse>(connection!, '/sessions/?archived=false', { signal }),
       ])
       return workspaces
         .filter(workspace => workspace.locator.kind !== 'managed-worktree')
@@ -29,12 +31,16 @@ export function ProjectsContainer() {
           workspace,
           sessions: sessions.filter(session => session.workspaceId === workspace.id),
         }))
-        .sort((a, b) => b.workspace.pinned - a.workspace.pinned || b.workspace.updatedAt - a.workspace.updatedAt)
+        .sort(
+          (a, b) =>
+            b.workspace.pinned - a.workspace.pinned || b.workspace.updatedAt - a.workspace.updatedAt,
+        )
     },
-    refetchInterval: data => data.state.data?.some(project =>
-      project.sessions.some(session => session.status === 'streaming'))
-? 2_000
-: 15_000,
+    refetchInterval: data =>
+      data.state.data?.some(project =>
+        project.sessions.some(session => session.status === 'streaming'))
+        ? 5_000
+        : false,
   })
 
   const refresh = async () => {

--- a/apps/mobile/src/features/projects/WorkspaceContainer.tsx
+++ b/apps/mobile/src/features/projects/WorkspaceContainer.tsx
@@ -12,6 +12,7 @@ import { ErrorState, LoadingState } from '@/components/ui/states'
 import { useConnection } from '@/features/connection/connection-context'
 import { useCreateWork } from '@/features/work/use-create-work'
 import { cradleRequest } from '@/lib/api'
+import { useRouteIsActive } from '@/lib/app-lifecycle-context'
 import { errorMessage } from '@/lib/errors'
 
 import { WorkspaceView } from './WorkspaceView'
@@ -19,18 +20,28 @@ import { WorkspaceView } from './WorkspaceView'
 export function WorkspaceContainer({ workspaceId }: { workspaceId: string }) {
   const { connection } = useConnection()
   const create = useCreateWork()
+  const isRouteActive = useRouteIsActive()
   const [isRefreshing, setIsRefreshing] = useState(false)
   const query = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['workspace', connection?.url, workspaceId],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const [workspaces, sessions, works, files] = await Promise.all([
-        cradleRequest<GetWorkspacesResponse>(connection!, '/workspaces'),
-        cradleRequest<GetSessionsResponse>(connection!, `/sessions/?workspaceId=${encodeURIComponent(workspaceId)}&archived=false`),
-        cradleRequest<GetWorksResponse>(connection!, `/works?workspaceId=${encodeURIComponent(workspaceId)}&archived=false`),
+        cradleRequest<GetWorkspacesResponse>(connection!, '/workspaces', { signal }),
+        cradleRequest<GetSessionsResponse>(
+          connection!,
+          `/sessions/?workspaceId=${encodeURIComponent(workspaceId)}&archived=false`,
+          { signal },
+        ),
+        cradleRequest<GetWorksResponse>(
+          connection!,
+          `/works?workspaceId=${encodeURIComponent(workspaceId)}&archived=false`,
+          { signal },
+        ),
         cradleRequest<GetWorkspacesByWorkspaceIdFilesChildrenResponse>(
           connection!,
           `/workspaces/${encodeURIComponent(workspaceId)}/files/children`,
+          { signal },
         ),
       ])
       const workspace = workspaces.find(candidate => candidate.id === workspaceId)
@@ -42,16 +53,17 @@ export function WorkspaceContainer({ workspaceId }: { workspaceId: string }) {
         sessions,
         works,
         files,
-        workspaces: workspaces.filter(candidate =>
-          candidate.availability === 'available' && candidate.locator.kind !== 'managed-worktree'),
+        workspaces: workspaces.filter(
+          candidate =>
+            candidate.availability === 'available' && candidate.locator.kind !== 'managed-worktree',
+        ),
       }
     },
-    refetchInterval: data => (
+    refetchInterval: data =>
       data.state.data?.sessions.some(session => session.status === 'streaming')
       || data.state.data?.works.some(work => work.activity === 'running')
-    )
-? 2_000
-: 15_000,
+        ? 5_000
+        : false,
   })
 
   const refresh = async () => {
@@ -64,8 +76,12 @@ export function WorkspaceContainer({ workspaceId }: { workspaceId: string }) {
     }
   }
 
-  if (query.isPending) { return <LoadingState /> }
-  if (query.error) { return <ErrorState title="Could not open project" description={errorMessage(query.error)} /> }
+  if (query.isPending) {
+    return <LoadingState />
+  }
+  if (query.error) {
+    return <ErrorState title="Could not open project" description={errorMessage(query.error)} />
+  }
   return (
     <>
       <Stack.Screen options={{ title: '' }} />

--- a/apps/mobile/src/features/pull-requests/PullRequestDetailContainer.tsx
+++ b/apps/mobile/src/features/pull-requests/PullRequestDetailContainer.tsx
@@ -5,6 +5,7 @@ import type { GetPullRequestsByOwnerByRepoByNumberDetailResponse } from '@/api-g
 import { ErrorState, LoadingState } from '@/components/ui/states'
 import { useConnection } from '@/features/connection/connection-context'
 import { cradleRequest } from '@/lib/api'
+import { useRouteIsActive } from '@/lib/app-lifecycle-context'
 import { errorMessage } from '@/lib/errors'
 
 import { PullRequestDetailView } from './PullRequestDetailView'
@@ -15,27 +16,41 @@ interface PullRequestDetailContainerProps {
   number: string
 }
 
-export function PullRequestDetailContainer({ owner, repo, number }: PullRequestDetailContainerProps) {
+export function PullRequestDetailContainer({
+  owner,
+  repo,
+  number,
+}: PullRequestDetailContainerProps) {
   const { connection } = useConnection()
+  const isRouteActive = useRouteIsActive()
   const path = `/pull-requests/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(number)}`
   const query = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['pull-request', connection?.url, owner, repo, number],
-    queryFn: () => cradleRequest<GetPullRequestsByOwnerByRepoByNumberDetailResponse>(connection!, `${path}/detail`),
-    refetchInterval: data => data.state.data?.pullRequest.checksState === 'pending' ? 5_000 : 30_000,
+    queryFn: ({ signal }) =>
+      cradleRequest<GetPullRequestsByOwnerByRepoByNumberDetailResponse>(
+        connection!,
+        `${path}/detail`,
+        { signal },
+      ),
+    refetchInterval: data =>
+      data.state.data?.pullRequest.checksState === 'pending' ? 10_000 : false,
   })
 
   const action = useMutation({
-    mutationFn: ({ endpoint, body }: { endpoint: string, body: object }) => cradleRequest(
-      connection!,
-      `${path}/${endpoint}`,
-      { method: 'POST', body },
-    ),
+    mutationFn: ({ endpoint, body }: { endpoint: string, body: object }) =>
+      cradleRequest(connection!, `${path}/${endpoint}`, { method: 'POST', body }),
     onSuccess: () => void query.refetch(),
   })
 
-  if (query.isPending) { return <LoadingState /> }
-  if (query.error) { return <ErrorState title="Could not open pull request" description={errorMessage(query.error)} /> }
+  if (query.isPending) {
+    return <LoadingState />
+  }
+  if (query.error) {
+    return (
+      <ErrorState title="Could not open pull request" description={errorMessage(query.error)} />
+    )
+  }
   return (
     <>
       <Stack.Screen options={{ title: `#${query.data.pullRequest.number}` }} />
@@ -43,10 +58,11 @@ export function PullRequestDetailContainer({ owner, repo, number }: PullRequestD
         detail={query.data}
         isMutating={action.isPending}
         onComment={body => action.mutate({ endpoint: 'comment', body: { body } })}
-        onReview={(event, body) => action.mutate({
-          endpoint: 'review',
-          body: { event, ...(body ? { body } : {}) },
-        })}
+        onReview={(event, body) =>
+          action.mutate({
+            endpoint: 'review',
+            body: { event, ...(body ? { body } : {}) },
+          })}
       />
     </>
   )

--- a/apps/mobile/src/features/pull-requests/PullRequestListContainer.tsx
+++ b/apps/mobile/src/features/pull-requests/PullRequestListContainer.tsx
@@ -10,26 +10,39 @@ import type {
 import { ErrorState, LoadingState } from '@/components/ui/states'
 import { useConnection } from '@/features/connection/connection-context'
 import { cradleRequest } from '@/lib/api'
+import { useRouteIsActive } from '@/lib/app-lifecycle-context'
 import { errorMessage } from '@/lib/errors'
 
 import { PullRequestListView } from './PullRequestListView'
 
 export function PullRequestListContainer() {
   const { connection } = useConnection()
+  const isRouteActive = useRouteIsActive()
   const [isRefreshing, setIsRefreshing] = useState(false)
   const query = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['pull-requests', connection?.url],
-    queryFn: async () => {
-      const viewer = await cradleRequest<GetPullRequestsViewerResponse>(connection!, '/pull-requests/viewer')
+    queryFn: async ({ signal }) => {
+      const viewer = await cradleRequest<GetPullRequestsViewerResponse>(
+        connection!,
+        '/pull-requests/viewer',
+        { signal },
+      )
       const login = encodeURIComponent(viewer.viewer.login)
       const [authored, reviewing] = await Promise.all([
-        cradleRequest<GetPullRequestsAuthoredResponse>(connection!, `/pull-requests/authored?login=${login}`),
-        cradleRequest<GetPullRequestsReviewingResponse>(connection!, `/pull-requests/reviewing?login=${login}`),
+        cradleRequest<GetPullRequestsAuthoredResponse>(
+          connection!,
+          `/pull-requests/authored?login=${login}`,
+          { signal },
+        ),
+        cradleRequest<GetPullRequestsReviewingResponse>(
+          connection!,
+          `/pull-requests/reviewing?login=${login}`,
+          { signal },
+        ),
       ])
       return { login: viewer.viewer.login, authored: authored.items, reviewing: reviewing.items }
     },
-    refetchInterval: 30_000,
   })
 
   const refresh = async () => {
@@ -42,7 +55,9 @@ export function PullRequestListContainer() {
     }
   }
 
-  if (query.isPending) { return <LoadingState /> }
+  if (query.isPending) {
+    return <LoadingState />
+  }
   if (query.error) {
     return (
       <ErrorState
@@ -56,9 +71,8 @@ export function PullRequestListContainer() {
       {...query.data}
       isRefreshing={isRefreshing}
       onNavigate={section => router.replace(`/(tabs)/${section}`)}
-      onOpen={pullRequest => router.push(
-        `/pull-request/${pullRequest.owner}/${pullRequest.repo}/${pullRequest.number}`,
-      )}
+      onOpen={pullRequest =>
+        router.push(`/pull-request/${pullRequest.owner}/${pullRequest.repo}/${pullRequest.number}`)}
       onOpenUsage={() => router.push('/usage')}
       onRefresh={() => void refresh()}
     />

--- a/apps/mobile/src/features/usage/UsageContainer.tsx
+++ b/apps/mobile/src/features/usage/UsageContainer.tsx
@@ -9,6 +9,7 @@ import type {
 import { ErrorState, LoadingState } from '@/components/ui/states'
 import { useConnection } from '@/features/connection/connection-context'
 import { cradleRequest } from '@/lib/api'
+import { useRouteIsActive } from '@/lib/app-lifecycle-context'
 import { errorMessage } from '@/lib/errors'
 
 import type { UsageRange } from './usage-range'
@@ -17,6 +18,7 @@ import { UsageView } from './UsageView'
 
 export function UsageContainer() {
   const { connection } = useConnection()
+  const isRouteActive = useRouteIsActive()
   const [range, setRange] = useState<UsageRange>('30d')
   const days = usageRangeDays(range)
   const rangeFrom = useMemo(() => {
@@ -25,19 +27,23 @@ export function UsageContainer() {
     return date.toISOString().slice(0, 10)
   }, [days])
   const query = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['usage', connection?.url, range],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const [daily, summary, stats] = await Promise.all([
-        cradleRequest<GetUsageDailyResponse>(connection!, `/usage/daily?days=${days}`),
-        cradleRequest<GetUsageSummaryResponse>(connection!, `/usage/summary?from=${rangeFrom}`),
-        cradleRequest<GetUsageStatsResponse>(connection!, '/usage/stats'),
+        cradleRequest<GetUsageDailyResponse>(connection!, `/usage/daily?days=${days}`, { signal }),
+        cradleRequest<GetUsageSummaryResponse>(connection!, `/usage/summary?from=${rangeFrom}`, {
+          signal,
+        }),
+        cradleRequest<GetUsageStatsResponse>(connection!, '/usage/stats', { signal }),
       ])
       return { daily, stats, summary }
     },
   })
 
-  if (query.isPending) { return <LoadingState /> }
+  if (query.isPending) {
+    return <LoadingState />
+  }
   if (query.error) {
     return <ErrorState title="Could not load Usage" description={errorMessage(query.error)} />
   }

--- a/apps/mobile/src/features/work/WorkDetailContainer.tsx
+++ b/apps/mobile/src/features/work/WorkDetailContainer.tsx
@@ -5,6 +5,7 @@ import type { GetWorksByIdResponse } from '@/api-gen'
 import { ErrorState, LoadingState } from '@/components/ui/states'
 import { useConnection } from '@/features/connection/connection-context'
 import { cradleRequest } from '@/lib/api'
+import { useRouteIsActive } from '@/lib/app-lifecycle-context'
 import { errorMessage } from '@/lib/errors'
 
 import type { WorkHandoff } from './WorkDetailView'
@@ -12,34 +13,44 @@ import { WorkDetailView } from './WorkDetailView'
 
 export function WorkDetailContainer({ workId }: { workId: string }) {
   const { connection } = useConnection()
+  const isRouteActive = useRouteIsActive()
   const queryClient = useQueryClient()
   const query = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['work', connection?.url, workId],
-    queryFn: () => cradleRequest<GetWorksByIdResponse>(connection!, `/works/${encodeURIComponent(workId)}`),
-    refetchInterval: data => data.state.data?.activity === 'running' ? 2_000 : 10_000,
+    queryFn: ({ signal }) =>
+      cradleRequest<GetWorksByIdResponse>(connection!, `/works/${encodeURIComponent(workId)}`, {
+        signal,
+      }),
+    refetchInterval: data => (data.state.data?.activity === 'running' ? 5_000 : false),
   })
 
   const prepare = useMutation({
-    mutationFn: (handoff: WorkHandoff) => cradleRequest<GetWorksByIdResponse>(
-      connection!,
-      `/works/${encodeURIComponent(workId)}/prepare`,
-      { method: 'POST', body: handoff },
-    ),
+    mutationFn: (handoff: WorkHandoff) =>
+      cradleRequest<GetWorksByIdResponse>(
+        connection!,
+        `/works/${encodeURIComponent(workId)}/prepare`,
+        { method: 'POST', body: handoff },
+      ),
     onSuccess: data => queryClient.setQueryData(['work', connection?.url, workId], data),
   })
 
   const submit = useMutation({
-    mutationFn: (handoff: WorkHandoff) => cradleRequest<GetWorksByIdResponse>(
-      connection!,
-      `/works/${encodeURIComponent(workId)}/submit`,
-      { method: 'POST', body: handoff },
-    ),
+    mutationFn: (handoff: WorkHandoff) =>
+      cradleRequest<GetWorksByIdResponse>(
+        connection!,
+        `/works/${encodeURIComponent(workId)}/submit`,
+        { method: 'POST', body: handoff },
+      ),
     onSuccess: data => queryClient.setQueryData(['work', connection?.url, workId], data),
   })
 
-  if (query.isPending) { return <LoadingState /> }
-  if (query.error) { return <ErrorState title="Could not open Work" description={errorMessage(query.error)} /> }
+  if (query.isPending) {
+    return <LoadingState />
+  }
+  if (query.error) {
+    return <ErrorState title="Could not open Work" description={errorMessage(query.error)} />
+  }
   return (
     <>
       <Stack.Screen options={{ title: 'Work info' }} />
@@ -47,7 +58,8 @@ export function WorkDetailContainer({ workId }: { workId: string }) {
         detail={query.data}
         isPreparing={prepare.isPending}
         isSubmitting={submit.isPending}
-        onOpenPullRequest={(owner, repo, number) => router.push(`/pull-request/${owner}/${repo}/${number}`)}
+        onOpenPullRequest={(owner, repo, number) =>
+          router.push(`/pull-request/${owner}/${repo}/${number}`)}
         onPrepare={handoff => prepare.mutate(handoff)}
         onSubmit={handoff => submit.mutate(handoff)}
       />

--- a/apps/mobile/src/features/work/WorkListContainer.tsx
+++ b/apps/mobile/src/features/work/WorkListContainer.tsx
@@ -6,6 +6,7 @@ import type { GetWorkspacesResponse, GetWorksResponse } from '@/api-gen'
 import { ErrorState, LoadingState } from '@/components/ui/states'
 import { useConnection } from '@/features/connection/connection-context'
 import { cradleRequest } from '@/lib/api'
+import { useRouteIsActive } from '@/lib/app-lifecycle-context'
 import { errorMessage } from '@/lib/errors'
 
 import { useCreateWork } from './use-create-work'
@@ -14,22 +15,26 @@ import { WorkListView } from './WorkListView'
 export function WorkListContainer() {
   const { connection } = useConnection()
   const create = useCreateWork()
+  const isRouteActive = useRouteIsActive()
   const [isRefreshing, setIsRefreshing] = useState(false)
   const query = useQuery({
-    enabled: Boolean(connection),
+    enabled: Boolean(connection) && isRouteActive,
     queryKey: ['works', connection?.url],
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const [works, workspaces] = await Promise.all([
-        cradleRequest<GetWorksResponse>(connection!, '/works?archived=false'),
-        cradleRequest<GetWorkspacesResponse>(connection!, '/workspaces'),
+        cradleRequest<GetWorksResponse>(connection!, '/works?archived=false', { signal }),
+        cradleRequest<GetWorkspacesResponse>(connection!, '/workspaces', { signal }),
       ])
       return {
         works: works.sort((a, b) => b.updatedAt - a.updatedAt),
-        workspaces: workspaces.filter(workspace =>
-          workspace.availability === 'available' && workspace.locator.kind !== 'managed-worktree'),
+        workspaces: workspaces.filter(
+          workspace =>
+            workspace.availability === 'available' && workspace.locator.kind !== 'managed-worktree',
+        ),
       }
     },
-    refetchInterval: data => data.state.data?.works.some(work => work.activity === 'running') ? 2_000 : 12_000,
+    refetchInterval: data =>
+      data.state.data?.works.some(work => work.activity === 'running') ? 5_000 : false,
   })
 
   const refresh = async () => {
@@ -42,8 +47,12 @@ export function WorkListContainer() {
     }
   }
 
-  if (query.isPending) { return <LoadingState /> }
-  if (query.error) { return <ErrorState title="Could not load Work" description={errorMessage(query.error)} /> }
+  if (query.isPending) {
+    return <LoadingState />
+  }
+  if (query.error) {
+    return <ErrorState title="Could not load Work" description={errorMessage(query.error)} />
+  }
   return (
     <WorkListView
       isCreating={create.isPending}

--- a/apps/mobile/src/lib/app-lifecycle-context.ts
+++ b/apps/mobile/src/lib/app-lifecycle-context.ts
@@ -1,0 +1,19 @@
+import { useFocusEffect } from 'expo-router'
+import { createContext, useCallback, useContext, useState } from 'react'
+import { AppState } from 'react-native'
+
+export const AppActiveContext = createContext(AppState.currentState === 'active')
+
+export function useRouteIsActive(): boolean {
+  const isAppActive = useContext(AppActiveContext)
+  const [isRouteFocused, setIsRouteFocused] = useState(false)
+
+  useFocusEffect(
+    useCallback(() => {
+      setIsRouteFocused(true)
+      return () => setIsRouteFocused(false)
+    }, []),
+  )
+
+  return isAppActive && isRouteFocused
+}

--- a/apps/mobile/src/lib/app-lifecycle-provider.tsx
+++ b/apps/mobile/src/lib/app-lifecycle-provider.tsx
@@ -1,0 +1,36 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { focusManager } from '@tanstack/react-query'
+import type { PropsWithChildren } from 'react'
+import { useEffect, useState } from 'react'
+import type { AppStateStatus } from 'react-native'
+import { AppState } from 'react-native'
+
+import { AppActiveContext } from './app-lifecycle-context'
+
+interface AppLifecycleProviderProps extends PropsWithChildren {
+  queryClient: QueryClient
+}
+
+export function AppLifecycleProvider({ children, queryClient }: AppLifecycleProviderProps) {
+  const [isAppActive, setIsAppActive] = useState(AppState.currentState === 'active')
+
+  useEffect(() => {
+    const updateAppState = (state: AppStateStatus) => {
+      const active = state === 'active'
+      setIsAppActive(active)
+      focusManager.setFocused(active)
+      if (!active) {
+        void queryClient.cancelQueries()
+      }
+    }
+
+    updateAppState(AppState.currentState)
+    const subscription = AppState.addEventListener('change', updateAppState)
+    return () => {
+      subscription.remove()
+      focusManager.setFocused(undefined)
+    }
+  }, [queryClient])
+
+  return <AppActiveContext value={isAppActive}>{children}</AppActiveContext>
+}

--- a/apps/mobile/src/native/CradleMarkdownView.swift
+++ b/apps/mobile/src/native/CradleMarkdownView.swift
@@ -7,6 +7,8 @@ final class CradleMarkdownView: ExpoView {
   private var markdown = ""
   private var streaming = true
   private var lastReportedSize = CGSize.zero
+  private var needsRender = false
+  private var renderScheduled = false
 
   let onContentSizeChange = EventDispatcher()
 
@@ -16,7 +18,7 @@ final class CradleMarkdownView: ExpoView {
     var theme = MarkdownTheme.default
     theme.align(to: 14)
     markdownView.theme = theme
-    markdownView.throttleInterval = 1 / 20
+    markdownView.throttleInterval = 1 / 8
     markdownView.backgroundColor = .clear
 
     backgroundColor = .clear
@@ -50,19 +52,39 @@ final class CradleMarkdownView: ExpoView {
     markdownView.intrinsicContentSize
   }
 
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    if window != nil, needsRender {
+      scheduleRender()
+    }
+  }
+
   func setMarkdown(_ value: String) {
     guard value != markdown else { return }
     markdown = value
-    render()
+    scheduleRender()
   }
 
   func setStreaming(_ value: Bool) {
     guard value != streaming else { return }
     streaming = value
-    render()
+    scheduleRender()
+  }
+
+  private func scheduleRender() {
+    needsRender = true
+    guard window != nil, !renderScheduled else { return }
+    renderScheduled = true
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      self.renderScheduled = false
+      guard self.window != nil, self.needsRender else { return }
+      self.render()
+    }
   }
 
   private func render() {
+    needsRender = false
     let content = MarkdownContent(markdown: markdown, theme: markdownView.theme)
     if streaming {
       markdownView.setContent(content)


### PR DESCRIPTION
## Summary

- connect React Query and chat streaming to React Native foreground/background lifecycle
- stop queries, SSE, and polling when screens are not visible; make idle states event-driven
- reduce streaming update frequency and isolate chat renders to avoid rebuilding message history per token
- render lightweight text while Android messages stream, then parse Markdown once complete
- replace per-message hidden modals with a single activity sheet
- coalesce iOS native Markdown updates and skip off-screen rendering

## Root cause

Mounted Expo Router screens were treated as active even while blurred or backgrounded, so queries and streams kept waking JavaScript and the network. Chat streaming then amplified the cost by cloning and rerendering the full message list at 20 fps, including repeated Markdown work.

## Impact

The Mobile app now stops background work promptly, avoids idle polling, and substantially reduces CPU, network, bridge, and rendering activity during long chats and navigation.

## Validation

- Mobile typecheck
- Mobile lint
- chat stream tests (2/2)
- Android production bundle export
- iOS production bundle export
