### PR TITLE
refactor: remove legacy API boundaries

### DIFF
--- a/apps/desktop/src/main/ipc-devtool-store.ts
+++ b/apps/desktop/src/main/ipc-devtool-store.ts
@@ -1,7 +1,3 @@
-// Input: Electron WebContents, shared IPC observed event types
-// Output: IpcDevtoolStore ring buffer with live subscriber fan-out
-// Position: Main-process backend store for IPC devtool consumers
-
 import type { AcpDevtoolEvent, IpcObservedEvent } from '@cradle/ipc'
 import type { WebContents } from 'electron'
 

--- a/apps/desktop/src/main/ipc-devtool.ts
+++ b/apps/desktop/src/main/ipc-devtool.ts
@@ -1,7 +1,3 @@
-// Input: @cradle/ipc observer registration, Electron ipcMain/WebContents, IpcDevtoolStore
-// Output: Shared main-process IPC devtool backend — observer wiring, IPC handler registration
-// Position: Main-process integration point that connects IPC instrumentation to the devtool window
-
 import type { IpcObservedEvent } from '@cradle/ipc'
 import { setIpcObserver } from '@cradle/ipc'
 import type { WebContents } from 'electron'

--- a/apps/desktop/src/main/notification-center-manager.ts
+++ b/apps/desktop/src/main/notification-center-manager.ts
@@ -45,6 +45,25 @@ interface NativeNotification {
   on: (eventName: 'reply' | 'click' | 'close', listener: (event: unknown, reply?: string) => void) => void
 }
 
