### PR TITLE
fix(desktop): ship Linux updates and rpm

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -620,13 +620,17 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096
         run: pnpm --filter @cradle/desktop build
 
-      - name: Package Linux AppImage and deb
+      - name: Package Linux AppImage, deb, and rpm
         working-directory: apps/desktop
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
           CRADLE_DESKTOP_UPDATE_URL: ${{ needs.resolve.outputs.update_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm exec electron-builder --config electron-builder.mjs --linux AppImage deb --x64 --publish never
+        run: pnpm exec electron-builder --config electron-builder.mjs --linux AppImage deb rpm --x64 --publish never
+
+      - name: Verify Linux release artifacts and updater metadata
+        working-directory: apps/desktop
+        run: pnpm verify:linux-release
 
       - name: Upload artifacts
         uses: ./.github/actions/desktop-upload-artifacts
@@ -682,7 +686,7 @@ jobs:
           mkdir -p release-assets
 
           shopt -s globstar nullglob
-          for file in artifacts/**/*.{dmg,zip,exe,blockmap,yml,xml,AppImage,deb,delta}; do
+          for file in artifacts/**/*.{dmg,zip,exe,blockmap,yml,xml,AppImage,deb,rpm,delta}; do
             basename="$(basename "$file")"
             if [[ "$basename" == "builder-debug.yml" ]]; then
               continue
@@ -746,10 +750,12 @@ jobs:
             const exe = assets.find(f => f.endsWith('.exe'))
             const appImage = assets.find(f => f.endsWith('.AppImage'))
             const deb = assets.find(f => f.endsWith('.deb'))
+            const rpm = assets.find(f => f.endsWith('.rpm'))
             if (dmg) downloadLinks.push(`[macOS (arm64)](${releaseDownloadUrl}/${encodeURIComponent(dmg)})`)
             if (exe) downloadLinks.push(`[Windows (x64)](${releaseDownloadUrl}/${encodeURIComponent(exe)})`)
             if (appImage) downloadLinks.push(`[Linux AppImage (x64)](${releaseDownloadUrl}/${encodeURIComponent(appImage)})`)
             if (deb) downloadLinks.push(`[Linux deb (x64)](${releaseDownloadUrl}/${encodeURIComponent(deb)})`)
+            if (rpm) downloadLinks.push(`[Linux rpm (x64)](${releaseDownloadUrl}/${encodeURIComponent(rpm)})`)
 
             return template
               .replace(/\{\{title\}\}/g, title)
@@ -765,7 +771,7 @@ jobs:
               if (entry.isDirectory()) {
                 walk(entryPath, files)
               }
-              else if (entry.isFile() && entry.name.endsWith('.yml')) {
+              else if (entry.isFile() && /^latest(?:-[^.]+)?\.yml$/.test(entry.name)) {
                 files.push(entryPath)
               }
             }
@@ -925,6 +931,9 @@ jobs:
             fi
             if [ -f release-assets/latest.yml ]; then
               cp release-assets/latest.yml feed-assets/
+            fi
+            if [ -f release-assets/latest-linux.yml ]; then
+              cp release-assets/latest-linux.yml feed-assets/
             fi
             # Versioned mac zips for the feed channel.
             find release-assets -maxdepth 1 -type f \( -name 'Cradle-*-mac-*.zip' -o -name '*.delta' \) -exec cp {} feed-assets/ \;

--- a/apps/desktop/electron-builder.mjs
+++ b/apps/desktop/electron-builder.mjs
@@ -318,8 +318,10 @@ const config = {
     target: [
       'AppImage',
       'deb',
+      'rpm',
     ],
     category: 'Development',
+    syncDesktopName: true,
     artifactName: ['$', '{productName}-', '$', '{os}-', '$', '{arch}.', '$', '{ext}'].join(''),
   },
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "description": "Cradle desktop app",
+  "desktopName": "Cradle.desktop",
   "author": {
     "email": "wibus_wee@outlook.com",
     "name": "wibus-wee",
@@ -32,6 +33,7 @@
     "smoke:update": "node scripts/run-update-smoke.mjs",
     "dist:win": "pnpm build && electron-builder --config electron-builder.mjs --win",
     "dist:linux": "pnpm build && electron-builder --config electron-builder.mjs --linux",
+    "verify:linux-release": "node scripts/verify-linux-release.mjs",
     "typecheck": "pnpm --filter @cradle/plugin-sdk build && tsc --noEmit -p tsconfig.node.json"
   },
   "dependencies": {

--- a/apps/desktop/scripts/verify-linux-release.mjs
+++ b/apps/desktop/scripts/verify-linux-release.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import { createReadStream, existsSync, readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const desktopRoot = path.resolve(scriptDir, '..')
+const releaseDir = path.resolve(process.argv[2] ?? path.join(desktopRoot, 'release'))
+const manifestPath = path.join(releaseDir, 'latest-linux.yml')
+
+if (!existsSync(manifestPath)) {
+  throw new Error(`Missing Linux updater manifest: ${manifestPath}`)
+}
+
+const artifacts = readdirSync(releaseDir)
+const manifest = readFileSync(manifestPath, 'utf8')
+const requiredExtensions = ['.AppImage', '.deb', '.rpm']
+
+async function hashFile(file) {
+  const hash = createHash('sha512')
+  for await (const chunk of createReadStream(file)) {
+    hash.update(chunk)
+  }
+  return hash.digest('base64')
+}
+
+for (const extension of requiredExtensions) {
+  const names = artifacts.filter(name => name.endsWith(extension))
+  if (names.length !== 1) {
+    throw new Error(`Expected exactly one ${extension} artifact, found ${names.length}`)
+  }
+
+  const [name] = names
+  const artifactPath = path.join(releaseDir, name)
+  const sha512 = await hashFile(artifactPath)
+
+  if (!manifest.includes(name)) {
+    throw new Error(`latest-linux.yml does not reference ${name}`)
+  }
+  if (!manifest.includes(`sha512: ${sha512}`)) {
+    throw new Error(`latest-linux.yml does not contain the SHA-512 digest for ${name}`)
+  }
+}
+
+console.log(`Verified Linux updater manifest and ${requiredExtensions.length} release targets in ${releaseDir}`)

--- a/apps/desktop/src/main/README.md
+++ b/apps/desktop/src/main/README.md
@@ -32,11 +32,11 @@
 - `native-appshot-codex-assets.test.ts`：覆盖 Codex temp asset reader 的 root 边界、image 类型过滤、baseline inventory 过滤，以及 observer 对新产物的识别。
 - `native-appshot-target.ts`：拥有 desktop-owned Appshot research target synthesis，在没有 renderer composer frame 时生成 composer-like destination，避免 parity probe 退回到 source-equals-destination geometry。
 - `native-services.test.ts`：覆盖 Appshot parity target synthesis，确保 research probe 的默认 destination 不等于 frontmost window fallback。
-- `update-manager.ts`：拥有 renderer-visible Desktop Updates workflow；按平台编排 macOS Sparkle updater 或 Windows NSIS updater 的检查、下载、安装触发和状态事件。
-- `update-manager.test.ts`：覆盖 Desktop Updates 手动 Check/Download/Apply 编排、macOS Sparkle install、Windows NSIS updater apply、quit hook，以及没有 prepared update 时的 apply error。
+- `update-manager.ts`：拥有 renderer-visible Desktop Updates workflow；按平台编排 macOS Sparkle updater 或 Windows/Linux electron-updater 的检查、下载、安装触发和状态事件。
+- `update-manager.test.ts`：覆盖 Desktop Updates 手动 Check/Download/Apply 编排、macOS Sparkle install、Windows NSIS 与 Linux AppImage updater apply、目标 artifact 过滤、quit hook，以及没有 prepared update 时的 apply error。
 - `macos-sparkle-update-adapter.ts`：拥有 macOS `electron-sparkle-updater` / Sparkle bridge adapter，只负责 appcast 初始化、自动检查开关和原生检查 UI。
-- `update-feed.ts`：拥有 shared feed URL helpers（Windows generic root / macOS appcast 推导、public Ed key 读取）。
-- `windows-update-adapter.ts`：拥有 Windows `electron-updater` adapter，把 GitHub release feed 中的 `latest.yml`、NSIS installer 和 blockmap 投影到统一的 desktop update 状态模型。
+- `update-feed.ts`：拥有 shared feed URL helpers（Windows/Linux generic root / macOS appcast 推导、public Ed key 读取）。
+- `electron-updater-adapter.ts`：拥有 Windows/Linux `electron-updater` adapter，按当前 NSIS、AppImage、deb 或 rpm 安装类型筛选 release manifest，并把下载与安装状态投影到统一的 desktop update / Download Center 模型。
 - `mac-bridge-manager.ts`：拥有 desktop-owned `cradle-mac-bridge` 子进程生命周期、NDJSON request/response 协议、hotkey event 投影、显式 parity-test synthetic hotkey helper、dev/packaged binary 路径解析，以及缺少 binary 时的非阻塞状态。
 - `mac-bridge-protocol.ts`：定义 Electron main 与 Swift Mac Bridge 共享的协议 schema，包括 `bridge.status`、权限状态、双 Command hotkey 配置、显式 synthetic both-Command parity helper、frontmost window capture、显式 `targetWindow` capture、Appshot capture/frontmost context、display/window recording 和 hotkey event。
 - `mac-screenshot-sinks.ts`：拥有 Mac Bridge screenshot 的 post-capture sink，包括保留文件、写剪贴板和可选 CleanShot URL scheme handoff。CleanShot 不是 hard dependency。
@@ -63,20 +63,21 @@
 
 ## Desktop update ownership
 
-`update-manager.ts` owns the renderer-visible Desktop Updates workflow. The explicit user flow is Check, Download, then Restart on Windows. On macOS, Cradle only opens Sparkle's native update UI; Sparkle exclusively owns discovery, download, installation, relaunch, and their state.
+`update-manager.ts` owns the renderer-visible Desktop Updates workflow. The explicit user flow is Check, Download, then Restart on Windows and Linux. On macOS, Cradle only opens Sparkle's native update UI; Sparkle exclusively owns discovery, download, installation, relaunch, and their state.
 
-Updates are available only in packaged macOS and Windows builds with update feeds configured:
+Updates are available only in packaged macOS, Windows, and Linux builds with update feeds configured:
 
 - macOS: `CRADLE_DESKTOP_SPARKLE_APPCAST_URL` (or derive `appcast.xml` from `CRADLE_DESKTOP_UPDATE_URL`) plus `SPARKLE_ED_PUBLIC_KEY`
 - Windows: `CRADLE_DESKTOP_UPDATE_URL` generic feed root containing `latest.yml`
+- Linux: `CRADLE_DESKTOP_UPDATE_URL` generic feed root containing `latest-linux.yml`; electron-updater selects AppImage, deb, or rpm from the package type embedded by electron-builder
 
 macOS uses `electron-sparkle-updater` (Sparkle) with ad-hoc or Developer ID codesigning. Packaging re-signs the staged `.app` ad-hoc after pack so `generate_appcast` can verify the archive. Sparkle owns download/install/relaunch; Cradle does not stage zip replacement through Download Center on macOS. Release CI gives every channel an increasing numeric `CFBundleVersion` from the workflow run number for Sparkle comparison, while retaining the channel's human-facing version in `CFBundleShortVersionString`. `generate_appcast` projects those values to `sparkle:version` and `sparkle:shortVersionString`. The workflow uses `Innei/electron-sparkle-updater/action@v1` to sign the appcast, pull prior release zips as delta bases, and emit `appcast.xml` + optional `*.delta` patches (full zip remains the fallback when no base matches).
 
-Windows uses `electron-updater` with the NSIS target. `CRADLE_DESKTOP_UPDATE_URL` points at the feed directory containing `latest.yml`. Restart prepares the desktop runtime shutdown, then delegates quit/install/relaunch to the downloaded NSIS installer through `quitAndInstall`.
+Windows and Linux use `electron-updater`. `CRADLE_DESKTOP_UPDATE_URL` points at the feed directory containing `latest.yml` or `latest-linux.yml`. The adapter projects only the artifact for the current installation type into renderer and Download Center state, so a deb install never advertises the AppImage bytes (and vice versa). Restart prepares the desktop runtime shutdown, then delegates quit/install/relaunch to the downloaded NSIS, AppImage, deb, or rpm updater through `quitAndInstall`; deb/rpm installation may request system privileges through the host package manager.
 
 ## Desktop Download Center ownership
 
-`download-center/` is the only Electron-main owner for ordinary desktop artifact transfer state. It persists a compact, redacted task record under Electron user data, keeps URLs/headers and artifact paths private to the main process, broadcasts task views through `download-center:task-changed`, and exposes only list/get/cancel to preload. The web Download Center feature subscribes to that projection and to the server projection; it does not create another downloader or updater-progress bridge. Windows `electron-updater` remains the transport owner for NSIS, but reports its lifecycle into this task model. macOS Sparkle updates do not use Download Center for update bytes.
+`download-center/` is the only Electron-main owner for ordinary desktop artifact transfer state. It persists a compact, redacted task record under Electron user data, keeps URLs/headers and artifact paths private to the main process, broadcasts task views through `download-center:task-changed`, and exposes only list/get/cancel to preload. The web Download Center feature subscribes to that projection and to the server projection; it does not create another downloader or updater-progress bridge. Windows/Linux `electron-updater` remains the transport owner for NSIS/AppImage/deb/rpm, but reports its lifecycle into this task model. macOS Sparkle updates do not use Download Center for update bytes.
 
 ## Mac Bridge ownership
 

--- a/apps/desktop/src/main/electron-updater-adapter.ts
+++ b/apps/desktop/src/main/electron-updater-adapter.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
 import type {
   AppUpdater,
   CancellationToken,
@@ -14,35 +17,44 @@ import type {
   DesktopUpdateStatus,
 } from './update-types'
 
-export type WindowsDesktopUpdateAdapterOptions = {
+export type ElectronUpdaterPlatform = 'linux' | 'win32'
+export type ElectronUpdaterArtifactType = 'AppImage' | 'deb' | 'exe' | 'rpm'
+
+export type ElectronDesktopUpdateAdapterOptions = {
+  platform: ElectronUpdaterPlatform
+  artifactType?: ElectronUpdaterArtifactType
   updateFeedUrl: string
   updater?: AppUpdater
   onStatusChanged: (patch: Partial<DesktopUpdateStatus>) => void
   downloadCenter?: Pick<DesktopDownloadCenterService, 'beginExternal' | 'reportExternal'>
 }
 
-export class WindowsDesktopUpdateAdapter {
+export class ElectronDesktopUpdateAdapter {
   private readonly updater: AppUpdater
   private readonly onStatusChanged: (patch: Partial<DesktopUpdateStatus>) => void
   private downloadedFilePath: string | null = null
   private cancellationToken: CancellationToken | null = null
   private readonly updateFeedUrl: string
+  private readonly platform: ElectronUpdaterPlatform
+  private readonly artifactType: ElectronUpdaterArtifactType
   private downloadCenter: Pick<DesktopDownloadCenterService, 'beginExternal' | 'reportExternal'> | null
   private projectedTaskId: string | null = null
   private latestUpdateInfo: UpdateInfo | null = null
 
-  constructor(options: WindowsDesktopUpdateAdapterOptions) {
+  constructor(options: ElectronDesktopUpdateAdapterOptions) {
     this.updater = options.updater ?? autoUpdater
     this.onStatusChanged = options.onStatusChanged
     this.updateFeedUrl = options.updateFeedUrl
+    this.platform = options.platform
+    this.artifactType = options.artifactType ?? readArtifactType(options.platform)
     this.downloadCenter = options.downloadCenter ?? null
 
     this.updater.autoDownload = false
     this.updater.autoInstallOnAppQuit = false
     this.updater.allowPrerelease = true
-    this.updater.disableWebInstaller = true
+    this.updater.disableWebInstaller = options.platform === 'win32'
     this.updater.logger = console
-    this.updater.setFeedURL(resolveWindowsUpdaterFeedUrl(options.updateFeedUrl))
+    this.updater.setFeedURL(resolveElectronUpdaterFeedUrl(options.updateFeedUrl))
 
     this.updater.on('checking-for-update', () => {
       this.onStatusChanged({
@@ -55,7 +67,7 @@ export class WindowsDesktopUpdateAdapter {
       this.downloadedFilePath = null
       this.onStatusChanged({
         isCheckingForUpdates: false,
-        updateInfo: projectUpdateInfo(info),
+        updateInfo: projectUpdateInfo(info, this.artifactType),
         updateDownloaded: false,
       })
     })
@@ -110,7 +122,7 @@ export class WindowsDesktopUpdateAdapter {
       return null
     }
     this.latestUpdateInfo = result.updateInfo
-    return projectUpdateInfo(result.updateInfo)
+    return projectUpdateInfo(result.updateInfo, this.artifactType)
   }
 
   setDownloadCenter(downloadCenter: Pick<DesktopDownloadCenterService, 'beginExternal' | 'reportExternal'>): void {
@@ -120,7 +132,12 @@ export class WindowsDesktopUpdateAdapter {
   async downloadUpdate(): Promise<string | null> {
     if (this.downloadCenter && this.latestUpdateInfo) {
       const task = await this.downloadCenter.beginExternal(
-        createWindowsDownloadRequest(this.latestUpdateInfo, this.updateFeedUrl),
+        createDownloadRequest(
+          this.latestUpdateInfo,
+          this.updateFeedUrl,
+          this.platform,
+          this.artifactType,
+        ),
         () => this.cancelDownload(),
       )
       this.projectedTaskId = task.taskId
@@ -162,38 +179,71 @@ export class WindowsDesktopUpdateAdapter {
   }
 }
 
-function createWindowsDownloadRequest(info: UpdateInfo, updateFeedUrl: string) {
-  const file = info.files[0]
+function createDownloadRequest(
+  info: UpdateInfo,
+  updateFeedUrl: string,
+  platform: ElectronUpdaterPlatform,
+  artifactType: ElectronUpdaterArtifactType,
+) {
+  const file = info.files.find(candidate => hasArtifactExtension(candidate.url, artifactType))
   if (!file || !file.size || file.size <= 0) {
-    throw new Error('Windows update file size is required')
+    throw new Error(`${artifactType} update file with a valid size is required`)
   }
-  const url = new URL(file.url, resolveWindowsUpdaterFeedUrl(updateFeedUrl)).toString()
+  const artifactUrl = new URL(file.url, resolveElectronUpdaterFeedUrl(updateFeedUrl))
   return {
     owner: {
       namespace: 'desktop-update',
-      resourceType: 'windows-update',
+      resourceType: platform === 'linux' ? 'linux-update' : 'windows-update',
       resourceId: info.version,
       displayName: `Cradle ${info.version}`,
     },
-    fileName: file.url.split('/').at(-1) || `Cradle-${info.version}.exe`,
-    sources: [{ id: 'electron-updater', url }],
+    fileName: decodeURIComponent(path.posix.basename(artifactUrl.pathname)) || defaultArtifactName(info.version, artifactType),
+    sources: [{ id: 'electron-updater', url: artifactUrl.toString() }],
     integrity: file.sha512 ? { expectedBytes: file.size, checksum: { algorithm: 'sha512' as const, value: file.sha512 } } : { expectedBytes: file.size },
     maxBytes: file.size,
   }
 }
 
-export function resolveWindowsUpdaterFeedUrl(updateFeedUrl: string): string {
-  return resolveElectronUpdaterFeedUrl(updateFeedUrl)
+function defaultArtifactName(version: string, artifactType: ElectronUpdaterArtifactType): string {
+  return `Cradle-${version}.${artifactType}`
 }
 
-function projectUpdateInfo(info: UpdateInfo): DesktopUpdateInfo {
+function projectUpdateInfo(
+  info: UpdateInfo,
+  artifactType: ElectronUpdaterArtifactType,
+): DesktopUpdateInfo {
   return {
     version: info.version,
     releaseName: info.releaseName ?? null,
     releaseNotes: projectReleaseNotes(info.releaseNotes),
     releaseDate: info.releaseDate,
-    files: info.files.map(projectUpdateFile),
+    files: info.files
+      .filter(file => hasArtifactExtension(file.url, artifactType))
+      .map(projectUpdateFile),
   }
+}
+
+function hasArtifactExtension(url: string, artifactType: ElectronUpdaterArtifactType): boolean {
+  const pathname = new URL(url, 'https://updates.invalid/').pathname
+  return pathname.toLowerCase().endsWith(`.${artifactType.toLowerCase()}`)
+}
+
+function readArtifactType(platform: ElectronUpdaterPlatform): ElectronUpdaterArtifactType {
+  if (platform === 'win32') {
+    return 'exe'
+  }
+
+  try {
+    const packageType = readFileSync(path.join(process.resourcesPath, 'package-type'), 'utf8').trim()
+    if (packageType === 'deb' || packageType === 'rpm') {
+      return packageType
+    }
+  }
+  catch {
+    // AppImage builds intentionally do not contain electron-updater's package-type marker.
+  }
+
+  return 'AppImage'
 }
 
 function projectUpdateFile(file: UpdateInfo['files'][number]): DesktopUpdateFile {

--- a/apps/desktop/src/main/update-manager.test.ts
+++ b/apps/desktop/src/main/update-manager.test.ts
@@ -246,6 +246,57 @@ describe('desktopUpdateManager', () => {
     expect(electronUpdaterMocks.autoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true)
   })
 
+  it('checks, downloads, and applies Linux AppImage updates through electron-updater', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    const updateInfo = {
+      version: '2.0.0',
+      releaseName: 'Linux 2.0.0',
+      releaseNotes: 'linux notes',
+      releaseDate: '2026-08-09T00:00:00.000Z',
+      files: [
+        { url: 'Cradle-linux-x64.AppImage', size: 42, sha512: 'appimage-sha' },
+        { url: 'Cradle-linux-x64.deb', size: 43, sha512: 'deb-sha' },
+        { url: 'Cradle-linux-x64.rpm', size: 44, sha512: 'rpm-sha' },
+      ],
+    }
+    electronUpdaterMocks.autoUpdater.checkForUpdates.mockImplementation(async () => {
+      electronUpdaterMocks.autoUpdater.emit('update-available', updateInfo)
+      return { isUpdateAvailable: true, updateInfo }
+    })
+    electronUpdaterMocks.autoUpdater.downloadUpdate.mockImplementation(async () => {
+      electronUpdaterMocks.autoUpdater.emit('update-downloaded', {
+        ...updateInfo,
+        downloadedFile: '/tmp/Cradle-linux-x64.AppImage',
+      })
+      return ['/tmp/Cradle-linux-x64.AppImage']
+    })
+
+    const prepareQuitForUpdate = vi.fn(async () => undefined)
+    const { DesktopUpdateManager } = await import('./update-manager')
+    const manager = new DesktopUpdateManager({
+      updateFeedUrl: 'https://github.com/wibus-wee/cradle-app/releases/download/feed-dev/',
+      prepareQuitForUpdate,
+    })
+
+    await expect(manager.checkForUpdates()).resolves.toMatchObject({
+      unsupported: false,
+      provider: 'electron-updater',
+      updateInfo: {
+        version: '2.0.0',
+        files: [{ url: 'Cradle-linux-x64.AppImage', size: 42 }],
+      },
+    })
+    expect(electronUpdaterMocks.autoUpdater.disableWebInstaller).toBe(false)
+    expect(electronUpdaterMocks.autoUpdater.setFeedURL).toHaveBeenCalledWith(
+      'https://github.com/wibus-wee/cradle-app/releases/download/feed-dev/',
+    )
+
+    await expect(manager.downloadUpdate()).resolves.toMatchObject({ updateDownloaded: true })
+    await manager.applyUpdate()
+    expect(prepareQuitForUpdate).toHaveBeenCalled()
+    expect(electronUpdaterMocks.autoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true)
+  })
+
   it('reports an error when apply is requested without a prepared Windows update', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     const { DesktopUpdateManager } = await import('./update-manager')

--- a/apps/desktop/src/main/update-manager.ts
+++ b/apps/desktop/src/main/update-manager.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events'
 import { app } from 'electron'
 
 import type { DesktopDownloadCenterService } from './download-center'
+import { ElectronDesktopUpdateAdapter } from './electron-updater-adapter'
 import { MacOSSparkleUpdateAdapter } from './macos-sparkle-update-adapter'
 import {
   readSparkleAppcastUrl,
@@ -14,7 +15,6 @@ import type {
   DesktopUpdateStatus,
 } from './update-types'
 import { readErrorMessage } from './update-types'
-import { WindowsDesktopUpdateAdapter } from './windows-update-adapter'
 
 export type {
   DesktopUpdateFile,
@@ -37,9 +37,9 @@ export type DesktopUpdateManagerOptions = {
   updateFeedUrl?: string | null
   preferences?: Partial<DesktopUpdatePreferences>
   prepareQuitForUpdate?: () => void | Promise<void>
-  downloadCenter?: Pick<DesktopDownloadCenterService, 'execute' | 'release'>
+  downloadCenter?: Pick<DesktopDownloadCenterService, 'beginExternal' | 'reportExternal'>
   sparkleAdapter?: MacOSSparkleUpdateAdapter
-  windowsUpdater?: WindowsDesktopUpdateAdapter
+  electronUpdater?: ElectronDesktopUpdateAdapter
 }
 
 type CheckForUpdatesOptions = {
@@ -73,14 +73,13 @@ export class DesktopUpdateManager {
   private readonly events = new EventEmitter()
   private readonly prepareQuitForUpdate: (() => void | Promise<void>) | null
   private readonly sparkleAdapter: MacOSSparkleUpdateAdapter | null
-  private readonly windowsUpdater: WindowsDesktopUpdateAdapter | null
+  private readonly electronUpdater: ElectronDesktopUpdateAdapter | null
   private preferences: DesktopUpdatePreferences
   private statusSnapshot: DesktopUpdateStatus
   private backgroundTimer: NodeJS.Timeout | null = null
   private backgroundCheckRunning = false
   private downloadInProgress = false
   private sparkleReadyPromise: Promise<void> | null = null
-  private downloadCenter: Pick<DesktopDownloadCenterService, 'execute' | 'release'> | null
 
   constructor(options: DesktopUpdateManagerOptions = {}) {
     const currentVersion = app.getVersion()
@@ -89,16 +88,17 @@ export class DesktopUpdateManager {
     const updatePlatform = unsupportedReason ? null : readUpdatePlatform()
 
     this.prepareQuitForUpdate = options.prepareQuitForUpdate ?? null
-    this.downloadCenter = options.downloadCenter ?? null
     this.sparkleAdapter = updatePlatform === 'darwin'
       ? (options.sparkleAdapter ?? new MacOSSparkleUpdateAdapter({
           updateFeedUrl,
         }))
       : null
-    this.windowsUpdater = updatePlatform === 'win32'
-      ? (options.windowsUpdater ?? new WindowsDesktopUpdateAdapter({
+    this.electronUpdater = updatePlatform === 'win32' || updatePlatform === 'linux'
+      ? (options.electronUpdater ?? new ElectronDesktopUpdateAdapter({
+          platform: updatePlatform,
           updateFeedUrl: updateFeedUrl!,
           onStatusChanged: patch => this.setStatus(patch),
+          downloadCenter: options.downloadCenter,
         }))
       : null
     this.preferences = {
@@ -111,7 +111,7 @@ export class DesktopUpdateManager {
         ? null
         : updatePlatform === 'darwin'
           ? 'sparkle'
-          : updatePlatform === 'win32'
+          : updatePlatform === 'win32' || updatePlatform === 'linux'
             ? 'electron-updater'
             : null,
       currentVersion,
@@ -131,9 +131,8 @@ export class DesktopUpdateManager {
     return this.statusSnapshot
   }
 
-  setDownloadCenter(downloadCenter: Pick<DesktopDownloadCenterService, 'execute' | 'release' | 'beginExternal' | 'reportExternal'>): void {
-    this.downloadCenter = downloadCenter
-    this.windowsUpdater?.setDownloadCenter(downloadCenter)
+  setDownloadCenter(downloadCenter: Pick<DesktopDownloadCenterService, 'beginExternal' | 'reportExternal'>): void {
+    this.electronUpdater?.setDownloadCenter(downloadCenter)
   }
 
   /**
@@ -171,7 +170,7 @@ export class DesktopUpdateManager {
 
   startBackgroundChecks(): void {
     if (
-      (!this.sparkleAdapter && !this.windowsUpdater)
+      (!this.sparkleAdapter && !this.electronUpdater)
       || this.backgroundTimer
       || this.backgroundCheckRunning
       || !this.preferences.autoCheckForUpdates
@@ -238,8 +237,8 @@ export class DesktopUpdateManager {
   }
 
   async checkForUpdates(options: CheckForUpdatesOptions = {}): Promise<DesktopUpdateStatus> {
-    if (this.windowsUpdater) {
-      return await this.checkForWindowsUpdates(options)
+    if (this.electronUpdater) {
+      return await this.checkForElectronUpdates(options)
     }
 
     if (this.sparkleAdapter) {
@@ -250,8 +249,8 @@ export class DesktopUpdateManager {
   }
 
   async downloadUpdate(): Promise<DesktopUpdateStatus> {
-    if (this.windowsUpdater) {
-      return await this.downloadWindowsUpdate()
+    if (this.electronUpdater) {
+      return await this.downloadElectronUpdate()
     }
 
     if (this.sparkleAdapter) {
@@ -263,8 +262,8 @@ export class DesktopUpdateManager {
   }
 
   async applyUpdate(): Promise<void> {
-    if (this.windowsUpdater) {
-      await this.applyWindowsUpdate()
+    if (this.electronUpdater) {
+      await this.applyElectronUpdate()
       return
     }
 
@@ -346,7 +345,7 @@ export class DesktopUpdateManager {
     this.events.emit('statusChanged', this.statusSnapshot)
   }
 
-  private async checkForWindowsUpdates(options: CheckForUpdatesOptions): Promise<DesktopUpdateStatus> {
+  private async checkForElectronUpdates(options: CheckForUpdatesOptions): Promise<DesktopUpdateStatus> {
     if (this.statusSnapshot.isCheckingForUpdates || this.downloadInProgress || this.statusSnapshot.isPreparingUpdate) {
       return this.statusSnapshot
     }
@@ -357,7 +356,7 @@ export class DesktopUpdateManager {
     })
 
     try {
-      const updateInfo = await retryWithBackoff(() => this.windowsUpdater!.checkForUpdates())
+      const updateInfo = await retryWithBackoff(() => this.electronUpdater!.checkForUpdates())
       this.setStatus({
         isCheckingForUpdates: false,
         updateInfo,
@@ -376,7 +375,7 @@ export class DesktopUpdateManager {
     return this.statusSnapshot
   }
 
-  private async downloadWindowsUpdate(): Promise<DesktopUpdateStatus> {
+  private async downloadElectronUpdate(): Promise<DesktopUpdateStatus> {
     if (this.downloadInProgress || !this.statusSnapshot.updateInfo) {
       return this.statusSnapshot
     }
@@ -385,7 +384,7 @@ export class DesktopUpdateManager {
     this.setStatus({ isPreparingUpdate: false, updateDownloaded: false, errorMessage: null })
 
     try {
-      await this.windowsUpdater!.downloadUpdate()
+      await this.electronUpdater!.downloadUpdate()
       this.setStatus({
         isPreparingUpdate: false,
         updateDownloaded: true,
@@ -405,7 +404,7 @@ export class DesktopUpdateManager {
     return this.statusSnapshot
   }
 
-  private async applyWindowsUpdate(): Promise<void> {
+  private async applyElectronUpdate(): Promise<void> {
     if (!this.statusSnapshot.updateDownloaded) {
       this.setStatus({
         errorMessage: 'No prepared desktop update is available',
@@ -421,7 +420,7 @@ export class DesktopUpdateManager {
 
     try {
       await this.prepareQuitForUpdate()
-      this.windowsUpdater!.applyUpdate()
+      this.electronUpdater!.applyUpdate()
     }
     catch (error) {
       this.setStatus({
@@ -432,8 +431,8 @@ export class DesktopUpdateManager {
 }
 
 function readUnsupportedReason(updateFeedUrl: string | null): string | null {
-  if (process.platform !== 'darwin' && process.platform !== 'win32') {
-    return 'Desktop self-updates are only available on macOS and Windows'
+  if (process.platform !== 'darwin' && process.platform !== 'linux' && process.platform !== 'win32') {
+    return `Desktop self-updates are unavailable on ${process.platform}`
   }
   if (process.platform === 'darwin') {
     if (!readSparkleAppcastUrl(updateFeedUrl)) {
@@ -449,8 +448,8 @@ function readUnsupportedReason(updateFeedUrl: string | null): string | null {
   return null
 }
 
-function readUpdatePlatform(): 'darwin' | 'win32' | null {
-  if (process.platform === 'darwin' || process.platform === 'win32') {
+function readUpdatePlatform(): 'darwin' | 'linux' | 'win32' | null {
+  if (process.platform === 'darwin' || process.platform === 'linux' || process.platform === 'win32') {
     return process.platform
   }
   return null

--- a/apps/server/src/modules/chat-runtime/pending-user-input.test.ts
+++ b/apps/server/src/modules/chat-runtime/pending-user-input.test.ts
@@ -82,6 +82,28 @@ describe('pending runtime user input', () => {
           }),
         },
       },
+      {
+        runId: 'run-pending-user-input-1',
+        chunk: {
+          type: 'data-cradle-runtime-user-input-request',
+          transient: true,
+          data: {
+            sessionId: 'session-pending-user-input-1',
+            requestId: 'request-1',
+            questions: [
+              {
+                id: 'scope',
+                header: 'Scope',
+                question: 'Which scope should I use?',
+                isOther: false,
+                isSecret: false,
+                multiSelect: false,
+                options: [{ label: 'Small', description: 'Limit the change' }],
+              },
+            ],
+          },
+        },
+      },
     ])
     expect(recordedEvents).toMatchObject([
       {

--- a/apps/web/src/components/layout/sidebar-update-button.tsx
+++ b/apps/web/src/components/layout/sidebar-update-button.tsx
@@ -62,7 +62,11 @@ export function SidebarUpdateButton({ collapsed }: { collapsed: boolean }) {
 
   const updateDownload = downloadTasks.find(task => task.scope === 'desktop'
     && task.owner.namespace === 'desktop-update'
-    && (task.owner.resourceType === 'macos-update' || task.owner.resourceType === 'windows-update')
+    && (
+      task.owner.resourceType === 'macos-update'
+      || task.owner.resourceType === 'windows-update'
+      || task.owner.resourceType === 'linux-update'
+    )
     && isActiveDownload(task))
   const hasUpdateNotice = !!status.updateInfo
     || !!updateDownload

--- a/apps/web/src/features/settings/desktop-update-settings.tsx
+++ b/apps/web/src/features/settings/desktop-update-settings.tsx
@@ -49,7 +49,11 @@ export function DesktopUpdateSettings() {
 
   const updateDownload = downloadTasks.find(task => task.scope === 'desktop'
     && task.owner.namespace === 'desktop-update'
-    && (task.owner.resourceType === 'macos-update' || task.owner.resourceType === 'windows-update')
+    && (
+      task.owner.resourceType === 'macos-update'
+      || task.owner.resourceType === 'windows-update'
+      || task.owner.resourceType === 'linux-update'
+    )
     && isActiveDownload(task)) ?? null
   const busy = loading
     || status.isCheckingForUpdates


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Linux desktop releases were only partially packaged and could not self-update: the update manager rejected Linux, the release workflow omitted RPM and did not publish `latest-linux.yml` to the dev feed, and a multi-artifact Linux manifest could cause the updater UI to treat AppImage, DEB, and RPM as one download.

After this branch was rebased, base commit `18ec2535` (#142) also published a new runtime user-input request event without updating its adjacent test expectation, causing both Server Tests and the aggregate Unit Tests to fail on the current base.

## Summary

- enable `electron-updater` on Linux and select AppImage, DEB, or RPM from the installed package type
- expose only the matching Linux artifact to the renderer and Download Center
- build and publish AppImage, DEB, and RPM packages plus Linux updater metadata
- align the Linux desktop filename with Electron's window class
- add a release-artifact verifier for package presence and SHA-512 manifest coverage
- add Linux updater tests and include Linux update resources in the web UI
- update the pre-existing pending-user-input test to cover the request event introduced by base commit `18ec2535`

## Test plan

- `./node_modules/.bin/vitest apps/desktop/src/main/update-manager.test.ts --run` — 7 tests passed
- `./node_modules/.bin/vitest apps/server/src/modules/chat-runtime/pending-user-input.test.ts --run` — 3 tests passed
- `./node_modules/.bin/tsc --noEmit -p apps/desktop/tsconfig.node.json` — passed
- `./node_modules/.bin/tsc --noEmit -p apps/web/tsconfig.json` — passed
- ESLint on changed TypeScript/TSX/MJS files — passed
- parsed `.github/workflows/release-desktop.yml` with PyYAML — passed
- `git diff --check origin/main...HEAD` — passed
- Electron Vite main/preload/renderer production build — passed
- full local package generation was blocked after the build by the Work sandbox's native-module cache permissions and disk limit; CI now runs `verify:linux-release` after packaging to require exactly one AppImage, DEB, RPM, and matching `latest-linux.yml` hashes

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is denied or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** N/A — not included without explicit context-sharing consent
- **Constraints / non-goals:** N/A
- **Decision rationale:** N/A
- **Deliberately not done:** N/A
- **Unknowns / confidence:** Full packaging is delegated to CI because the local Work sandbox could not complete Electron's native-module rebuild.

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->