+function createNativeNotification(options: Electron.NotificationConstructorOptions): NativeNotification {
+  const notification = new Notification(options)
+  return {
+    show: () => notification.show(),
+    close: () => notification.close(),
+    on(eventName, listener) {
+      if (eventName === 'reply') {
+        notification.on('reply', (event, reply) => listener(event, reply))
+        return
+      }
+      if (eventName === 'click') {
+        notification.on('click', event => listener(event))
+        return
+      }
+      notification.on('close', event => listener(event))
+    },
+  }
+}
+
 interface NotificationCenterManagerOptions {
   serverUrl: string
   chatStreamBroker: ChatStreamBroker
@@ -83,8 +102,7 @@ export class NotificationCenterManager {
     this.chatStreamBroker = options.chatStreamBroker
     this.getMainWindow = options.getMainWindow ?? (() => null)
     this.fetchFn = options.fetchFn ?? fetch
-    this.createNotification = options.createNotification
-      ?? (notificationOptions => new Notification(notificationOptions) as unknown as NativeNotification)
+    this.createNotification = options.createNotification ?? createNativeNotification
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
     this.nowSeconds = options.nowSeconds ?? (() => Math.floor(Date.now() / 1000))
     this.platform = options.platform ?? process.platform

--- a/apps/desktop/src/preload/browser-annotation-runtime.ts
+++ b/apps/desktop/src/preload/browser-annotation-runtime.ts
@@ -4817,13 +4817,13 @@ class BrowserAnnotationRuntime {
     if (!fiberKey) {
       return null
     }
-    const value = (element as unknown as Record<string, unknown>)[fiberKey]
+    const value = Object.getOwnPropertyDescriptor(element, fiberKey)?.value
     if (!fiberKey.startsWith('__reactProps$')) {
       return value
     }
     const fallbackKey = keys.find(key =>
       key.startsWith('__reactFiber$') || key.startsWith('__reactInternalInstance$'))
-    return fallbackKey ? (element as unknown as Record<string, unknown>)[fallbackKey] : null
+    return fallbackKey ? Object.getOwnPropertyDescriptor(element, fallbackKey)?.value : null
   }
 
   private reactComponentName(type: unknown): string | null {

--- a/apps/mobile/src/api-gen/types.gen.ts
+++ b/apps/mobile/src/api-gen/types.gen.ts
@@ -2438,33 +2438,6 @@ export type GetProviderTargetsByProviderTargetIdCodexAccountDiagnosticsResponses
             planType: string | null;
             requiresOpenaiAuth: boolean | null;
         } | null;
-        rateLimits: {
-            limitId: string | null;
-            limitName: string | null;
-            primary: {
-                usedPercent: number;
-                windowDurationMins: number | null;
-                resetsAt: number | null;
-            } | null;
-            secondary: {
-                usedPercent: number;
-                windowDurationMins: number | null;
-                resetsAt: number | null;
-            } | null;
-            credits: {
-                hasCredits: boolean;
-                unlimited: boolean;
-                balance: string | null;
-            } | null;
-            individualLimit: {
-                limit: string;
-                used: string;
-                remainingPercent: number;
-                resetsAt: number;
-            } | null;
-            planType: string | null;
-            rateLimitReachedType: string | null;
-        } | null;
         rateLimitsByLimitId: {
             [key: string]: {
                 limitId: string | null;

--- a/apps/server/scripts/prepare-desktop-plugins.mjs
+++ b/apps/server/scripts/prepare-desktop-plugins.mjs
@@ -1,9 +1,4 @@
 #!/usr/bin/env node
-/**
- * Output: Creates apps/server/dist/desktop-plugins as the first-party plugin artifact consumed by Cradle desktop packaging.
- * Input: plugins/* package manifests and built plugin dist directories.
- * Position: Server-owned desktop plugin packaging boundary; desktop includes this artifact without enumerating plugin packages.
- */
 import { spawnSync } from 'node:child_process'
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { builtinModules } from 'node:module'

--- a/apps/server/scripts/prepare-desktop-runtime.mjs
+++ b/apps/server/scripts/prepare-desktop-runtime.mjs
@@ -1,9 +1,4 @@
 #!/usr/bin/env node
-/**
- * Output: Creates apps/server/dist/desktop-runtime as the server-owned artifact consumed by Cradle desktop packaging.
- * Input: apps/server/dist from Vite, apps/server/package.json, and the workspace pnpm lockfile.
- * Position: Server runtime packaging boundary; desktop includes this artifact without installing or copying server internals.
- */
 import { spawnSync } from 'node:child_process'
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'

--- a/apps/server/scripts/rebuild-electron-runtime.mjs
+++ b/apps/server/scripts/rebuild-electron-runtime.mjs
@@ -1,9 +1,4 @@
 #!/usr/bin/env node
-/**
- * Output: Rebuilds bundled server native dependencies for Cradle desktop's Electron runtime.
- * Input: apps/server/dist/desktop-runtime plus the target Electron version from CRADLE_ELECTRON_VERSION or apps/desktop/package.json.
- * Position: Server-owned desktop runtime artifact preparation; desktop packaging consumes the artifact without mutating it.
- */
 import { spawnSync } from 'node:child_process'
 import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'

--- a/apps/server/src/helpers/agent-runtime-config.ts
+++ b/apps/server/src/helpers/agent-runtime-config.ts
@@ -7,14 +7,6 @@ export const cliTuiLaunchSpecSchema = z.object({
   env: z.record(z.string(), z.string()).optional(),
 })
 
-export const codexCliSessionBindingSchema = z.object({
-  sessionId: z.uuid(),
-  capturedAt: z.number().int().positive(),
-  startedAt: z.number().int().positive(),
-  workspacePath: z.string().trim().min(1),
-  sourcePath: z.string().trim().min(1),
-})
-
 export const providerSessionBindingSchema = z.object({
   source: z.string().trim().min(1),
   agent: z.string().trim().min(1),
@@ -36,8 +28,6 @@ const sessionRuntimeConfigSchema = z.object({
   cliTuiLaunch: cliTuiLaunchSpecSchema.optional(),
   /** Generalized provider conversation binding for CLI TUI resume. */
   providerSession: providerSessionBindingSchema.optional(),
-  /** @deprecated Prefer providerSession; still written for Codex capture compat. */
-  codexCliSession: codexCliSessionBindingSchema.optional(),
 }).passthrough()
 
 export const AgentRuntimeConfigJsonSchema = z.union([
@@ -53,7 +43,6 @@ export const SessionRuntimeConfigJsonSchema = z.union([
 ]).pipe(sessionRuntimeConfigSchema)
 
 export type CliTuiLaunchSpec = z.infer<typeof cliTuiLaunchSpecSchema>
-export type CodexCliSessionBinding = z.infer<typeof codexCliSessionBindingSchema>
 export type ProviderSessionBinding = z.infer<typeof providerSessionBindingSchema>
 export type AgentRuntimeConfig = z.infer<typeof agentRuntimeConfigSchema>
 export type SessionRuntimeConfig = z.infer<typeof sessionRuntimeConfigSchema>
@@ -73,7 +62,6 @@ export function readTrustedSessionRuntimeConfig(raw?: string | null): SessionRun
 export function buildSessionRuntimeConfigJson(input: {
   cliTuiLaunch?: CliTuiLaunchSpec | null
   providerSession?: ProviderSessionBinding | null
-  codexCliSession?: CodexCliSessionBinding | null
 }): string {
   const payload: Record<string, unknown> = {}
   if (input.cliTuiLaunch) {
@@ -86,9 +74,6 @@ export function buildSessionRuntimeConfigJson(input: {
   }
   if (input.providerSession) {
     payload.providerSession = input.providerSession
-  }
-  if (input.codexCliSession) {
-    payload.codexCliSession = input.codexCliSession
   }
   return JSON.stringify(payload)
 }
@@ -103,36 +88,5 @@ export function writeProviderSessionBindingToSessionConfig(input: {
     providerSession: input.binding,
   }
 
-  // Keep legacy Codex field in sync so older readers still resume.
-  if (input.binding.agent === 'codex' && input.binding.kind === 'id') {
-    payload.codexCliSession = {
-      sessionId: input.binding.value,
-      capturedAt: input.binding.capturedAt,
-      startedAt: input.binding.startedAt,
-      workspacePath: input.binding.workspacePath,
-      sourcePath: input.binding.sourcePath ?? input.binding.value,
-    } satisfies CodexCliSessionBinding
-  }
-
   return JSON.stringify(payload)
-}
-
-export function writeCodexCliSessionBindingToSessionConfig(input: {
-  configJson?: string | null
-  binding: CodexCliSessionBinding
-}): string {
-  return writeProviderSessionBindingToSessionConfig({
-    configJson: input.configJson,
-    binding: {
-      source: 'cradle:codex',
-      agent: 'codex',
-      kind: 'id',
-      value: input.binding.sessionId,
-      workspacePath: input.binding.workspacePath,
-      capturedAt: input.binding.capturedAt,
-      startedAt: input.binding.startedAt,
-      sourcePath: input.binding.sourcePath,
-      confidence: 'exact',
-    },
-  })
 }

--- a/apps/server/src/modules/chat-runtime-providers/acp/metadata.ts
+++ b/apps/server/src/modules/chat-runtime-providers/acp/metadata.ts
@@ -1,9 +1,3 @@
-/**
- * Output: ACP Chat runtime identity and static capabilities.
- * Input: no runtime data.
- * Position: ACP provider package metadata owner.
- */
-
 import type {
   ChatRuntimeCapabilities,
   ChatRuntimeMetadata,

--- a/apps/server/src/modules/chat-runtime-providers/async-event-queue.ts
+++ b/apps/server/src/modules/chat-runtime-providers/async-event-queue.ts
@@ -1,9 +1,3 @@
-/**
- * Output: provider-agnostic async FIFO queue for runtime adapter event streams.
- * Input: pushed events, close/fail signals, and optional abort signals for waiters.
- * Position: shared chat-runtime-providers infrastructure with no provider protocol semantics.
- */
-
 export class AsyncEventQueue<TEvent> implements AsyncIterable<TEvent> {
   private readonly buffered: TEvent[] = []
   private readonly waiters: Array<{

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/async-input-stream.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/async-input-stream.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Claude Agent SDK user-message async input stream.
- * Input: provider-projected Claude Agent user content and close signals.
- * Position: Claude Agent provider package stream primitive built on shared provider infrastructure.
- */
-
 import { randomUUID } from 'node:crypto'
 
 import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk'

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/event-to-chunk-mapper.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/event-to-chunk-mapper.ts
@@ -1,9 +1,3 @@
-/**
- * Output: AI SDK UIMessageChunk events projected from Claude Agent SDK messages.
- * Input: Claude Agent SDK stream messages, tool-use snapshots, result messages, and subagent parent tool ids.
- * Position: Claude Agent provider package event mapper between SDK-native events and Chat Runtime chunks.
- */
-
 import { randomUUID } from 'node:crypto'
 
 import type {

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/input-projector.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/input-projector.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Claude Agent SDK user content and query options projected from Chat Runtime input.
- * Input: Cradle UIMessage turns, history, provider target config, workspace snapshot, and ProviderContext.
- * Position: Claude Agent provider package boundary from Cradle runtime contracts to SDK-native input.
- */
-
 import type { McpServerConfig, Options } from '@anthropic-ai/claude-agent-sdk'
 import type { UIMessage } from 'ai'
 

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/integration/harness.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/integration/harness.ts
@@ -152,7 +152,7 @@ export async function createClaudeAgentIntegrationHarness(input: {
       }
       return chunks
     },
-    activeQueryCount: () => (provider as unknown as { activeQueries: Map<string, unknown> }).activeQueries.size,
+    activeQueryCount: () => provider.getActiveQueryCount(),
     async cleanup(): Promise<void> {
       await provider.dispose()
       if (ownsWorkspace) {

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/metadata.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/metadata.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Claude Agent runtime identity, static capabilities, and presentation projection.
- * Input: Claude Agent SDK slash command metadata.
- * Position: Claude Agent provider package metadata owner.
- */
-
 import type { SlashCommand } from '@anthropic-ai/claude-agent-sdk'
 
 import type {

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/permission-bridge.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/permission-bridge.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Claude Agent SDK permission callback decisions.
- * Input: SDK tool permission requests and Cradle runtime pending-input hooks.
- * Position: Provider-owned bridge between SDK canUseTool and Chat Runtime semantics.
- */
-
 import type { CanUseTool, HookCallback, Options, PermissionResult } from '@anthropic-ai/claude-agent-sdk'
 
 import type { GetCapabilitiesInput, ProviderContext, RuntimeSettings, StreamTurnInput } from '../../chat-runtime/runtime-provider-types'

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/provider.ts
@@ -221,6 +221,10 @@ export class ClaudeAgentProvider implements ChatRuntime {
     return this.presentation.getDraftPresentation()
   }
 
+  getActiveQueryCount(): number {
+    return this.activeQueries.size
+  }
+
   async getUiSlotStates(input: GetUiSlotStatesInput): Promise<RuntimeUiSlotState[]> {
     return await this.presentation.getUiSlotStates(input)
   }

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/state-projector.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/state-projector.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Claude Agent provider snapshot projections for session-local runtime state.
- * Input: workspace provider snapshots and requested model ids.
- * Position: Claude Agent provider package owner for providerStateSnapshot updates.
- */
-
 import type { AccountInfo, SDKAuthStatusMessage, SDKRateLimitInfo } from '@anthropic-ai/claude-agent-sdk'
 
 import { readObjectRecord as readRecord } from '../../../helpers/json-record'

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/types.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/types.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Claude Agent provider-private types shared by package modules.
- * Input: Claude Agent SDK message content and AI SDK UIMessage parts.
- * Position: Claude Agent provider package type boundary.
- */
-
 import type { SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk'
 import type { UIMessage } from 'ai'
 

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/user-question.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/user-question.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Claude Agent AskUserQuestion tool input/output projected to Runtime user input.
- * Input: Claude Agent SDK AskUserQuestion tool payloads and Runtime user input answers.
- * Position: Claude Agent provider-owned bridge between SDK-native question tools and Chat Runtime pending input.
- */
-
 import type { AskUserQuestionInput, AskUserQuestionOutput } from '@anthropic-ai/claude-agent-sdk/sdk-tools'
 
 import type { RuntimeUserInputQuestion } from '../../chat-runtime/runtime-provider-types'

--- a/apps/server/src/modules/chat-runtime-providers/claude-agent/workflow/declaration-instrumenter.ts
+++ b/apps/server/src/modules/chat-runtime-providers/claude-agent/workflow/declaration-instrumenter.ts
@@ -28,7 +28,7 @@ export function instrumentClaudeWorkflowScript(script: string): InstrumentedClau
     sourceType: 'module',
     allowAwaitOutsideFunction: true,
     allowReturnOutsideFunction: true,
-  }) as unknown as SyntaxNode
+  })
   const insertions: Insertion[] = []
   const branchIds = new Set<string>()
   let insertionOrder = 0

--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/account-diagnostics.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/account-diagnostics.test.ts
@@ -135,8 +135,8 @@ describe('codex account diagnostics', () => {
       planType: 'pro',
       requiresOpenaiAuth: false,
     })
-    expect(diagnostics.rateLimits?.primary?.usedPercent).toBe(40)
-    expect(diagnostics.rateLimits?.individualLimit).toEqual({
+    expect(diagnostics.rateLimitsByLimitId?.codex?.primary?.usedPercent).toBe(40)
+    expect(diagnostics.rateLimitsByLimitId?.codex?.individualLimit).toEqual({
       limit: '100.00',
       used: '12.34',
       remainingPercent: 87.66,

--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/account-diagnostics.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/account-diagnostics.ts
@@ -68,7 +68,6 @@ export interface CodexAccountDiagnostics {
     planType: string | null
     requiresOpenaiAuth: boolean | null
   } | null
-  rateLimits: CodexRateLimitSnapshotDiagnostics | null
   rateLimitsByLimitId: Record<string, CodexRateLimitSnapshotDiagnostics> | null
   rateLimitResetCredits: {
     availableCount: string
@@ -190,7 +189,6 @@ export async function readCodexAccountDiagnostics(
       unavailableReason: resolved.unavailableReason,
       refreshedAt: null,
       account: null,
-      rateLimits: null,
       rateLimitsByLimitId: null,
       rateLimitResetCredits: null,
       tokenUsage: null,
@@ -219,8 +217,7 @@ export async function readCodexAccountDiagnostics(
       supported: true,
       unavailableReason: null,
       refreshedAt: Date.now(),
-      account: projectAccountDiagnostics(accountResponse, chatgptAuth, rateLimitsResponse.rateLimits),
-      rateLimits: projectRateLimitSnapshot(rateLimitsResponse.rateLimits),
+      account: projectAccountDiagnostics(accountResponse, chatgptAuth),
       rateLimitsByLimitId: projectRateLimitsByLimitId(rateLimitsResponse.rateLimitsByLimitId),
       rateLimitResetCredits: rateLimitsResponse.rateLimitResetCredits
         ? {
@@ -405,7 +402,6 @@ async function acquireDiagnosticsHostLease(input: {
 function projectAccountDiagnostics(
   response: GetAccountResponse,
   chatgptAuth: NonNullable<ReturnType<typeof readCodexChatgptAuth>>,
-  rateLimits: RateLimitSnapshot,
 ): NonNullable<CodexAccountDiagnostics['account']> {
   const account = response.account
   const chatgptAccount = account?.type === 'chatgpt' ? account : null
@@ -414,7 +410,7 @@ function projectAccountDiagnostics(
     authMode: 'chatgptAuthTokens',
     accountType: account?.type ?? null,
     email: chatgptAccount?.email ?? null,
-    planType: chatgptAccount?.planType ?? chatgptAuth.chatgptPlanType ?? rateLimits.planType,
+    planType: chatgptAccount?.planType ?? chatgptAuth.chatgptPlanType,
     requiresOpenaiAuth: response.requiresOpenaiAuth,
   }
 }

--- a/apps/server/src/modules/chat-runtime-providers/codex/app-server/host-resource.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/app-server/host-resource.ts
@@ -10,15 +10,21 @@ export function createCodexAppServerHostResource(input: {
   clientOptions: CodexAppServerClientOptions
   createClient: (options: CodexAppServerClientOptions) => CodexAppServerClientLike
 }): CodexAppServerHostResource {
-  const resource = {
-    client: undefined as unknown as CodexAppServerClientLike,
+  let resource: CodexAppServerHostResource | null = null
+  const client = input.createClient({
+    ...input.clientOptions,
+    serverRequestHandler: (request) => {
+      if (!resource) {
+        throw new Error('Codex app-server host received a request before resource initialization')
+      }
+      return dispatchCodexAppServerHostRequest(resource, request)
+    },
+  })
+  resource = {
+    client,
     serverRequestHandlers: new Set<CodexAppServerResourceRequestHandler>(),
     notificationSubscribers: new Set<CodexAppServerNotificationSubscriber>(),
-  } satisfies CodexAppServerHostResource
-  resource.client = input.createClient({
-    ...input.clientOptions,
-    serverRequestHandler: request => dispatchCodexAppServerHostRequest(resource, request),
-  })
+  }
   return resource
 }
 

--- a/apps/server/src/modules/chat-runtime-providers/codex/metadata.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/metadata.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Codex runtime identity, static capabilities, and presentation projection.
- * Input: generated Codex app-server capability manifest.
- * Position: Codex provider package metadata owner.
- */
-
 import type {
   ChatRuntimeCapabilities,
   ChatRuntimeMetadata,

--- a/apps/server/src/modules/chat-runtime-providers/codex/presentation.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/presentation.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Codex runtime presentation projection.
- * Input: generated Codex app-server capability manifest (+ optional config requirements).
- * Position: Codex provider package boundary from app-server capabilities to Chat Runtime presentation.
- */
-
 import type { RuntimePresentationCapabilities } from '../../chat-runtime/runtime-provider-types'
 import { CODEX_APP_SERVER_CAPABILITIES } from './app-server/capabilities'
 import { CODEX_RUNTIME_KIND } from './metadata'

--- a/apps/server/src/modules/chat-runtime-providers/codex/projection/state-projector.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/projection/state-projector.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Codex providerStateSnapshot projections for notifications, goal state, and native history.
- * Input: runtime session snapshots, Codex app-server notifications, and full app-server turn history.
- * Position: Codex provider package owner for provider snapshot state projection.
- */
-
 import { Buffer } from 'node:buffer'
 
 import { readObjectRecord as readRecord } from '../../../../helpers/json-record'

--- a/apps/server/src/modules/chat-runtime-providers/codex/projection/ui-slot-projector.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/projection/ui-slot-projector.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Codex runtime UI slot descriptors and provider-owned runtime UI slot states.
- * Input: app-server capability manifest, provider snapshot state, and app-server config/list reads.
- * Position: Codex provider package owner for runtime UI slot projection.
- */
-
 import type { RuntimeApprovalsUiSlotState, RuntimeBackgroundTerminal, RuntimeCompactUiSlotState, RuntimeConfigUiSlotState, RuntimeCrewAgentItem, RuntimeCrewCallItem, RuntimeCrewUiSlotState, RuntimeDiffUiSlotState, RuntimeFilesystemUiSlotState, RuntimeMcpUiSlotState, RuntimeModelUiSlotState, RuntimePlanUiSlotState, RuntimePluginUiSlotState, RuntimeReasoningUiSlotState, RuntimeSearchUiSlotState, RuntimeSkillsUiSlotItem, RuntimeSkillsUiSlotState, RuntimeStatusUiSlotState, RuntimeTerminalUiSlotState, RuntimeToolActivityStatus, RuntimeToolActivityUiSlotState, RuntimeUiSlot, RuntimeUiSlotState, RuntimeUsageUiSlotState } from '../../../chat-runtime/runtime-provider-types'
 import {
   RUNTIME_CODE_REVIEW_COMMAND_ACTION_ID,

--- a/apps/server/src/modules/chat-runtime-providers/codex/provider.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/provider.ts
@@ -2309,7 +2309,7 @@ function codexProviderThreadPartMetadata(
   turnId: string,
   itemId: string,
   itemType: string,
-  item: unknown,
+  _item: CodexAppServerItem,
 ): ProviderMetadata {
   return {
     codex: {
@@ -2317,9 +2317,8 @@ function codexProviderThreadPartMetadata(
       turnId,
       itemId,
       itemType,
-      item,
     },
-  } as unknown as ProviderMetadata
+  }
 }
 
 function readThreadStatusType(status: Thread['status']): string {

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/event-to-chunk-mapper.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/event-to-chunk-mapper.ts
@@ -1,9 +1,3 @@
-/**
- * Output: AI SDK UIMessageChunk events projected from Codex app-server notifications.
- * Input: Codex app-server item lifecycle, delta, patch, and server request notifications.
- * Position: Codex provider package event mapper between app-server protocol and Chat Runtime chunks.
- */
-
 import type { UIMessageChunk } from 'ai'
 
 import type { BoundedTextCollector } from '../../bounded-text-collector'

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/input-projector.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/input-projector.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Codex app-server user input and provider-native command projections.
- * Input: Cradle UIMessage/string turns, file parts, and selected skill context parts.
- * Position: Codex provider package boundary from Chat Runtime input to app-server UserInput.
- */
-
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-diagnostics.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-diagnostics.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Codex stream diagnostics, notification helpers, and provider stream errors.
- * Input: Codex app-server notifications and bounded diagnostic samples.
- * Position: Codex provider package owner for stream failure reporting.
- */
-
 import type { RuntimeWarningPartData } from '../../../chat-runtime/runtime-provider-types'
 import { OBSERVABILITY_CODES } from '../../../observability/contract'
 import type { RuntimeKind } from '../../../provider-contracts/types'

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-handler.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-handler.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Codex turn notification stream helpers and provider-thread event fanout.
- * Input: app-server client notifications, active goal snapshots, and provider-thread subscribers.
- * Position: Codex provider package owner for single-turn stream notification orchestration.
- */
-
 import type { UIMessageChunk } from 'ai'
 
 import type { ProviderThreadEvent } from '../../../chat-runtime/runtime-provider-types'

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/thread-lifecycle.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/thread-lifecycle.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Codex app-server thread lifecycle and history hydration helpers.
- * Input: runtime sessions, app-server clients, transcript snapshots, and native Codex history snapshots.
- * Position: Codex provider package owner for opening, restoring, and hydrating app-server threads.
- */
-
 import type { UIMessage } from 'ai'
 
 import type {

--- a/apps/server/src/modules/chat-runtime-providers/codex/types.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/types.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Codex provider-private types shared by package modules.
- * Input: provider context, app-server client options/messages, and active turn bookkeeping.
- * Position: Codex provider package type boundary.
- */
-
 import type {
   ProviderContext,
   RuntimeApprovalStatus,

--- a/apps/server/src/modules/chat-runtime-providers/openai-compatible/metadata.ts
+++ b/apps/server/src/modules/chat-runtime-providers/openai-compatible/metadata.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Standard runtime identity and static capabilities.
- * Input: no runtime data.
- * Position: OpenAI-compatible provider package metadata owner.
- */
-
 import type {
   ChatRuntimeCapabilities,
   ChatRuntimeMetadata,

--- a/apps/server/src/modules/chat-runtime-providers/opencode/config.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/config.ts
@@ -1,9 +1,3 @@
-/**
- * Output: opencode-native provider config and model selection.
- * Input: Cradle runtime provider target profile, requested model, and secret reader.
- * Position: opencode provider package boundary from Cradle provider targets to opencode config.
- */
-
 import type { Config } from '@opencode-ai/sdk'
 
 import type { RegisteredMcpServer } from '../../../plugins/mcp-registry'

--- a/apps/server/src/modules/chat-runtime-providers/opencode/event-to-chunk-mapper.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/event-to-chunk-mapper.ts
@@ -1,9 +1,3 @@
-/**
- * Output: AI SDK UIMessageChunk events projected from opencode message parts.
- * Input: opencode session.prompt response parts.
- * Position: opencode provider package event mapper between SDK-native parts and Chat Runtime chunks.
- */
-
 import type { AssistantMessage as OpencodeAssistantMessage, Part as OpencodePart } from '@opencode-ai/sdk'
 import type { UIMessageChunk } from 'ai'
 

--- a/apps/server/src/modules/chat-runtime-providers/opencode/input-projector.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/input-projector.ts
@@ -1,9 +1,3 @@
-/**
- * Output: opencode prompt parts projected from Chat Runtime input.
- * Input: Cradle UIMessage.
- * Position: opencode provider package boundary from Cradle message input to opencode session.prompt body.
- */
-
 import type { FilePartInput, SessionPromptAsyncData, SessionPromptData, TextPartInput } from '@opencode-ai/sdk'
 import type { UIMessage } from 'ai'
 

--- a/apps/server/src/modules/chat-runtime-providers/opencode/metadata.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/metadata.ts
@@ -1,9 +1,3 @@
-/**
- * Output: opencode runtime identity and static capabilities.
- * Input: no runtime data.
- * Position: opencode provider package metadata owner.
- */
-
 import type {
   ChatRuntimeCapabilities,
   ChatRuntimeMetadata,

--- a/apps/server/src/modules/chat-runtime-providers/opencode/native-provider-target-id.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/native-provider-target-id.ts
@@ -1,9 +1,3 @@
-/**
- * Output: opencode runtime-owned provider target id encoding.
- * Input: opencode native provider ids.
- * Position: lightweight opencode target identity helper without runtime host dependencies.
- */
-
 export const OPENCODE_RUNTIME_NATIVE_PROVIDER_TARGET_ID = 'runtime-native-opencode'
 export const OPENCODE_RUNTIME_NATIVE_PROVIDER_TARGET_PREFIX = 'runtime-native:opencode:'
 

--- a/apps/server/src/modules/chat-runtime-providers/opencode/owned-provider-targets.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/owned-provider-targets.ts
@@ -1,9 +1,3 @@
-/**
- * Output: opencode runtime-owned provider target projection.
- * Input: opencode native provider catalog and runtime target ids.
- * Position: opencode provider package owner for native provider target semantics.
- */
-
 import type {
   RuntimeOwnedProviderTarget,
   RuntimeOwnedProviderTargets,

--- a/apps/server/src/modules/chat-runtime-providers/opencode/presentation.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/presentation.ts
@@ -1,9 +1,3 @@
-/**
- * Output: opencode runtime presentation projection.
- * Input: opencode SDK command records.
- * Position: opencode provider package boundary from SDK-native presentation to Chat Runtime presentation.
- */
-
 import type { Command as OpencodeCommand } from '@opencode-ai/sdk'
 
 import type {

--- a/apps/server/src/modules/chat-runtime-providers/opencode/runtime-context.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/runtime-context.ts
@@ -1,8 +1,4 @@
 /**
- * Output: cwd-scoped OpenCode SDK server resources.
- * Input: OpenCode binary path and workspace directory.
- * Position: OpenCode provider package runtime process owner.
- *
  * Each managed `opencode serve` process inherits the user's native OpenCode
  * config, auth, and project scope. Hosts are pooled by binary path and cwd so
  * sessions in the same workspace can share a process without crossing project

--- a/apps/server/src/modules/chat-runtime-providers/opencode/subagent-bridge.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/subagent-bridge.ts
@@ -1,9 +1,3 @@
-/**
- * Output: OpenCode task/subagent provider-thread resolution and live stream fanout helpers.
- * Input: task tool parts, session.created events, and provider-thread threadId aliases.
- * Position: opencode provider package bridge between child sessions and Cradle provider-thread APIs.
- */
-
 import type {
   AssistantMessage as OpencodeAssistantMessage,
   Message as OpencodeMessage,

--- a/apps/server/src/modules/chat-runtime-providers/opencode/tools/mapper.ts
+++ b/apps/server/src/modules/chat-runtime-providers/opencode/tools/mapper.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Cradle-owned builtin tool payloads projected from opencode-native tool parts.
- * Input: opencode tool part state.
- * Position: opencode provider package tool envelope mapper.
- */
-
 import type { Permission, ToolPart } from '@opencode-ai/sdk'
 
 import type { CradleToolKind } from '../../../chat-runtime/runtime-provider-types'

--- a/apps/server/src/modules/chat-runtime-providers/system-agent/event-to-chunk-mapper.ts
+++ b/apps/server/src/modules/chat-runtime-providers/system-agent/event-to-chunk-mapper.ts
@@ -1,9 +1,3 @@
-/**
- * Output: AI SDK UIMessageChunk events projected from jar-core assistant message events.
- * Input: jar-core assistant message event payloads and per-turn bridge state.
- * Position: System Agent provider package event mapper between jar-core and Chat Runtime chunks.
- */
-
 import { randomUUID } from 'node:crypto'
 
 import type { UIMessageChunk } from 'ai'

--- a/apps/server/src/modules/chat-runtime-providers/system-agent/input-projector.ts
+++ b/apps/server/src/modules/chat-runtime-providers/system-agent/input-projector.ts
@@ -1,9 +1,3 @@
-/**
- * Output: System Agent user prompt projected from Chat Runtime input.
- * Input: Cradle UIMessage or text input.
- * Position: System Agent provider package boundary from Cradle input to jar-core prompt text.
- */
-
 import type { StreamTurnInput } from '../../chat-runtime/runtime-provider-types'
 import { projectTextOnlyInput } from '../kit/input-projector'
 

--- a/apps/server/src/modules/chat-runtime-providers/system-agent/metadata.ts
+++ b/apps/server/src/modules/chat-runtime-providers/system-agent/metadata.ts
@@ -1,9 +1,3 @@
-/**
- * Output: System Agent runtime identity and static capabilities.
- * Input: no runtime data.
- * Position: System Agent provider package metadata owner.
- */
-
 import type {
   ChatRuntimeCapabilities,
   ChatRuntimeMetadata,

--- a/apps/server/src/modules/chat-runtime-providers/system-agent/model-registry-bridge.ts
+++ b/apps/server/src/modules/chat-runtime-providers/system-agent/model-registry-bridge.ts
@@ -1,9 +1,3 @@
-/**
- * Output: jar-core provider/model options projected from Cradle provider config and model registry data.
- * Input: provider kind, System Agent config, preferences thinking level, and model-registry lookups.
- * Position: System Agent provider package bridge to Cradle-owned model registry.
- */
-
 import type { DefaultRuntimeConfigOptions } from '@hijarvis/core'
 
 import { lookupModelRaw } from '../../model-registry/model-info-registry'

--- a/apps/server/src/modules/chat-runtime-providers/system-agent/runtime-context.ts
+++ b/apps/server/src/modules/chat-runtime-providers/system-agent/runtime-context.ts
@@ -1,9 +1,3 @@
-/**
- * Output: System Agent runtime filesystem roots.
- * Input: Cradle server data-dir configuration.
- * Position: System Agent provider package runtime context owner.
- */
-
 import path from 'node:path'
 
 import { getServerConfig } from '../../../infra'

--- a/apps/server/src/modules/chat-runtime-providers/system-agent/state-projector.ts
+++ b/apps/server/src/modules/chat-runtime-providers/system-agent/state-projector.ts
@@ -1,9 +1,3 @@
-/**
- * Output: System Agent provider snapshot projections.
- * Input: existing provider snapshot and selected model id.
- * Position: System Agent provider package owner for providerStateSnapshot updates.
- */
-
 import { readProviderStateSnapshot } from '../kit/state-snapshot'
 
 export function projectSystemAgentModelSnapshot(rawSnapshot: string | null | undefined, currentModelId: string): string {

--- a/apps/server/src/modules/chat-runtime-providers/system-agent/types.ts
+++ b/apps/server/src/modules/chat-runtime-providers/system-agent/types.ts
@@ -1,9 +1,3 @@
-/**
- * Output: System Agent provider-private types shared inside the package.
- * Input: jar-core event names and Cradle runtime configuration needs.
- * Position: System Agent provider package type boundary.
- */
-
 export type JarvisThinkingLevel = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
 
 export type SystemAgentAssistantMessageEvent = {

--- a/apps/server/src/modules/chat-runtime/catalog-only-runtime-metadata.ts
+++ b/apps/server/src/modules/chat-runtime/catalog-only-runtime-metadata.ts
@@ -1,9 +1,3 @@
-/**
- * Output: Chat Runtime catalog-only builtin runtime metadata.
- * Input: no runtime data.
- * Position: Chat Runtime metadata owner for runtimes launched outside Provider Runtime.
- */
-
 import type { RuntimeKind } from '../provider-contracts/types'
 import type { ChatRuntimeMetadata } from './runtime-provider-types'
 

--- a/apps/server/src/modules/chat-runtime/pending-user-input.test.ts
+++ b/apps/server/src/modules/chat-runtime/pending-user-input.test.ts
@@ -73,6 +73,28 @@ describe('pending runtime user input', () => {
       {
         runId: 'run-pending-user-input-1',
         chunk: {
+          type: 'data-cradle-runtime-user-input-request',
+          transient: true,
+          data: {
+            sessionId: 'session-pending-user-input-1',
+            requestId: 'request-1',
+            questions: [
+              {
+                id: 'scope',
+                header: 'Scope',
+                question: 'Which scope should I use?',
+                isOther: false,
+                isSecret: false,
+                multiSelect: false,
+                options: [{ label: 'Small', description: 'Limit the change' }],
+              },
+            ],
+          },
+        },
+      },
+      {
+        runId: 'run-pending-user-input-1',
+        chunk: {
           type: 'tool-output-available',
           toolCallId: 'server-request-request-1',
           output: expect.objectContaining({

--- a/apps/server/src/modules/chat-runtime/pending-user-input.ts
+++ b/apps/server/src/modules/chat-runtime/pending-user-input.ts
@@ -17,6 +17,7 @@ import type {
 interface PendingUserInputState {
   request: RuntimeUserInputRequest
   createdAt: number
+  requestPublished: Promise<void>
   resolve: (resolution: RuntimeUserInputResolution) => void
   reject: (error: Error) => void
 }
@@ -58,10 +59,18 @@ export async function requestRuntimeUserInput(
   }
 
   const createdAt = currentUnixSeconds()
+  let resolveRequestPublished!: () => void
+  let rejectRequestPublished!: (error: Error) => void
+  const requestPublished = new Promise<void>((resolve, reject) => {
+    resolveRequestPublished = resolve
+    rejectRequestPublished = reject
+  })
+  void requestPublished.catch(() => undefined)
   const pending = new Promise<RuntimeUserInputResolution>((resolve, reject) => {
     pendingUserInputById.set(pendingKey, {
       request: input,
       createdAt,
+      requestPublished,
       resolve,
       reject,
     })
@@ -89,12 +98,15 @@ export async function requestRuntimeUserInput(
         questions: input.questions,
       },
     })
+    resolveRequestPublished()
   }
  catch (error) {
+    const requestError = error instanceof Error ? error : new Error(String(error))
+    rejectRequestPublished(requestError)
     const current = pendingUserInputById.get(pendingKey)
     if (current?.request === input) {
       pendingUserInputById.delete(pendingKey)
-      current.reject(error instanceof Error ? error : new Error(String(error)))
+      current.reject(requestError)
     }
     throw error
   }
@@ -110,6 +122,16 @@ export async function submitRuntimeUserInput(input: {
   const pendingKey = readPendingKey(input.sessionId, input.requestId)
   const pending = pendingUserInputById.get(pendingKey)
   if (!pending || pending.request.sessionId !== input.sessionId) {
+    throw new AppError({
+      code: 'chat_runtime_user_input_not_found',
+      status: 404,
+      message: 'Pending runtime user input request was not found',
+      details: { requestId: input.requestId, sessionId: input.sessionId },
+    })
+  }
+
+  await pending.requestPublished
+  if (pendingUserInputById.get(pendingKey) !== pending) {
     throw new AppError({
       code: 'chat_runtime_user_input_not_found',
       status: 404,

--- a/apps/server/src/modules/observability/runtime-snapshot.ts
+++ b/apps/server/src/modules/observability/runtime-snapshot.ts
@@ -21,6 +21,7 @@ import * as Health from '../health/service'
 import { providerRuntimeHostManager } from '../provider-runtime/host-manager'
 import { summarizeRuntimeProcessResources } from '../provider-runtime/process-resources'
 import * as Pty from '../pty/service'
+import type { DesktopRuntimeSample } from './service'
 import { getDesktopRuntimeSamples, getQueueHealth } from './service'
 
 const TOP_DRILLDOWN_LIMIT = 10
@@ -51,7 +52,11 @@ function summarizeKimiServerResources(resources: KimiServerResources[]) {
 }
 
 function readActiveResourceCount(name: '_getActiveHandles' | '_getActiveRequests'): number {
-  const reader = (process as unknown as Record<string, unknown>)[name]
+  const runtimeProcess = process as NodeJS.Process & {
+    _getActiveHandles?: () => unknown[]
+    _getActiveRequests?: () => unknown[]
+  }
+  const reader = runtimeProcess[name]
   if (typeof reader !== 'function') {
     return 0
   }
@@ -101,10 +106,8 @@ function toBytesFromKiB(value: number | null): number | null {
   return value === null ? null : value * 1024
 }
 
-function summarizeRendererDrilldowns(latestDesktopSample: Record<string, unknown> | undefined) {
-  const diagnostics = latestDesktopSample
-    ? readNestedRecord(latestDesktopSample, 'diagnostics')
-    : undefined
+function summarizeRendererDrilldowns(latestDesktopSample: DesktopRuntimeSample | undefined) {
+  const diagnostics = latestDesktopSample?.diagnostics
   const renderers = readNestedArray(diagnostics ?? {}, 'renderers')
   const topChatSessions: Array<Record<string, unknown>> = []
   const activeStreamingMessages: Array<Record<string, unknown>> = []
@@ -247,10 +250,8 @@ function summarizeRendererDrilldowns(latestDesktopSample: Record<string, unknown
   }
 }
 
-function summarizeBrowserPanelDrilldowns(latestDesktopSample: Record<string, unknown> | undefined) {
-  const diagnostics = latestDesktopSample
-    ? readNestedRecord(latestDesktopSample, 'diagnostics')
-    : undefined
+function summarizeBrowserPanelDrilldowns(latestDesktopSample: DesktopRuntimeSample | undefined) {
+  const diagnostics = latestDesktopSample?.diagnostics
   const browser = readNestedRecord(diagnostics ?? {}, 'browser')
   const panel = readNestedRecord(browser ?? {}, 'panel')
   const limits = readNestedRecord(browser ?? {}, 'limits')
@@ -427,9 +428,6 @@ export async function getRuntimeSnapshot() {
   }
 
   const latestDesktopSample = desktop.latestSamples.at(-1)
-  const latestDesktopSampleRecord = latestDesktopSample as unknown as
-    | Record<string, unknown>
-    | undefined
   const appProcessCountByType: Record<string, number> = {}
   const appProcessMemoryBytesByType: Record<string, number> = {}
   for (const metric of latestDesktopSample?.appMetrics ?? []) {
@@ -453,9 +451,7 @@ export async function getRuntimeSnapshot() {
   const rendererChatStoreTotals: Record<string, number> = {}
   const rendererDocumentTotals: Record<string, number> = {}
   const rendererPerformanceTotals: Record<string, number> = {}
-  const diagnostics = latestDesktopSampleRecord
-    ? readNestedRecord(latestDesktopSampleRecord, 'diagnostics')
-    : undefined
+  const diagnostics = latestDesktopSample?.diagnostics
   for (const item of readNestedArray(diagnostics ?? {}, 'renderers')) {
     if (!item || typeof item !== 'object' || Array.isArray(item)) {
       continue
@@ -569,8 +565,8 @@ export async function getRuntimeSnapshot() {
   updateObservabilityMetrics(observability)
 
   const drilldowns = {
-    renderer: summarizeRendererDrilldowns(latestDesktopSampleRecord),
-    browserPanel: summarizeBrowserPanelDrilldowns(latestDesktopSampleRecord),
+    renderer: summarizeRendererDrilldowns(latestDesktopSample),
+    browserPanel: summarizeBrowserPanelDrilldowns(latestDesktopSample),
     runStreams: {
       topRuns: summarizeRunStreamDrilldowns(activeRuns, runStreams),
     },

--- a/apps/server/src/modules/provider-targets/model.ts
+++ b/apps/server/src/modules/provider-targets/model.ts
@@ -259,7 +259,6 @@ export const ProviderTargetsModel = {
       }, { additionalProperties: false }),
       t.Null(),
     ]),
-    rateLimits: t.Union([codexRateLimitSnapshotDiagnostics, t.Null()]),
     rateLimitsByLimitId: t.Union([
       t.Object({}, { additionalProperties: codexRateLimitSnapshotDiagnostics }),
       t.Null(),

--- a/apps/server/src/modules/pty/README.md
+++ b/apps/server/src/modules/pty/README.md
@@ -15,7 +15,7 @@ Opt-in durable screen history lives under `$CRADLE_DATA_DIR/terminal-history` wh
 - `pty.runtime.ts`: `node-pty` runtime registry, process lifecycle hooks, and process tree memory/CPU resource sampling.
 - `pty.timeline.ts`: Sequence-aware snapshots, replay windows, exit history, and restore metadata.
 - `pty.socket.ts`: WebSocket adapter that bridges runtime/timeline to clients.
-- `launch-planner.ts`: Pure CLI TUI launch planner. Decides `live-attach` / `resume` / `fresh`, builds Claude/Codex/Kimi argv, resolves generalized `providerSession` bindings (with legacy `codexCliSession` compat), and decides when provider filesystem capture is needed.
+- `launch-planner.ts`: Pure CLI TUI launch planner. Decides `live-attach` / `resume` / `fresh`, builds Claude/Codex/Kimi argv, resolves generalized `providerSession` bindings, and decides when provider filesystem capture is needed.
 - `service.ts`: Session/profile/workspace ownership rules, start-or-attach orchestration, host diagnostics, session archive/delete PTY release hooks, memory/CPU resource totals, explicit bottom-panel shell lifecycle, and module shutdown. `startOrAttach` returns `{ sessionId, running, mode, restore }`.
 # PTY lifecycle and activity
 

--- a/apps/server/src/modules/pty/codex-session-capture.ts
+++ b/apps/server/src/modules/pty/codex-session-capture.ts
@@ -6,8 +6,6 @@ import { createInterface } from 'node:readline'
 
 import { z } from 'zod'
 
-import type { CodexCliSessionBinding } from '../../helpers/agent-runtime-config'
-
 const MAX_FILES_PER_DIRECTORY = 80
 const MAX_CANDIDATE_FILES = 120
 const CAPTURE_LOOKBACK_MS = 5_000
@@ -39,7 +37,12 @@ interface CodexSessionMeta {
   originator: string
 }
 
-export interface CapturedCodexCliSession extends CodexCliSessionBinding {
+export interface CapturedCodexCliSession {
+  sessionId: string
+  capturedAt: number
+  startedAt: number
+  workspacePath: string
+  sourcePath: string
   title?: string
 }
 

--- a/apps/server/src/modules/pty/launch-planner.test.ts
+++ b/apps/server/src/modules/pty/launch-planner.test.ts
@@ -59,7 +59,7 @@ describe('planCliTuiLaunch', () => {
     expect(resume.args).toEqual(['--resume', SESSION_ID])
   })
 
-  it('resumes Codex from providerSession and falls back to legacy codexCliSession', () => {
+  it('resumes Codex from providerSession', () => {
     const fromProvider = planCliTuiLaunch({
       sessionId: SESSION_ID,
       executable: 'codex',
@@ -86,24 +86,6 @@ describe('planCliTuiLaunch', () => {
       CODEX_SESSION_ID,
     ])
     expect(fromProvider.needsCapture).toBe(false)
-
-    const fromLegacy = planCliTuiLaunch({
-      sessionId: SESSION_ID,
-      executable: 'codex',
-      args: [],
-      running: false,
-      ptyStartedAt: 1_700_000_000,
-      workspacePath: WORKSPACE,
-      codexCliSession: {
-        sessionId: CODEX_SESSION_ID,
-        capturedAt: 1_700_000_100,
-        startedAt: 1_700_000_000,
-        workspacePath: WORKSPACE,
-        sourcePath: '/tmp/rollout.jsonl',
-      },
-    })
-    expect(fromLegacy.mode).toBe('resume')
-    expect(fromLegacy.args).toEqual(['resume', CODEX_SESSION_ID])
   })
 
   it('does not resume Codex when workspace mismatches and schedules capture', () => {
@@ -114,12 +96,16 @@ describe('planCliTuiLaunch', () => {
       running: false,
       ptyStartedAt: null,
       workspacePath: WORKSPACE,
-      codexCliSession: {
-        sessionId: CODEX_SESSION_ID,
+      providerSession: {
+        source: 'cradle:codex',
+        agent: 'codex',
+        kind: 'id',
+        value: CODEX_SESSION_ID,
         capturedAt: 1_700_000_100,
         startedAt: 1_700_000_000,
         workspacePath: '/tmp/other',
         sourcePath: '/tmp/rollout.jsonl',
+        confidence: 'exact',
       },
     })
 

--- a/apps/server/src/modules/pty/launch-planner.ts
+++ b/apps/server/src/modules/pty/launch-planner.ts
@@ -1,9 +1,6 @@
 import { basename } from 'node:path'
 
-import type {
-  CodexCliSessionBinding,
-  ProviderSessionBinding,
-} from '../../helpers/agent-runtime-config'
+import type { ProviderSessionBinding } from '../../helpers/agent-runtime-config'
 
 export type CliTuiLaunchMode = 'live-attach' | 'resume' | 'fresh'
 
@@ -32,8 +29,6 @@ export interface PlanCliTuiLaunchInput {
   ptyStartedAt: number | null
   workspacePath: string
   providerSession?: ProviderSessionBinding | null
-  /** @deprecated Prefer providerSession; kept for stored session config. */
-  codexCliSession?: CodexCliSessionBinding | null
   harnessSystemPrompt?: string | null
 }
 
@@ -158,7 +153,6 @@ export function detectAgent(executable: string): CliTuiAgent {
 
 export function resolveProviderSessionBinding(input: {
   providerSession?: ProviderSessionBinding | null
-  codexCliSession?: CodexCliSessionBinding | null
   workspacePath: string
   expectedAgent?: CliTuiAgent
 }): ProviderSessionBinding | null {
@@ -174,26 +168,7 @@ export function resolveProviderSessionBinding(input: {
     }
     return input.providerSession
   }
-
-  const legacy = input.codexCliSession
-  if (!legacy || legacy.workspacePath !== input.workspacePath) {
-    return null
-  }
-  if (input.expectedAgent && input.expectedAgent !== 'codex' && input.expectedAgent !== 'generic') {
-    return null
-  }
-
-  return {
-    source: 'cradle:codex',
-    agent: 'codex',
-    kind: 'id',
-    value: legacy.sessionId,
-    workspacePath: legacy.workspacePath,
-    capturedAt: legacy.capturedAt,
-    startedAt: legacy.startedAt,
-    sourcePath: legacy.sourcePath,
-    confidence: 'exact',
-  }
+  return null
 }
 
 export function providerSessionDedupeKey(binding: ProviderSessionBinding): string {
@@ -325,7 +300,6 @@ function planCodexLaunch(
   const autoResumeAllowed = !hasCodexPositionalArg(args) && !hasCodexResumeArg(args)
   const binding = resolveProviderSessionBinding({
     providerSession: input.providerSession,
-    codexCliSession: input.codexCliSession,
     workspacePath: input.workspacePath,
     expectedAgent: 'codex',
   })
@@ -366,7 +340,6 @@ function planBoundProviderResume(
 ): CliTuiLaunchPlan {
   const binding = resolveProviderSessionBinding({
     providerSession: input.providerSession,
-    codexCliSession: input.codexCliSession,
     workspacePath: input.workspacePath,
     expectedAgent: agent,
   })

--- a/apps/server/src/modules/pty/service.ts
+++ b/apps/server/src/modules/pty/service.ts
@@ -275,7 +275,6 @@ export function startOrAttach(input: { sessionId: string, cols: number, rows: nu
     ptyStartedAt: context.session.ptyStartedAt,
     workspacePath: context.workspacePath,
     providerSession: sessionConfig.providerSession,
-    codexCliSession: sessionConfig.codexCliSession,
     harnessSystemPrompt: getCradleHarnessSystemInstructions(),
   })
 
@@ -426,20 +425,7 @@ export function getProviderSession(sessionId: string): {
   const config = SessionRuntimeConfigJsonSchema.parse(context.session.configJson)
   return {
     sessionId,
-    providerSession: config.providerSession
-      ?? (config.codexCliSession
-        ? {
-            source: 'cradle:codex',
-            agent: 'codex',
-            kind: 'id' as const,
-            value: config.codexCliSession.sessionId,
-            workspacePath: config.codexCliSession.workspacePath,
-            capturedAt: config.codexCliSession.capturedAt,
-            startedAt: config.codexCliSession.startedAt,
-            sourcePath: config.codexCliSession.sourcePath,
-            confidence: 'exact' as const,
-          }
-        : null),
+    providerSession: config.providerSession ?? null,
   }
 }
 
@@ -525,11 +511,11 @@ export function clearProviderSession(sessionId: string): {
 } {
   const context = requireTerminalContext(sessionId)
   const config = SessionRuntimeConfigJsonSchema.parse(context.session.configJson)
-  if (!config.providerSession && !config.codexCliSession) {
+  if (!config.providerSession) {
     return { sessionId, providerSession: null }
   }
 
-  const { providerSession: _providerSession, codexCliSession: _codexCliSession, ...rest } = config
+  const { providerSession: _providerSession, ...rest } = config
   db()
     .update(sessions)
     .set({ configJson: JSON.stringify(rest) })

--- a/apps/server/tests/agent-runtime-config.test.ts
+++ b/apps/server/tests/agent-runtime-config.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 
 import {
   SessionRuntimeConfigJsonSchema,
-  writeCodexCliSessionBindingToSessionConfig,
   writeProviderSessionBindingToSessionConfig,
 } from '../src/helpers/agent-runtime-config'
 
@@ -19,14 +18,18 @@ describe('agent runtime config helpers', () => {
       unrelated: { value: true },
     })
 
-    const next = writeCodexCliSessionBindingToSessionConfig({
+    const next = writeProviderSessionBindingToSessionConfig({
       configJson: initial,
       binding: {
-        sessionId: CODEX_SESSION_ID,
+        source: 'cradle:codex',
+        agent: 'codex',
+        kind: 'id',
+        value: CODEX_SESSION_ID,
         capturedAt: 1_779_123_000,
         startedAt: 1_779_122_900,
         workspacePath: '/tmp/workspace',
         sourcePath: '/tmp/codex/sessions/rollout.jsonl',
+        confidence: 'exact',
       },
     })
 
@@ -48,17 +51,10 @@ describe('agent runtime config helpers', () => {
       sourcePath: '/tmp/codex/sessions/rollout.jsonl',
       confidence: 'exact',
     })
-    expect(config.codexCliSession).toEqual({
-      sessionId: CODEX_SESSION_ID,
-      capturedAt: 1_779_123_000,
-      startedAt: 1_779_122_900,
-      workspacePath: '/tmp/workspace',
-      sourcePath: '/tmp/codex/sessions/rollout.jsonl',
-    })
     expect(JSON.parse(next).unrelated).toEqual({ value: true })
   })
 
-  it('writes generalized providerSession bindings and keeps Codex legacy fields in sync', () => {
+  it('writes generalized providerSession bindings', () => {
     const next = writeProviderSessionBindingToSessionConfig({
       configJson: JSON.stringify({ cliTuiLaunch: { executable: 'codex', args: [] } }),
       binding: {
@@ -76,6 +72,5 @@ describe('agent runtime config helpers', () => {
 
     const config = SessionRuntimeConfigJsonSchema.parse(next)
     expect(config.providerSession?.value).toBe(CODEX_SESSION_ID)
-    expect(config.codexCliSession?.sessionId).toBe(CODEX_SESSION_ID)
   })
 })

--- a/apps/web/scripts/i18n-workflow/clean-unused-keys.ts
+++ b/apps/web/scripts/i18n-workflow/clean-unused-keys.ts
@@ -1,12 +1,33 @@
 import type { SupportedLocale } from '../../src/i18n/locales'
 import { isSupportedLocale } from '../../src/i18n/locales'
+import type { Namespace } from '../../src/locales/default'
+import { isNamespace } from '../../src/locales/default'
 import { localeNamespacePath, nonDefaultLocales, pathExists, readJson, resolveFromWebRoot, writeJson } from './utils'
 
 interface UnusedReport {
   unusedKeys: Array<{
-    namespace: string
+    namespace: Namespace
     key: string
   }>
+}
+
+function readUnusedReport(value: Record<string, unknown>): UnusedReport {
+  if (!Array.isArray(value.unusedKeys)) {
+    throw new TypeError('Unused-key report is missing unusedKeys')
+  }
+  return {
+    unusedKeys: value.unusedKeys.map((entry, index) => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new Error(`Invalid unusedKeys entry at index ${index}`)
+      }
+      const namespace = Reflect.get(entry, 'namespace')
+      const key = Reflect.get(entry, 'key')
+      if (typeof namespace !== 'string' || !isNamespace(namespace) || typeof key !== 'string') {
+        throw new Error(`Invalid unusedKeys entry at index ${index}`)
+      }
+      return { namespace, key }
+    }),
+  }
 }
 
 const dryRun = !process.argv.includes('--no-dry-run')
@@ -17,7 +38,7 @@ if (!(await pathExists(reportPath))) {
   process.exit(1)
 }
 
-const report = await readJson(reportPath) as unknown as UnusedReport
+const report = readUnusedReport(await readJson(reportPath))
 
 for (const locale of nonDefaultLocales()) {
   if (!isSupportedLocale(locale)) {
@@ -25,7 +46,7 @@ for (const locale of nonDefaultLocales()) {
   }
 
   for (const { namespace, key } of report.unusedKeys) {
-    const filePath = resolveFromWebRoot(localeNamespacePath(locale as SupportedLocale, namespace as never))
+    const filePath = resolveFromWebRoot(localeNamespacePath(locale as SupportedLocale, namespace))
     if (!(await pathExists(filePath))) {
       continue
     }

--- a/apps/web/src/api-gen/types.gen.ts
+++ b/apps/web/src/api-gen/types.gen.ts
@@ -2438,33 +2438,6 @@ export type GetProviderTargetsByProviderTargetIdCodexAccountDiagnosticsResponses
             planType: string | null;
             requiresOpenaiAuth: boolean | null;
         } | null;
-        rateLimits: {
-            limitId: string | null;
-            limitName: string | null;
-            primary: {
-                usedPercent: number;
-                windowDurationMins: number | null;
-                resetsAt: number | null;
-            } | null;
-            secondary: {
-                usedPercent: number;
-                windowDurationMins: number | null;
-                resetsAt: number | null;
-            } | null;
-            credits: {
-                hasCredits: boolean;
-                unlimited: boolean;
-                balance: string | null;
-            } | null;
-            individualLimit: {
-                limit: string;
-                used: string;
-                remainingPercent: number;
-                resetsAt: number;
-            } | null;
-            planType: string | null;
-            rateLimitReachedType: string | null;
-        } | null;
         rateLimitsByLimitId: {
             [key: string]: {
                 limitId: string | null;

--- a/apps/web/src/components/editor/markdown-editor.test.tsx
+++ b/apps/web/src/components/editor/markdown-editor.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { Editor } from '@tiptap/core'
 import Link from '@tiptap/extension-link'
 import StarterKit from '@tiptap/starter-kit'
+import type { MarkdownStorage } from 'tiptap-markdown'
 import { Markdown } from 'tiptap-markdown'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -65,8 +66,8 @@ describe('markdown editor', () => {
         },
       })
 
-      const storage = editor.storage as unknown as { markdown: { getMarkdown: () => string } }
-      const markdown = storage.markdown.getMarkdown()
+      const markdownStorage: MarkdownStorage = editor.storage.markdown
+      const markdown = markdownStorage.getMarkdown()
 
       expect(markdown).toContain('[[CRA-007] Smart mentions](cradle://mention/issue/issue-1?label=CRA-007&title=Smart+mentions&detail=Todo+%C2%B7+high&workspaceId=workspace-1)')
     }

--- a/apps/web/src/components/editor/markdown-editor.tsx
+++ b/apps/web/src/components/editor/markdown-editor.tsx
@@ -8,6 +8,7 @@ import Typography from '@tiptap/extension-typography'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import type { MarkdownStorage } from 'tiptap-markdown'
 import { Markdown } from 'tiptap-markdown'
 
 import { toastManager } from '~/components/ui/toast'
@@ -24,9 +25,14 @@ import { SlashCommand } from './slash-command'
 import { SmartMention } from './smart-mention'
 import type { SmartMentionAttrs, SmartMentionItem } from './smart-mention-utils'
 
-function getMarkdownContent(storage: unknown): string {
-  const s = storage as { markdown: { getMarkdown: () => string } }
-  return s.markdown.getMarkdown()
+declare module '@tiptap/core' {
+  interface Storage {
+    markdown: MarkdownStorage
+  }
+}
+
+function getMarkdownContent(storage: { markdown: MarkdownStorage }): string {
+  return storage.markdown.getMarkdown()
 }
 
 const EDITOR_IMAGE_ACCEPT = 'image/png,image/jpeg,image/webp'

--- a/apps/web/src/features/agent-management/codex-account-diagnostics-panel.tsx
+++ b/apps/web/src/features/agent-management/codex-account-diagnostics-panel.tsx
@@ -51,7 +51,7 @@ import { cn } from '~/lib/cn'
 import { clampPercent } from '~/lib/number-format'
 
 type CodexAccountDiagnostics = GetProviderTargetsByProviderTargetIdCodexAccountDiagnosticsResponse
-type RateLimitSnapshot = NonNullable<CodexAccountDiagnostics['rateLimits']>
+type RateLimitSnapshot = NonNullable<CodexAccountDiagnostics['rateLimitsByLimitId']>[string]
 type RateLimitWindow = NonNullable<RateLimitSnapshot['primary']>
 type DailyBucket = NonNullable<CodexAccountDiagnostics['tokenUsage']>['dailyUsageBuckets'][number]
 
@@ -501,25 +501,14 @@ function RateLimitsTab({
     return <div className="px-6 py-8">{body}</div>
   }
 
-  // The single-bucket `rateLimits` is a backward-compatible mirror of the
-  // primary limit; the multi-bucket `rateLimitsByLimitId` is the source of
-  // truth. Rendering both duplicates the same limit, so prefer the multi-bucket
-  // view when present and only fall back to the single bucket otherwise.
-  const defaultSnapshot = diagnostics?.rateLimits ?? null
   const byLimitId = diagnostics?.rateLimitsByLimitId ?? null
   const entries = byLimitId ? Object.entries(byLimitId) : []
 
-  const cards: Array<{ key: string, snapshot: RateLimitSnapshot, highlighted: boolean }> = []
-  if (entries.length > 0) {
-    const primaryLimitId = defaultSnapshot?.limitId ?? null
-    const highlightedKey = (primaryLimitId && byLimitId![primaryLimitId]) ? primaryLimitId : entries[0][0]
-    for (const [limitId, snapshot] of entries) {
-      cards.push({ key: limitId, snapshot, highlighted: limitId === highlightedKey })
-    }
-  }
-  else if (defaultSnapshot) {
-    cards.push({ key: defaultSnapshot.limitId ?? 'default', snapshot: defaultSnapshot, highlighted: true })
-  }
+  const cards = entries.map(([limitId, snapshot], index) => ({
+    key: limitId,
+    snapshot,
+    highlighted: index === 0,
+  }))
 
   const totalBuckets = cards.length
   const limitedCount = cards.filter(c => Boolean(c.snapshot.rateLimitReachedType)).length
@@ -1261,9 +1250,6 @@ function deriveStatusKind(
   }
   if (!diagnostics.supported) {
     return 'unsupported'
-  }
-  if (diagnostics.rateLimits?.rateLimitReachedType) {
-    return 'limited'
   }
   const byLimitId = Object.values(diagnostics.rateLimitsByLimitId ?? {})
   if (byLimitId.some(r => Boolean(r.rateLimitReachedType))) {

--- a/apps/web/src/features/agent-management/provider-templates.ts
+++ b/apps/web/src/features/agent-management/provider-templates.ts
@@ -173,14 +173,6 @@ export function suggestCatalogPresetsByEndpoint(
   })
 }
 
-/** @deprecated Use suggestCatalogPresetsByEndpoint — identity must not be auto-resolved. */
-export function matchCatalogPresetByEndpoint(
-  presets: ProviderPreset[],
-  endpoint: string,
-): ProviderPreset | null {
-  return suggestCatalogPresetsByEndpoint(presets, endpoint)[0] ?? null
-}
-
 /** Auth methods for unbound profiles (no providerId). */
 export function unboundAuthMethods(): ProviderPresetAuthMethod[] {
   return API_KEY_ONLY

--- a/apps/web/src/features/browser/browser-panel.test.tsx
+++ b/apps/web/src/features/browser/browser-panel.test.tsx
@@ -131,9 +131,11 @@ function installTestBrowserBridge() {
     },
   }
 
-  window.cradle = {
-    browser: bridge,
-  } as unknown as Window['cradle']
+  Object.defineProperty(window, 'cradle', {
+    configurable: true,
+    writable: true,
+    value: { browser: bridge },
+  })
 
   return bridge
 }
@@ -373,7 +375,16 @@ describe('browserPanel rendering', () => {
       viewport!.getBoundingClientRect = () => new DOMRect(0, 0, 600, 400)
       const popover = originalCreateElement('div')
       popover.setAttribute('data-slot', 'popover-content')
-      popover.getClientRects = () => [new DOMRect(100, 100, 200, 120)] as unknown as DOMRectList
+      const rect = new DOMRect(100, 100, 200, 120)
+      const rects: DOMRectList = {
+        0: rect,
+        length: 1,
+        item: index => index === 0 ? rect : null,
+        [Symbol.iterator]() {
+          return [rect].values()
+        },
+      }
+      popover.getClientRects = () => rects
       document.body.append(popover)
 
       await waitFor(() => {

--- a/apps/web/src/features/browser/side-conversation-message.ts
+++ b/apps/web/src/features/browser/side-conversation-message.ts
@@ -2,7 +2,7 @@ import type { FileUIPart, UIMessage } from 'ai'
 
 import { useRendererChatStore } from '~/store/renderer-chat'
 
-import type { ChatRuntimeSettingsPatch, ChatThinkingEffort } from '../chat/commands/chat-response-command'
+import type { ChatThinkingEffort, RuntimeSettingsPatch } from '../chat/commands/chat-response-command'
 import { startSideConversationResponse } from '../chat/commands/chat-response-command'
 import type { ChatContextPart } from '../chat/context/chat-context-parts'
 import { toOrderedUserMessageParts } from '../chat/context/chat-context-parts'
@@ -16,7 +16,7 @@ export interface SubmitSideConversationMessageInput {
   contextParts?: ChatContextPart[]
   modelId?: string
   thinkingEffort?: ChatThinkingEffort | null | undefined
-  runtimeSettings?: ChatRuntimeSettingsPatch
+  runtimeSettings?: RuntimeSettingsPatch
 }
 
 export function buildSideConversationViewId(sideConversationId: string): string {

--- a/apps/web/src/features/chat/commands/chat-response-command.ts
+++ b/apps/web/src/features/chat/commands/chat-response-command.ts
@@ -8,6 +8,7 @@ import {
   getChatSessionsBySessionIdQueue,
   patchChatSessionsBySessionIdQueueByQueueItemId,
   postChatSessionsBySessionIdBangCommand,
+  postChatSessionsBySessionIdBangTranscript,
   postChatSessionsBySessionIdCancel,
   postChatSessionsBySessionIdMessagesByMessageIdPlanImplementationApproval,
   postChatSessionsBySessionIdQueue,
@@ -34,7 +35,7 @@ export interface ChatResponseRequestBody {
   providerTargetId?: string
   modelId?: string | null
   thinkingEffort?: ChatThinkingEffort
-  runtimeSettings?: ChatRuntimeSettingsPatch
+  runtimeSettings?: RuntimeSettingsPatch
   reviewTarget?: RuntimeReviewTarget
 }
 
@@ -50,11 +51,6 @@ export type RuntimeSettingsPatchValue = RuntimeSettingsValue | null
 export type RuntimeSettingsPatch = Record<string, RuntimeSettingsPatchValue | undefined>
 export type RuntimeSettingsPayload = Record<string, RuntimeSettingsPatchValue>
 
-/** @deprecated Use RuntimeSettings — provider-native session settings. */
-export type ChatRuntimeSettings = RuntimeSettings
-/** @deprecated Use RuntimeSettingsPatch */
-export type ChatRuntimeSettingsPatch = RuntimeSettingsPatch
-
 export interface ChatQueueItem {
   id: string
   sessionId: string
@@ -66,7 +62,7 @@ export interface ChatQueueItem {
   providerTargetId: string | null
   modelId: string | null
   thinkingEffort: ChatThinkingEffort | null
-  runtimeSettings: ChatRuntimeSettings
+  runtimeSettings: RuntimeSettings
   position: number
   sourceRunId: string | null
   startedRunId: string | null
@@ -372,26 +368,17 @@ export async function persistBangTranscript(args: {
   exitCode?: number | null
   signal?: AbortSignal
 }): Promise<BangCommandResult> {
-  const response = await fetch(`${SERVER_BASE}/chat/sessions/${args.sessionId}/bang-transcript`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
+  const result = await postChatSessionsBySessionIdBangTranscript({
+    path: { sessionId: args.sessionId },
+    body: {
       transcript: args.transcript,
       command: args.command,
       durationMs: args.durationMs,
       exitCode: args.exitCode,
-    }),
+    },
     signal: args.signal,
   })
-  if (!response.ok) {
-    const message = await response.text().catch(() => '')
-    throw new Error(message || `Failed to persist bang transcript (${response.status})`)
-  }
-  const payload = await response.json() as { data?: BangCommandResult } | BangCommandResult
-  if (payload && typeof payload === 'object' && 'data' in payload && payload.data) {
-    return payload.data
-  }
-  return payload as BangCommandResult
+  return readSdkData(result, 'Failed to persist bang transcript') as BangCommandResult
 }
 
 export async function createSideChat(args: {

--- a/apps/web/src/features/chat/composer/composer-attachment-state.ts
+++ b/apps/web/src/features/chat/composer/composer-attachment-state.ts
@@ -1,6 +1,6 @@
 import type { FileUIPart } from 'ai'
 import { convertFileListToFileUIParts } from 'ai'
-import type { ChangeEvent, ClipboardEvent, RefObject } from 'react'
+import type { ChangeEvent, RefObject } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { ModelDescriptor } from '~/features/agent-runtime/types'
@@ -14,7 +14,7 @@ export interface ComposerAttachmentController {
   supportsAttachments: boolean
   clearAttachments: () => void
   handleFilesSelected: (event: ChangeEvent<HTMLInputElement>) => Promise<void>
-  handlePaste: (event: ClipboardEvent<HTMLElement>) => void
+  handlePaste: (event: ClipboardEvent) => void
   pickFiles: () => void
   removeAttachment: (index: number) => void
   replaceAttachments: (fileParts: FileUIPart[]) => void
@@ -160,8 +160,12 @@ export function useComposerAttachments({
   )
 
   const handlePaste = useCallback(
-    (event: ClipboardEvent<HTMLElement>) => {
+    (event: ClipboardEvent) => {
       if (!supportsAttachments) {
+        return
+      }
+
+      if (!event.clipboardData) {
         return
       }
 

--- a/apps/web/src/features/chat/composer/light-ocr.ts
+++ b/apps/web/src/features/chat/composer/light-ocr.ts
@@ -1,20 +1,7 @@
 import type { FileUIPart } from 'ai'
 
-import { getServerUrl } from '~/lib/electron'
-import { cradleFetch } from '~/lib/server-credential'
-
-interface LightOcrResponse {
-  items: Array<{
-    index: number
-    text: string
-    lineCount: number
-    modelBundleId: string
-  }>
-}
-
-interface LightOcrErrorResponse {
-  message?: string
-}
+import { postImageOcrRecognize } from '~/api-gen/sdk.gen'
+import type { PostImageOcrRecognizeResponse } from '~/api-gen/types.gen'
 
 type LightOcrFilePart = FileUIPart & {
   providerMetadata?: Record<string, unknown>
@@ -26,7 +13,7 @@ function isImageAttachment(file: FileUIPart): boolean {
 
 function withLightOcrMetadata(
   file: FileUIPart,
-  item: LightOcrResponse['items'][number],
+  item: PostImageOcrRecognizeResponse['items'][number],
 ): FileUIPart {
   const metadata = (file as LightOcrFilePart).providerMetadata ?? {}
   const cradle = typeof metadata.cradle === 'object' && metadata.cradle !== null
@@ -55,22 +42,10 @@ export async function prepareLightOcrAttachments(files: FileUIPart[]): Promise<F
     return files
   }
 
-  const response = await cradleFetch(new URL('/image-ocr/recognize', getServerUrl()), {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ files: images }),
+  const { data: payload } = await postImageOcrRecognize({
+    body: { files: images },
+    throwOnError: true,
   })
-  const payload = (await response.json().catch(() => null)) as
-    | LightOcrResponse
-    | LightOcrErrorResponse
-    | null
-  if (!response.ok || !payload || !('items' in payload)) {
-    const detail
-      = payload && 'message' in payload && typeof payload.message === 'string'
-        ? payload.message
-        : `Local image text recognition failed (${response.status}).`
-    throw new Error(detail)
-  }
 
   const itemsByIndex = new Map(payload.items.map(item => [item.index, item]))
   let imageIndex = 0

--- a/apps/web/src/features/chat/composer/views/composer-view.tsx
+++ b/apps/web/src/features/chat/composer/views/composer-view.tsx
@@ -24,8 +24,8 @@ import type {
 } from '../../capabilities/chat-capabilities'
 import { readBangCommand } from '../../commands/bang-command'
 import type {
-  ChatRuntimeSettings,
-  ChatRuntimeSettingsPatch,
+  RuntimeSettings,
+  RuntimeSettingsPatch,
 } from '../../commands/chat-response-command'
 import type { ChatContextPart } from '../../context/chat-context-parts'
 import type { MentionItem, MentionPickerItem, PluginMentionItem } from '../../mentions/mention-panel'
@@ -178,9 +178,9 @@ export interface ComposerExternalSignals {
 
 export interface ComposerRuntimeSettingsController {
   runtimeKind?: RuntimeKind | null
-  settings: ChatRuntimeSettings
+  settings: RuntimeSettings
   disabled?: boolean
-  onChange: (patch: ChatRuntimeSettingsPatch) => void
+  onChange: (patch: RuntimeSettingsPatch) => void
 }
 
 export interface ComposerViewOptions {
@@ -820,7 +820,7 @@ export function ComposerView({
 
   const handlePaste = useCallback(
     (event: ClipboardEvent) => {
-      handleAttachmentPaste(event as unknown as React.ClipboardEvent<HTMLElement>)
+      handleAttachmentPaste(event)
       if (event.defaultPrevented) {
         return
       }

--- a/apps/web/src/features/chat/session/optimistic-chat-turn.ts
+++ b/apps/web/src/features/chat/session/optimistic-chat-turn.ts
@@ -9,7 +9,7 @@ import { useChatStore } from '~/store/chat'
 
 import { chatMessageSnapshotQueryKey } from '../api/messages'
 import { runtimeUiSlotStatesQueryKey } from '../capabilities/chat-capabilities'
-import type { ChatResponseRequestBody, ChatRuntimeSettingsPatch } from '../commands/chat-response-command'
+import type { ChatResponseRequestBody, RuntimeSettingsPatch } from '../commands/chat-response-command'
 import { runtimeSessionStatusQueryKey } from '../commands/runtime-session-status-command'
 import { runtimeSettingsQueryKey } from '../commands/runtime-settings-command'
 import type { ChatContextPart } from '../context/chat-context-parts'
@@ -35,7 +35,7 @@ interface StartOptimisticChatResponseInput {
     providerTargetId?: string
     modelId?: string | null
     thinkingEffort?: ChatResponseRequestBody['thinkingEffort']
-    runtimeSettings?: ChatRuntimeSettingsPatch
+    runtimeSettings?: RuntimeSettingsPatch
     reviewTarget?: ChatResponseRequestBody['reviewTarget']
   }
   supportsGoalCommand?: boolean

--- a/apps/web/src/features/chat/session/use-chat-session-types.ts
+++ b/apps/web/src/features/chat/session/use-chat-session-types.ts
@@ -5,7 +5,7 @@ import type { GetChatSessionsBySessionIdMessagesResponse } from '~/api-gen/types
 import type { ChatRunState } from '~/store/chat'
 import { useChatStore } from '~/store/chat'
 
-import type { ChatContinuationMode, ChatQueueItem, ChatRuntimeSettingsPatch, ChatThinkingEffort } from '../commands/chat-response-command'
+import type { ChatContinuationMode, ChatQueueItem, ChatThinkingEffort, RuntimeSettingsPatch } from '../commands/chat-response-command'
 import type { RuntimeSessionRunStatus } from '../commands/runtime-session-status-command'
 
 // ── Message Snapshot Types ──────────────────────────────────
@@ -17,7 +17,7 @@ export interface SendMessageOptions {
   providerTargetId?: string
   modelId?: string | null
   thinkingEffort?: ChatThinkingEffort | null | undefined
-  runtimeSettings?: ChatRuntimeSettingsPatch
+  runtimeSettings?: RuntimeSettingsPatch
   continuationMode?: ChatContinuationMode
   reviewTarget?: RuntimeReviewTarget
 }

--- a/apps/web/src/features/chat/transcript/containers/message-bubble-by-id-detail.test.tsx
+++ b/apps/web/src/features/chat/transcript/containers/message-bubble-by-id-detail.test.tsx
@@ -10,7 +10,7 @@ import { useChatStore } from '~/store/chat'
 
 import { MessageBubbleById } from './message-bubble-by-id'
 
-const fullMessage = {
+const fullMessage: UIMessage = {
   id: 'visible',
   role: 'assistant' as const,
   parts: [
@@ -23,7 +23,7 @@ const fullMessage = {
       output: { ok: true },
     },
   ],
-} as unknown as UIMessage
+}
 
 function shellMessage(id: string): UIMessage {
   return {

--- a/apps/web/src/features/chat/transport/chat-stream-transport.ts
+++ b/apps/web/src/features/chat/transport/chat-stream-transport.ts
@@ -57,14 +57,6 @@ interface DesktopStreamState {
   closed: boolean
 }
 
-type UIMessageChunkValidationResult
-  = | { success: true, value: UIMessageChunk }
-    | { success: false, error: unknown }
-
-interface UIMessageChunkValidator {
-  validate?: (value: unknown) => UIMessageChunkValidationResult | PromiseLike<UIMessageChunkValidationResult>
-}
-
 const PENDING_DESKTOP_STREAM_LIMIT = 32
 const PENDING_DESKTOP_EVENTS_PER_STREAM = 512
 const CLOSED_DESKTOP_STREAM_LIMIT = 512
@@ -238,7 +230,7 @@ function routeDesktopEvent(event: BufferedDesktopEvent): void {
       return
     }
     if (event.kind === 'chunk') {
-      const schema = uiMessageChunkSchema() as unknown as UIMessageChunkValidator
+      const schema = uiMessageChunkSchema()
       if (!schema.validate) {
         closeDesktopStreamWithError(state, new Error('AI SDK UIMessageChunk schema is unavailable'))
         return

--- a/apps/web/src/features/chat/transport/sse-chat-transport.ts
+++ b/apps/web/src/features/chat/transport/sse-chat-transport.ts
@@ -23,13 +23,7 @@ type RunSettledHandler = (data: ChatRunSettledPayload) => void
 type ChatRunBroadcastEvent
   = | { kind: 'activity', payload: ChatRunActivityPayload }
     | { kind: 'settled', payload: ChatRunSettledPayload }
-type UIMessageChunkValidationResult
-  = | { success: true, value: UIMessageChunk }
-    | { success: false, error: unknown }
-
-interface UIMessageChunkValidator {
-  validate?: (value: unknown) => UIMessageChunkValidationResult | PromiseLike<UIMessageChunkValidationResult>
-}
+type UIMessageChunkValidator = ReturnType<typeof uiMessageChunkSchema>
 
 const globalHandlers = new Set<RunActivityHandler>()
 const settledHandlers = new Set<RunSettledHandler>()
@@ -249,7 +243,7 @@ function parseUIMessageChunkEventStream(
   stream: ReadableStream<Uint8Array>,
   initialReplay = false,
 ): ReadableStream<ParsedUIMessageChunk> {
-  const schema = uiMessageChunkSchema() as unknown as UIMessageChunkValidator
+  const schema = uiMessageChunkSchema()
   if (!schema.validate) {
     throw new Error('AI SDK UIMessageChunk schema is unavailable')
   }

--- a/apps/web/src/features/chat/ui/use-chat-scroll-runtime.ts
+++ b/apps/web/src/features/chat/ui/use-chat-scroll-runtime.ts
@@ -36,10 +36,8 @@ interface ChatScrollDisplayRow {
 interface UseChatScrollRuntimeOptions {
   active: boolean
   sessionId: string | null
-  /** Virtualized transcript rows (display order). Prefer expanded steer rows. */
-  displayRows?: ChatScrollDisplayRow[]
-  /** @deprecated Prefer displayRows — kept for callers that only have canonical ids. */
-  messageIds?: string[]
+  /** Virtualized transcript rows in display order, including expanded steer rows. */
+  displayRows: ChatScrollDisplayRow[]
   status: string
 }
 
@@ -75,12 +73,11 @@ export function useChatScrollRuntime({
   active,
   sessionId,
   displayRows,
-  messageIds: legacyMessageIds,
   status,
 }: UseChatScrollRuntimeOptions): ChatScrollRuntime {
   const messageIds = useMemo(
-    () => displayRows?.map(row => row.messageId) ?? legacyMessageIds ?? [],
-    [displayRows, legacyMessageIds],
+    () => displayRows.map(row => row.messageId),
+    [displayRows],
   )
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const viewportRef = useRef<HTMLDivElement>(null)

--- a/apps/web/src/features/desktop-tray/api.ts
+++ b/apps/web/src/features/desktop-tray/api.ts
@@ -1,15 +1,11 @@
-import { getServerUrl } from '~/lib/electron'
+import { getDesktopAwaits } from '~/api-gen/sdk.gen'
 
 import type { DesktopAwaitItem } from './types'
 
-async function requestDesktopJson(path: string): Promise<unknown> {
-  const response = await fetch(`${getServerUrl()}${path}`, { cache: 'no-store' })
-  if (!response.ok) {
-    throw new Error(`Request failed: ${response.status}`)
-  }
-  return response.json()
-}
-
 export async function readDesktopAwaits(): Promise<DesktopAwaitItem[]> {
-  return await requestDesktopJson('/desktop/awaits') as DesktopAwaitItem[]
+  const { data } = await getDesktopAwaits({
+    cache: 'no-store',
+    throwOnError: true,
+  })
+  return data
 }

--- a/apps/web/src/features/devtool/acp/acp-event-detail.tsx
+++ b/apps/web/src/features/devtool/acp/acp-event-detail.tsx
@@ -1,7 +1,3 @@
-// Input: ACP devtool store, cn utility
-// Output: AcpEventDetail — metadata and raw output viewer for a selected ACP runtime event
-// Position: Right pane of the ACP runtime mode inside the devtool page
-
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/apps/web/src/features/devtool/acp/acp-events-table.tsx
+++ b/apps/web/src/features/devtool/acp/acp-events-table.tsx
@@ -1,7 +1,3 @@
-// Input: ACP devtool stores, filtered ACP process events, cn utility
-// Output: AcpEventsTable — selectable event timeline for ACP lifecycle and stream output
-// Position: Left pane of the ACP runtime mode inside the devtool page
-
 import { cn } from '~/lib/cn'
 
 import { useAcpDevtoolStore, useAcpFilteredEvents } from './use-acp-events'

--- a/apps/web/src/features/devtool/acp/acp-filter-bar.tsx
+++ b/apps/web/src/features/devtool/acp/acp-filter-bar.tsx
@@ -1,7 +1,3 @@
-// Input: ACP devtool Zustand stores, cn utility
-// Output: AcpFilterBar — search, agent select, stream toggles, pause, and clear controls
-// Position: Top toolbar for the ACP runtime pane inside the devtool page
-
 import { useTranslation } from 'react-i18next'
 
 import { cn } from '~/lib/cn'

--- a/apps/web/src/features/devtool/acp/use-acp-events.ts
+++ b/apps/web/src/features/devtool/acp/use-acp-events.ts
@@ -1,7 +1,3 @@
-// Input: ACP devtool preload API, ACP runtime event types, Zustand selectors
-// Output: ACP devtool stores and derived hooks for filtered ACP process events
-// Position: Core state layer for the ACP runtime pane inside the devtool feature
-
 import { useMemo } from 'react'
 import { create } from 'zustand'
 

--- a/apps/web/src/features/devtool/acp/use-acp-keyboard.ts
+++ b/apps/web/src/features/devtool/acp/use-acp-keyboard.ts
@@ -1,7 +1,3 @@
-// Input: window keydown events, acp-devtool stores (selection / paused / clear), filtered events
-// Output: useAcpKeyboard hook wiring arrow-key row navigation plus pause/clear/search shortcuts
-// Position: Called once from IpcDevtoolPage — owns the ACP pane's global keybindings
-
 import { useEffect } from 'react'
 
 import { useAcpDevtoolStore, useAcpFilteredEvents } from './use-acp-events'

--- a/apps/web/src/features/devtool/flow-color.ts
+++ b/apps/web/src/features/devtool/flow-color.ts
@@ -1,7 +1,3 @@
-// Input: Stable string → palette mapping for IPC flow id color chips
-// Output: flowColor(id) — Tailwind bg class chosen deterministically per flowId
-// Position: Small helper used by ipc-events-table and ipc-event-detail for visual grouping
-
 const PALETTE = [
   'bg-sky-500',
   'bg-violet-500',

--- a/apps/web/src/features/devtool/health/health-panel.tsx
+++ b/apps/web/src/features/devtool/health/health-panel.tsx
@@ -1,61 +1,27 @@
-import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 
-import { getServerUrl } from '~/lib/electron'
+import { getHealthOptions } from '~/api-gen/@tanstack/react-query.gen'
 import { formatUptimeSeconds } from '~/lib/number-format'
-
-const SERVER_BASE = getServerUrl()
-
-interface HealthData {
-  status: string
-  uptime: number
-  memory: {
-    heapUsed: number
-    heapTotal: number
-    rss: number
-    external: number
-  }
-  timestamp: number
-}
 
 export function HealthPanel() {
   const { t } = useTranslation('devtool')
-  const [health, setHealth] = useState<HealthData | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  const healthQuery = useQuery({
+    ...getHealthOptions(),
+    refetchInterval: 10_000,
+  })
 
-  const fetchHealth = async () => {
-    try {
-      const res = await fetch(`${SERVER_BASE}/health`)
-      if (!res.ok) {
-        setError(`HTTP ${res.status}`)
-        return
-      }
-      const data: HealthData = await res.json()
-      setHealth(data)
-      setError(null)
-    }
-    catch (err) {
-      setError(String(err))
-    }
-  }
-
-  useEffect(() => {
-    void fetchHealth()
-    const id = setInterval(() => void fetchHealth(), 10_000)
-    return () => clearInterval(id)
-  }, [fetchHealth])
-
-  if (error) {
+  if (healthQuery.error) {
     return (
       <div className="flex h-full items-center justify-center p-4 text-xs text-muted-foreground/50">
         {t('health.fetchError')}
 {' '}
-{error}
+        {healthQuery.error.message}
       </div>
     )
   }
 
-  if (!health) {
+  if (!healthQuery.data) {
     return (
       <div className="flex h-full items-center justify-center text-xs text-muted-foreground/50">
         {t('status.loading')}
@@ -63,6 +29,7 @@ export function HealthPanel() {
     )
   }
 
+  const health = healthQuery.data
   const rows: [string, string][] = [
     [t('health.status'), health.status],
     [t('health.uptime'), formatUptimeSeconds(health.uptime, { includeSeconds: true })],

--- a/apps/web/src/features/devtool/ipc/ipc-event-detail.tsx
+++ b/apps/web/src/features/devtool/ipc/ipc-event-detail.tsx
@@ -1,7 +1,3 @@
-// Input: Zustand selection store, cn utility
-// Output: IpcEventDetail — selected trace metadata + args/result/error/stack tabs + flow timeline for push streams
-// Position: Right pane inside the IPC devtool page
-
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 

--- a/apps/web/src/features/devtool/ipc/ipc-events-table.tsx
+++ b/apps/web/src/features/devtool/ipc/ipc-events-table.tsx
@@ -1,7 +1,3 @@
-// Input: Zustand ipc-devtool stores, IpcTrace model, cn utility
-// Output: IpcEventsTable — sortable, selectable table of IPC traces grouped by traceId
-// Position: Left/main pane inside the IPC devtool page
-
 import { useMemo, useState } from 'react'
 
 import { cn } from '~/lib/cn'

--- a/apps/web/src/features/devtool/ipc/ipc-filter-bar.tsx
+++ b/apps/web/src/features/devtool/ipc/ipc-filter-bar.tsx
@@ -1,7 +1,3 @@
-// Input: Zustand ipc-devtool stores, @cradle/ipc status/side types, cn utility
-// Output: IpcFilterBar — search / status / side toggles + pause & clear controls for the devtool
-// Position: Top toolbar inside the IPC devtool page
-
 import { useTranslation } from 'react-i18next'
 
 import { cn } from '~/lib/cn'

--- a/apps/web/src/features/devtool/ipc/use-ipc-events.ts
+++ b/apps/web/src/features/devtool/ipc/use-ipc-events.ts
@@ -1,7 +1,3 @@
-// Input: window.ipcDevtool preload API, Zustand create/selectors
-// Output: useIpcDevtoolStore / useIpcFiltersStore / useIpcTraces / useIpcFilteredTraces hooks driving the devtool UI
-// Position: Core state layer for the ipc-devtool feature (single producer, single consumer per devtool window)
-
 import { useMemo } from 'react'
 import { create } from 'zustand'
 

--- a/apps/web/src/features/devtool/ipc/use-ipc-keyboard.ts
+++ b/apps/web/src/features/devtool/ipc/use-ipc-keyboard.ts
@@ -1,7 +1,3 @@
-// Input: window keydown events, ipc-devtool stores (selection / paused / clear), filtered traces
-// Output: useIpcKeyboard hook wiring arrow-key row navigation plus pause/clear/search shortcuts
-// Position: Called once from IpcDevtoolPage — owns the devtool window's global keybindings
-
 import { useEffect } from 'react'
 
 import { useIpcDevtoolStore, useIpcFilteredTraces } from './use-ipc-events'

--- a/apps/web/src/features/devtool/observability/use-observability-events.ts
+++ b/apps/web/src/features/devtool/observability/use-observability-events.ts
@@ -1,76 +1,14 @@
-import { z } from 'zod'
 import { create } from 'zustand'
 
-import { getServerUrl } from '~/lib/electron'
-
-const SERVER_BASE = getServerUrl()
-
-interface ObservabilityEvent {
-  id: string
-  source: string
-  code: string
-  severity: string
-  category: string
-  message: string
-  attrs?: Record<string, unknown>
-  chatSessionId?: string
-  runId?: string
-  occurredAt: number
-  recordedAt: number
-}
-
-interface ObservabilityIncident {
-  id: string
-  dedupeKey: string
-  code: string
-  severity: string
-  status: 'open' | 'resolved'
-  source: string
-  message: string
-  chatSessionId?: string
-  runId?: string
-  firstOccurredAt: number
-  lastOccurredAt: number
-  lastRecordedAt: number
-  count: number
-}
-
-const ObservabilityEventSchema = z.object({
-  id: z.string(),
-  source: z.string(),
-  code: z.string(),
-  severity: z.string(),
-  category: z.string(),
-  message: z.string(),
-  attrs: z.record(z.string(), z.unknown()).optional(),
-  chatSessionId: z.string().optional(),
-  runId: z.string().optional(),
-  occurredAt: z.number().finite(),
-  recordedAt: z.number().finite(),
-})
-
-const ObservabilityIncidentSchema = z.object({
-  id: z.string(),
-  dedupeKey: z.string(),
-  code: z.string(),
-  severity: z.string(),
-  status: z.enum(['open', 'resolved']),
-  source: z.string(),
-  message: z.string(),
-  chatSessionId: z.string().optional(),
-  runId: z.string().optional(),
-  firstOccurredAt: z.number().finite(),
-  lastOccurredAt: z.number().finite(),
-  lastRecordedAt: z.number().finite(),
-  count: z.number().finite(),
-})
-
-const ObservabilityEventsSchema = z.array(ObservabilityEventSchema)
-const ObservabilityIncidentsSchema = z.array(ObservabilityIncidentSchema)
+import { getObservabilityEvents, getObservabilityIncidents } from '~/api-gen/sdk.gen'
+import type {
+  GetObservabilityEventsResponse,
+  GetObservabilityIncidentsResponse,
+} from '~/api-gen/types.gen'
 
 export type ObservabilityEntry
-  = | { kind: 'event', payload: ObservabilityEvent }
-    | { kind: 'incident', payload: ObservabilityIncident }
+  = | { kind: 'event', payload: GetObservabilityEventsResponse[number] }
+    | { kind: 'incident', payload: GetObservabilityIncidentsResponse[number] }
 
 interface ObservabilityDevtoolState {
   entries: ObservabilityEntry[]
@@ -90,16 +28,18 @@ export const useObservabilityDevtoolStore = create<ObservabilityDevtoolState>(se
   load: async () => {
     set({ loading: true, error: null })
     try {
-      const [eventsRes, incidentsRes] = await Promise.all([
-        fetch(`${SERVER_BASE}/observability/events?limit=200`),
-        fetch(`${SERVER_BASE}/observability/incidents?limit=50`),
+      const [eventsResponse, incidentsResponse] = await Promise.all([
+        getObservabilityEvents({
+          query: { limit: '200' },
+          throwOnError: true,
+        }),
+        getObservabilityIncidents({
+          query: { limit: '50' },
+          throwOnError: true,
+        }),
       ])
-      if (!eventsRes.ok || !incidentsRes.ok) {
-        throw new Error('Failed to load observability entries')
-      }
-
-      const events = ObservabilityEventsSchema.parse(await eventsRes.json())
-      const incidents = ObservabilityIncidentsSchema.parse(await incidentsRes.json())
+      const events = eventsResponse.data
+      const incidents = incidentsResponse.data
 
       const entries: ObservabilityEntry[] = [
         ...events.map(e => ({ kind: 'event' as const, payload: e })),

--- a/apps/web/src/features/onboarding/credential-setup-store.ts
+++ b/apps/web/src/features/onboarding/credential-setup-store.ts
@@ -93,6 +93,3 @@ export const useFirstRunSetupStore = create<FirstRunSetupState>()(
     },
   ),
 )
-
-/** @deprecated Prefer useFirstRunSetupStore. */
-export const useCredentialSetupStore = useFirstRunSetupStore

--- a/apps/web/src/features/settings/worktree-settings.tsx
+++ b/apps/web/src/features/settings/worktree-settings.tsx
@@ -8,6 +8,13 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
+  getWorktreesManagedOptions,
+  getWorktreesManagedQueryKey,
+  postWorkspacesByWorkspaceIdWorktreesByWorktreeIdCleanupMutation,
+  postWorktreesCleanupMutation,
+} from '~/api-gen/@tanstack/react-query.gen'
+import type { GetWorktreesManagedResponse } from '~/api-gen/types.gen'
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -29,7 +36,6 @@ import {
 } from '~/components/ui/number-field'
 import { Spinner } from '~/components/ui/spinner'
 import { cn } from '~/lib/cn'
-import { getServerUrl } from '~/lib/electron'
 
 import { SettingsGroup, SettingsPage } from './settings-container'
 import { SettingsRow } from './settings-row'
@@ -37,37 +43,7 @@ import type { AppPreferences } from './use-app-preferences'
 import { useAppPreferences } from './use-app-preferences'
 
 type SettingsKey = keyof typeof import('~/locales/default').default.settings
-
-interface ManagedWorktree {
-  id: string
-  sourceWorkspaceId: string
-  workspaceName: string
-  name: string
-  path: string
-  branch: string
-  baseRef: string
-  status: 'active' | 'merged' | 'abandoned'
-  createdBySessionId: string | null
-  createdAt: number
-  updatedAt: number
-  sizeBytes: number
-  sizeMeasuredAt: number | null
-  sizeMeasurementError: string | null
-  sessionCount: number
-}
-
-interface ManagedWorktreeListResponse {
-  worktrees: ManagedWorktree[]
-  totalSizeBytes: number
-}
-
-interface CleanupResponse {
-  cleaned: ManagedWorktree[]
-  skipped: number
-  totalSizeBytes: number
-}
-
-const MANAGED_WORKTREES_QUERY_KEY = ['managed-worktrees']
+type ManagedWorktree = GetWorktreesManagedResponse['worktrees'][number]
 
 function formatBytes(bytes: number): string {
   if (bytes <= 0) {
@@ -95,40 +71,17 @@ function clampNumber(value: number | null | undefined, min: number, max: number)
   return Math.min(Math.max(Math.round(value), min), max)
 }
 
-async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
-  const response = await fetch(new URL(path, getServerUrl()), {
-    ...init,
-    headers: {
-      'content-type': 'application/json',
-      ...init?.headers,
-    },
-  })
-  if (!response.ok) {
-    throw new Error(await response.text())
-  }
-  return await response.json() as T
-}
-
 function useManagedWorktrees() {
-  return useQuery({
-    queryKey: MANAGED_WORKTREES_QUERY_KEY,
-    queryFn: () => requestJson<ManagedWorktreeListResponse>('/worktrees/managed'),
-  })
+  return useQuery(getWorktreesManagedOptions())
 }
 
 function useCleanupWorktree() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (worktree: ManagedWorktree) => requestJson<{ ok: true }>(
-      `/workspaces/${encodeURIComponent(worktree.sourceWorkspaceId)}/worktrees/${encodeURIComponent(worktree.id)}/cleanup`,
-      {
-        method: 'POST',
-        body: JSON.stringify({ mode: 'abandon' }),
-      },
-    ),
+    ...postWorkspacesByWorkspaceIdWorktreesByWorktreeIdCleanupMutation(),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: MANAGED_WORKTREES_QUERY_KEY })
+      await queryClient.invalidateQueries({ queryKey: getWorktreesManagedQueryKey() })
     },
   })
 }
@@ -137,12 +90,9 @@ function useCleanupPolicy() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (policy: AppPreferences['worktreeCleanup']) => requestJson<CleanupResponse>('/worktrees/cleanup', {
-      method: 'POST',
-      body: JSON.stringify(policy),
-    }),
+    ...postWorktreesCleanupMutation(),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: MANAGED_WORKTREES_QUERY_KEY })
+      await queryClient.invalidateQueries({ queryKey: getWorktreesManagedQueryKey() })
     },
   })
 }
@@ -230,7 +180,10 @@ export function WorktreeSettings() {
   const cleanupPolicy = useCleanupPolicy()
   const [confirmWorktree, setConfirmWorktree] = useState<ManagedWorktree | null>(null)
 
-  const worktrees = worktreesQuery.data?.worktrees ?? []
+  const worktrees = useMemo(
+    () => worktreesQuery.data?.worktrees ?? [],
+    [worktreesQuery.data?.worktrees],
+  )
   const totalSizeBytes = worktreesQuery.data?.totalSizeBytes ?? 0
   const sortedWorktrees = useMemo(
     () => [...worktrees].sort((left, right) => right.createdAt - left.createdAt),
@@ -256,7 +209,13 @@ export function WorktreeSettings() {
     if (!confirmWorktree) {
       return
     }
-    cleanupOne.mutate(confirmWorktree, {
+    cleanupOne.mutate({
+      path: {
+        workspaceId: confirmWorktree.sourceWorkspaceId,
+        worktreeId: confirmWorktree.id,
+      },
+      body: { mode: 'abandon' },
+    }, {
       onSettled: () => setConfirmWorktree(null),
     })
   }
@@ -276,7 +235,7 @@ export function WorktreeSettings() {
             variant="outline"
             size="sm"
             disabled={!prefs || cleanupBusy || prefsLoading}
-            onClick={() => cleanupPolicy.mutate(policy)}
+            onClick={() => cleanupPolicy.mutate({ body: policy })}
           >
             {cleanupPolicy.isPending ? <Spinner className="size-3.5" /> : <RefreshIcon className="size-3.5" />}
             {t('worktrees.action.runCleanup' as SettingsKey)}
@@ -350,7 +309,7 @@ export function WorktreeSettings() {
                     <WorktreeRow
                       key={worktree.id}
                       worktree={worktree}
-                      busy={cleanupOne.isPending && cleanupOne.variables?.id === worktree.id}
+                      busy={cleanupOne.isPending && cleanupOne.variables?.path.worktreeId === worktree.id}
                       onCleanup={setConfirmWorktree}
                     />
                   ))}

--- a/apps/web/src/lib/dotmatrix-core.tsx
+++ b/apps/web/src/lib/dotmatrix-core.tsx
@@ -6,6 +6,10 @@ import type { CSSProperties } from 'react'
 
 import { useDotMatrixPhases, usePrefersReducedMotion } from '~/lib/dotmatrix-hooks'
 
+type DotMatrixStyle = CSSProperties & {
+  [property in `--dmx-${string}`]?: string | number
+}
+
 export type MatrixPattern = 'diamond' | 'full' | 'outline' | 'rose' | 'cross' | 'rings'
 export type DotShape = 'circle' | 'square' | 'diamond' | 'hearts'
 export type DotMatrixPhase = 'idle' | 'collapse' | 'hoverRipple' | 'loadingRipple'
@@ -735,7 +739,7 @@ export function DotMatrixBase({
   const unit = dotSize + gap
   const { resolvedColor, dotFill } = resolveDmxColorTokens(color, colorPreset)
 
-  const dmxVarStyle = {
+  const dmxVarStyle: DotMatrixStyle = {
     'width': matrixSpan,
     'height': matrixSpan,
     '--dmx-speed': speedScale,
@@ -752,7 +756,7 @@ export function DotMatrixBase({
         transformOrigin: 'center center' as const,
       }
       : { minWidth: minSize, minHeight: minSize }),
-  } as unknown as CSSProperties
+  }
 
   const dots = Array.from({ length: MATRIX_SIZE * MATRIX_SIZE }).map((_, index) => {
     const { row, col } = indexToCoord(index)

--- a/apps/web/src/lib/electron.ts
+++ b/apps/web/src/lib/electron.ts
@@ -7,7 +7,6 @@ import {
   getRendererServerUrl,
   getServerNetworkUrl as getTransportServerNetworkUrl,
   isCradleServerLocalUrl,
-  isCustomSchemeProxyMode,
 } from './server-transport/base-url'
 
 /**
@@ -88,30 +87,6 @@ export async function getAuthenticatedServerWebSocketUrl(
   }
   const payload = await response.json() as { ticket: string }
   return getServerWebSocketUrl(path, { ...query, ticket: payload.ticket })
-}
-
-/**
- * @deprecated Prefer `openServerEventSource` (fetch-backed SSE via cradleFetch).
- * Kept for residual HTTP ticket flows until all call sites migrate.
- */
-export async function getAuthenticatedEventSourceUrl(url: string): Promise<string> {
-  // Custom-scheme proxy mode: Main injects credentials; tickets are unnecessary.
-  if (isCustomSchemeProxyMode()) {
-    return new URL(url, getServerUrl()).toString()
-  }
-  const target = new URL(url, getServerUrl())
-  const audience = `sse:${target.pathname}`
-  const response = await cradleFetch(new URL('/auth/websocket-ticket', getServerUrl()), {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ audience }),
-  })
-  if (!response.ok) {
-    throw new Error(`Failed to issue event stream ticket: HTTP ${response.status}`)
-  }
-  const payload = await response.json() as { ticket: string }
-  target.searchParams.set('eventTicket', payload.ticket)
-  return target.toString()
 }
 
 /**

--- a/apps/web/src/lib/observability-client.ts
+++ b/apps/web/src/lib/observability-client.ts
@@ -1,4 +1,6 @@
-import { getServerUrl, isElectron, platform } from './electron'
+import { postObservabilityEvents } from '~/api-gen/sdk.gen'
+
+import { isElectron, platform } from './electron'
 
 type ObservabilitySeverity = 'debug' | 'info' | 'warn' | 'error' | 'fatal'
 type ObservabilityCategory = 'chat' | 'provider' | 'event-bus' | 'ipc' | 'system' | 'performance' | 'diagnostics'
@@ -47,10 +49,9 @@ export function reportRendererObservabilityEvent(input: RendererObservabilityEve
     },
   }
 
-  void fetch(new URL('/observability/events', getServerUrl()), {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(payload),
+  void postObservabilityEvents({
+    body: payload,
+    throwOnError: true,
   }).catch(() => {})
 }
 

--- a/apps/web/src/locales/default/index.ts
+++ b/apps/web/src/locales/default/index.ts
@@ -63,4 +63,8 @@ export type Namespace = keyof DefaultResources
 
 export const allNamespaces = Object.keys(resources) as Namespace[]
 
+export function isNamespace(value: string): value is Namespace {
+  return value in resources
+}
+
 export default resources

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,20 +11,18 @@ import { I18nProvider } from './i18n/client'
 import { bootstrapBrowserAuthSession } from './lib/server-credential'
 import { waitForServer } from './lib/server-readiness'
 
-type SharedModuleRegistry = Window & {
-  [key: symbol]: Record<string, unknown>
-}
-
 // Expose shared React modules for plugin runtime
 // Plugins loaded via dynamic import() need access to the SAME React instance
-const sharedModuleRegistry = window as unknown as SharedModuleRegistry
-sharedModuleRegistry[Symbol.for('cradle:modules')] = {
-  'react': React,
-  'react-dom': ReactDOM,
-  'react-dom/client': ReactDOMClient,
-  'react/jsx-dev-runtime': ReactJSXDevRuntime,
-  'react/jsx-runtime': ReactJSXRuntime,
-}
+Object.defineProperty(window, Symbol.for('cradle:modules'), {
+  configurable: true,
+  value: {
+    'react': React,
+    'react-dom': ReactDOM,
+    'react-dom/client': ReactDOMClient,
+    'react/jsx-dev-runtime': ReactJSXDevRuntime,
+    'react/jsx-runtime': ReactJSXRuntime,
+  },
+})
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/apps/web/src/store/chat.ts
+++ b/apps/web/src/store/chat.ts
@@ -1,4 +1,4 @@
-// This file is kept for backwards compatibility — all code lives in ./chat/
+// Public chat-store API.
 export type { ChatDisplayRow, MessagePartsProjection } from './chat/expand-messages-for-display'
 export { chatSelectors, createChatStore, getChatStoreTelemetrySnapshot, useChatStore } from './chat/store'
 export type {

--- a/apps/web/src/store/chat/index.ts
+++ b/apps/web/src/store/chat/index.ts
@@ -1,4 +1,4 @@
-// Public API — same exports as before
+// Public chat-store API.
 export type { ChatDisplayRow, MessagePartsProjection } from './expand-messages-for-display'
 export { chatSelectors, createChatStore, getChatStoreTelemetrySnapshot, useChatStore } from './store'
 export type {

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -38,13 +38,18 @@ if (typeof globalThis.Event === 'undefined') {
 }
 
 if (typeof globalThis.MessageEvent === 'undefined') {
-  globalThis.MessageEvent = class MessageEvent extends Event {
+  class TestMessageEvent extends Event {
     data: unknown
     constructor(type: string, init?: MessageEventInit) {
       super(type)
       this.data = init?.data ?? null
     }
-  } as unknown as typeof MessageEvent
+  }
+  Object.defineProperty(globalThis, 'MessageEvent', {
+    configurable: true,
+    value: TestMessageEvent,
+    writable: true,
+  })
 }
 
 if (typeof globalThis.ResizeObserver === 'undefined') {

--- a/packages/model-api-simulator/protocol/generated-artifacts.json
+++ b/packages/model-api-simulator/protocol/generated-artifacts.json
@@ -5,5 +5,5 @@
     "openai-schemas.ts": "44f9398e91c7fd40c897e10e34d538df82a7c4c38c0987645c7b7c9a3081eb58",
     "protocol-coverage.json": "6668151111e133884f102b9a39ec288b3db1705d4affb3eab75fd974c5d40340"
   },
-  "inputFingerprint": "399309ba90187298ec50af5146f0f7107f21898f2f8fd1ae3f8462207077fdbe"
+  "inputFingerprint": "c256d5b9cfa6afcceff8aa7fbe3cafb2300d04539c3feb3d4e01ce3914b66d01"
 }

--- a/packages/model-api-simulator/protocol/generated-artifacts.json
+++ b/packages/model-api-simulator/protocol/generated-artifacts.json
@@ -5,5 +5,5 @@
     "openai-schemas.ts": "44f9398e91c7fd40c897e10e34d538df82a7c4c38c0987645c7b7c9a3081eb58",
     "protocol-coverage.json": "6668151111e133884f102b9a39ec288b3db1705d4affb3eab75fd974c5d40340"
   },
-  "inputFingerprint": "c256d5b9cfa6afcceff8aa7fbe3cafb2300d04539c3feb3d4e01ce3914b66d01"
+  "inputFingerprint": "d34d43b466a7ed6cd0cd769cbb34a19f77ff3a33f621439f877f606d2dd91655"
 }

--- a/packages/model-api-simulator/scripts/check-protocol-coverage.ts
+++ b/packages/model-api-simulator/scripts/check-protocol-coverage.ts
@@ -10,19 +10,88 @@ import {
   ensureProtocolArtifactCache,
   readGeneratedArtifactManifest,
 } from './protocol-artifact-cache'
-import { readJson } from './protocol-utils'
+import type { Json } from './protocol-utils'
+import { asRecord, readJson } from './protocol-utils'
 
 interface CorpusManifest {
   readonly witnesses: readonly {
     readonly id: string
-    readonly schemaId: string
+    readonly schemaId: ProtocolSchemaId
     readonly value: JsonValue
   }[]
   readonly invalidWitnesses: readonly {
     readonly id: string
-    readonly schemaId: string
+    readonly schemaId: ProtocolSchemaId
     readonly value: JsonValue
   }[]
+}
+
+function readString(value: Json | undefined, label: string): string {
+  if (typeof value !== 'string') {
+    throw new TypeError(`Expected ${label} to be a string`)
+  }
+  return value
+}
+
+function readStringArray(value: Json | undefined, label: string): string[] {
+  if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) {
+    throw new Error(`Expected ${label} to be a string array`)
+  }
+  return value
+}
+
+function readProtocolSchemaId(value: Json | undefined, label: string): ProtocolSchemaId {
+  const schemaId = readString(value, label)
+  const anthropicPrefix = 'anthropic:draft-07:'
+  if (schemaId.startsWith(anthropicPrefix) && schemaId.length > anthropicPrefix.length) {
+    return `anthropic:draft-07:${schemaId.slice(anthropicPrefix.length)}`
+  }
+  const openAiPrefix = 'openai:2020-12:'
+  if (schemaId.startsWith(openAiPrefix) && schemaId.length > openAiPrefix.length) {
+    return `openai:2020-12:${schemaId.slice(openAiPrefix.length)}`
+  }
+  throw new Error(`Invalid protocol schema ID in ${label}: ${schemaId}`)
+}
+
+function readWitnesses(value: Json | undefined, label: string): CorpusManifest['witnesses'] {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`Expected ${label} to be an array`)
+  }
+  return value.map((entry, index) => {
+    const record = asRecord(entry)
+    if (record.value === undefined) {
+      throw new Error(`Expected ${label}[${index}].value`)
+    }
+    return {
+      id: readString(record.id, `${label}[${index}].id`),
+      schemaId: readProtocolSchemaId(record.schemaId, `${label}[${index}].schemaId`),
+      value: record.value,
+    }
+  })
+}
+
+function readCorpusManifest(value: Json): CorpusManifest {
+  const record = asRecord(value)
+  return {
+    witnesses: readWitnesses(record.witnesses, 'witnesses'),
+    invalidWitnesses: readWitnesses(record.invalidWitnesses, 'invalidWitnesses'),
+  }
+}
+
+function readCoverageManifest(value: Json): CoverageManifest {
+  const record = asRecord(value)
+  const schemaBranches = asRecord(record.schemaBranches)
+  const transitions = asRecord(record.transitions)
+  return {
+    schemaBranches: {
+      covered: readStringArray(schemaBranches.covered, 'schemaBranches.covered'),
+      uncovered: readStringArray(schemaBranches.uncovered, 'schemaBranches.uncovered'),
+    },
+    transitions: {
+      covered: readStringArray(transitions.covered, 'transitions.covered'),
+      uncovered: readStringArray(transitions.uncovered, 'transitions.uncovered'),
+    },
+  }
 }
 
 interface CoverageManifest {
@@ -41,12 +110,12 @@ const cache = await ensureProtocolArtifactCache(
   manifest.inputFingerprint,
   generateProtocolArtifacts,
 )
-const corpus = await readJson(
+const corpus = readCorpusManifest(await readJson(
   resolve(cache.directory, 'corpus-manifest.json'),
-) as unknown as CorpusManifest
-const coverage = await readJson(
+))
+const coverage = readCoverageManifest(await readJson(
   resolve(cache.directory, 'protocol-coverage.json'),
-) as unknown as CoverageManifest
+))
 
 const uncovered = [...coverage.schemaBranches.uncovered, ...coverage.transitions.uncovered]
 if (uncovered.length > 0) {
@@ -55,10 +124,10 @@ if (uncovered.length > 0) {
 
 const registry = new JsonSchemaRegistry()
 for (const witness of corpus.witnesses) {
-  if (!registry.accepts(witness.schemaId as ProtocolSchemaId, witness.value)) { throw new Error(`Generated positive witness failed schema validation: ${witness.id}`) }
+  if (!registry.accepts(witness.schemaId, witness.value)) { throw new Error(`Generated positive witness failed schema validation: ${witness.id}`) }
 }
 for (const witness of corpus.invalidWitnesses) {
-  if (registry.accepts(witness.schemaId as ProtocolSchemaId, witness.value)) { throw new Error(`Generated negative witness unexpectedly passed schema validation: ${witness.id}`) }
+  if (registry.accepts(witness.schemaId, witness.value)) { throw new Error(`Generated negative witness unexpectedly passed schema validation: ${witness.id}`) }
 }
 
 console.log(

--- a/packages/model-api-simulator/scripts/protocol-artifact-cache.ts
+++ b/packages/model-api-simulator/scripts/protocol-artifact-cache.ts
@@ -89,7 +89,21 @@ export async function refreshProtocolArtifactCache(
 
 export async function readGeneratedArtifactManifest(): Promise<GeneratedArtifactManifest> {
   const manifest = asRecord(await readJson(MANIFEST_PATH))
-  return manifest as unknown as GeneratedArtifactManifest
+  if (typeof manifest.inputFingerprint !== 'string') {
+    throw new TypeError('Generated artifact manifest is missing inputFingerprint')
+  }
+  const rawFiles = asRecord(manifest.files)
+  const files = Object.fromEntries(GENERATED_FILES.map((file) => {
+    const hash = rawFiles[file]
+    if (typeof hash !== 'string') {
+      throw new TypeError(`Generated artifact manifest is missing hash for ${file}`)
+    }
+    return [file, hash]
+  }))
+  return {
+    inputFingerprint: manifest.inputFingerprint,
+    files,
+  }
 }
 
 export async function protocolArtifactInputFingerprint(): Promise<string> {

--- a/packages/streamdown/src/plugins/remark-attribute-directive.ts
+++ b/packages/streamdown/src/plugins/remark-attribute-directive.ts
@@ -1,4 +1,4 @@
-import type { Paragraph, PhrasingContent, Root, RootContent } from 'mdast'
+import type { Paragraph, PhrasingContent, Root } from 'mdast'
 import type {
   CompileContext,
   Extension as FromMarkdownExtension,
@@ -376,7 +376,7 @@ function liftAttributeDirectives(tree: Root, name: string) {
       return
     }
 
-    const children = node.children as PhrasingContent[]
+    const children = node.children
     let hasDirective = false
     for (const child of children) {
       if (child.type === name) {
@@ -388,7 +388,7 @@ function liftAttributeDirectives(tree: Root, name: string) {
       return
     }
 
-    const replacement: RootContent[] = []
+    const replacement: unknown[] = []
     let buffer: PhrasingContent[] = []
 
     const flushBuffer = () => {
@@ -403,16 +403,24 @@ function liftAttributeDirectives(tree: Root, name: string) {
     for (const child of children) {
       if (child.type === name) {
         flushBuffer()
-        replacement.push(child as unknown as RootContent)
+        replacement.push(child)
         continue
       }
       buffer.push(child)
     }
     flushBuffer()
 
-    parent.children.splice(index, 1, ...replacement)
+    replaceChild(parent, index, replacement)
     return [SKIP, index + replacement.length]
   })
+}
+
+function replaceChild(
+  parent: { children: unknown[] },
+  index: number,
+  replacement: unknown[],
+): void {
+  parent.children.splice(index, 1, ...replacement)
 }
 
 function trimParagraphChildren(children: PhrasingContent[]): PhrasingContent[] {


### PR DESCRIPTION
## Summary

- migrate equivalent non-Chronicle JSON requests to the generated API client and React Query
- remove 55 AI-generated `Input / Output / Position` file headers
- migrate callers away from deprecated and backwards-compatibility APIs, then remove the legacy surfaces
- eliminate audited `as unknown as` casts with public ownership APIs, real imported types, adapters, property descriptors, or runtime validation
- replace Claude Agent harness access to private `activeQueries` state with a public read-only query count
- remove the legacy PTY `codexCliSession` field and single-bucket Codex rate-limit compatibility mirror

Chronicle is intentionally excluded from this cleanup.

## Why

The repository had accumulated parallel hand-written HTTP layers beside api-gen, compatibility fields whose callers had already moved on, AI boilerplate headers, and unsafe double assertions at ownership boundaries. These patterns weakened generated API guarantees and allowed consumers to reach into private provider state.

## Impact

Equivalent JSON endpoints now use the generated contract, health polling uses generated React Query options, provider state is read through an explicit public API, and legacy compatibility surfaces are gone. Raw transport remains where api-gen is not equivalent, including SSE, binary downloads, startup probes, multipart uploads, and private dynamic plugin routes.

## Validation

- Web, Server, Desktop, Mobile, Model API Simulator, and Streamdown typechecks
- Server module-boundary checks
- 52 focused tests
- protocol generated-artifact and coverage checks
- ESLint on changed files with no errors
- `git diff --check`
- remote compare confirms one commit ahead of `main` with no divergence
