### PR TITLE
perf(server): remove session startup persistence bottlenecks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ apps/desktop/resources/relayd/**/relayd-runtime.json
 .expo/
 .claude/worktrees/
 apps/server/openapi.json
+apps/server/dist-benchmark/
 apps/web/i18n-hardcoded-report.json
 apps/web/i18n-missing-report.json
 apps/web/i18n-unused-keys-report.json

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -32,6 +32,7 @@
     "check:boundaries": "tsx scripts/check-module-boundaries.ts",
     "test": "pnpm --filter @cradle/plugin-sdk build && pnpm --filter \"../../plugins/*\" build && vitest run",
     "test:watch": "vitest",
+    "benchmark:session-startup": "vite build --config vite.benchmark.config.ts && node --import tsx scripts/session-startup-benchmark.ts",
     "benchmark:relay": "vitest run tests/relay-transport/performance-compare.test.ts --reporter=verbose",
     "benchmark:relay:codec": "CRADLE_RELAY_BENCHMARK=1 vitest run tests/relay-transport/codec-throughput-benchmark.test.ts --reporter=verbose --maxWorkers=1 --no-file-parallelism",
     "benchmark:relay:full": "pnpm run benchmark:relay && pnpm run benchmark:relay:runtime",

--- a/apps/server/scripts/session-startup-benchmark.ts
+++ b/apps/server/scripts/session-startup-benchmark.ts
@@ -1,0 +1,557 @@
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { isAbsolute, join, resolve } from 'node:path'
+import { monitorEventLoopDelay } from 'node:perf_hooks'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import {
+  createSimulatorApp,
+  createSimulatorRuntime,
+} from '../../../packages/model-api-simulator/src/server'
+
+const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url))
+const REPO_ROOT = resolve(SCRIPT_DIR, '../../..')
+const DEFAULT_DIST_DIR = resolve(REPO_ROOT, 'apps/server/dist-benchmark')
+const MODELS_DEV_URL = 'https://models.dev/api.json'
+const SIMULATOR_ORIGIN = 'http://model-api-simulator.local'
+const MODEL_ID = 'gpt-benchmark'
+
+interface BenchmarkApp {
+  handle: (request: Request) => Promise<Response> | Response
+  stop: () => Promise<unknown> | unknown
+}
+
+interface RegistryRuntime {
+  fetchModelsDevData: (options?: { forceRefresh?: boolean }) => Promise<unknown>
+  warmupModelsDevCache: () => void
+}
+
+interface LatencySummary {
+  count: number
+  meanMs: number
+  p50Ms: number
+  p95Ms: number
+  p99Ms: number
+  maxMs: number
+}
+
+interface TurnTiming {
+  headersMs: number
+  firstTokenMs: number
+  completeMs: number
+}
+
+interface ConcurrencyResult {
+  concurrency: number
+  iterations: number
+  throughputPerSecond: number
+  wallMs: number
+  headers: LatencySummary
+  firstToken: LatencySummary
+  complete: LatencySummary
+  cpuMs: number
+  cpuPercent: number
+  peakRssMb: number
+  eventLoopP95Ms: number
+  simulatorRequests: number
+  modelsDevRequests: number
+}
+
+interface BenchmarkReport {
+  schema: 'cradle-session-startup-benchmark/v1'
+  generatedAt: string
+  distDir: string
+  node: string
+  configuration: {
+    sessionIterations: number
+    serialTurnIterations: number
+    concurrentTurnIterations: number
+    concurrencies: number[]
+    longSessionTurns: number[]
+  }
+  startup: {
+    appCreateMs: number
+    registryWarmupMs: number
+    modelsDevRequests: number
+    modelsDevPeakConcurrency: number
+  }
+  sessionCreation: {
+    coldMs: number
+    warm: LatencySummary
+    throughputPerSecond: number
+  }
+  firstTurn: ConcurrencyResult[]
+  longSession: Array<{
+    priorTurns: number
+    nextTurn: TurnTiming
+  }>
+  simulatorRequestsTotal: number
+}
+
+function readPositiveInteger(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) {
+    return fallback
+  }
+  const value = Number.parseInt(raw, 10)
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+  return value
+}
+
+function readIntegerList(name: string, fallback: number[]): number[] {
+  const raw = process.env[name]
+  if (!raw) {
+    return fallback
+  }
+  const values = raw.split(',').map(value => Number.parseInt(value.trim(), 10))
+  if (values.length === 0 || values.some(value => !Number.isSafeInteger(value) || value <= 0)) {
+    throw new Error(`${name} must be a comma-separated list of positive integers`)
+  }
+  return [...new Set(values)]
+}
+
+function round(value: number, digits = 2): number {
+  const scale = 10 ** digits
+  return Math.round(value * scale) / scale
+}
+
+function percentile(sorted: number[], ratio: number): number {
+  if (sorted.length === 0) {
+    return 0
+  }
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1)
+  return sorted[index]!
+}
+
+function summarize(values: number[]): LatencySummary {
+  const sorted = values.toSorted((left, right) => left - right)
+  const total = sorted.reduce((sum, value) => sum + value, 0)
+  return {
+    count: sorted.length,
+    meanMs: round(total / Math.max(1, sorted.length)),
+    p50Ms: round(percentile(sorted, 0.5)),
+    p95Ms: round(percentile(sorted, 0.95)),
+    p99Ms: round(percentile(sorted, 0.99)),
+    maxMs: round(sorted.at(-1) ?? 0),
+  }
+}
+
+async function loadProductionRuntime(distDir: string): Promise<{
+  createServerApp: (options?: { startBackgroundTasks?: boolean }) => Promise<BenchmarkApp>
+  registry: RegistryRuntime
+  shutdown: () => void
+}> {
+  const entryPath = join(distDir, 'benchmark-app.js')
+  const runtimeModule = await import(pathToFileURL(entryPath).href) as Record<string, unknown>
+  const createServerApp = runtimeModule.createServerApp
+  if (typeof createServerApp !== 'function') {
+    throw new TypeError(`Production benchmark entry ${entryPath} does not export createServerApp`)
+  }
+  const fetchModelsDevData = runtimeModule.fetchModelsDevData
+  const warmupModelsDevCache = runtimeModule.warmupModelsDevCache
+  const shutdownBenchmarkRuntime = runtimeModule.shutdownBenchmarkRuntime
+  if (typeof fetchModelsDevData !== 'function' || typeof warmupModelsDevCache !== 'function') {
+    throw new TypeError(`Production benchmark entry ${entryPath} does not export the registry runtime`)
+  }
+  if (typeof shutdownBenchmarkRuntime !== 'function') {
+    throw new TypeError(`Production benchmark entry ${entryPath} does not export shutdownBenchmarkRuntime`)
+  }
+  return {
+    createServerApp: createServerApp as (options?: { startBackgroundTasks?: boolean }) => Promise<BenchmarkApp>,
+    registry: {
+      fetchModelsDevData: fetchModelsDevData as RegistryRuntime['fetchModelsDevData'],
+      warmupModelsDevCache: warmupModelsDevCache as RegistryRuntime['warmupModelsDevCache'],
+    },
+    shutdown: shutdownBenchmarkRuntime as () => void,
+  }
+}
+
+async function requireOk(response: Response, operation: string): Promise<Response> {
+  if (response.ok) {
+    return response
+  }
+  throw new Error(`${operation} failed with ${response.status}: ${await response.text()}`)
+}
+
+function jsonRequest(method: string, body: unknown): RequestInit {
+  return {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }
+}
+
+async function createSession(
+  app: BenchmarkApp,
+  workspaceId: string,
+  providerTargetId: string,
+  sessionId: string,
+): Promise<void> {
+  const response = await app.handle(new Request('http://localhost/sessions', jsonRequest('POST', {
+    id: sessionId,
+    workspaceId,
+    title: `Benchmark ${sessionId}`,
+    providerTargetId,
+    runtimeKind: 'standard',
+  })))
+  await requireOk(response, `create session ${sessionId}`)
+}
+
+async function consumeTurn(app: BenchmarkApp, sessionId: string, text: string): Promise<TurnTiming> {
+  const startedAt = performance.now()
+  const response = await app.handle(new Request(
+    `http://localhost/chat/sessions/${encodeURIComponent(sessionId)}/response`,
+    jsonRequest('POST', { text, modelId: MODEL_ID }),
+  ))
+  await requireOk(response, `run turn for ${sessionId}`)
+  const headersAt = performance.now()
+  if (!response.body) {
+    throw new Error(`Turn ${sessionId} returned no SSE body`)
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let pending = ''
+  let firstTokenAt: number | null = null
+  while (true) {
+    const { done, value } = await reader.read()
+    pending += decoder.decode(value, { stream: !done })
+    const blocks = pending.split('\n\n')
+    pending = blocks.pop() ?? ''
+    for (const block of blocks) {
+      const data = block
+        .split('\n')
+        .filter(line => line.startsWith('data: '))
+        .map(line => line.slice('data: '.length))
+        .join('\n')
+      if (!data || data === '[DONE]') {
+        continue
+      }
+      const chunk = JSON.parse(data) as { type?: string }
+      if (chunk.type === 'text-delta' && firstTokenAt === null) {
+        firstTokenAt = performance.now()
+      }
+    }
+    if (done) {
+      break
+    }
+  }
+  const completedAt = performance.now()
+  if (firstTokenAt === null) {
+    throw new Error(`Turn ${sessionId} completed without a text-delta chunk`)
+  }
+  return {
+    headersMs: headersAt - startedAt,
+    firstTokenMs: firstTokenAt - startedAt,
+    completeMs: completedAt - startedAt,
+  }
+}
+
+async function benchmarkConcurrency(input: {
+  app: BenchmarkApp
+  workspaceId: string
+  providerTargetId: string
+  concurrency: number
+  iterations: number
+  simulatorRequestCount: () => number
+  modelsDevRequestCount: () => number
+}): Promise<ConcurrencyResult> {
+  const sessionIds: string[] = []
+  for (let index = 0; index < input.iterations; index += 1) {
+    const sessionId = `bench-c${input.concurrency}-${index}-${randomUUID()}`
+    await createSession(input.app, input.workspaceId, input.providerTargetId, sessionId)
+    sessionIds.push(sessionId)
+  }
+
+  const headers: number[] = []
+  const firstTokens: number[] = []
+  const completions: number[] = []
+  let nextIndex = 0
+  let peakRss = process.memoryUsage().rss
+  const rssSampler = setInterval(() => {
+    peakRss = Math.max(peakRss, process.memoryUsage().rss)
+  }, 5)
+  rssSampler.unref?.()
+  const eventLoop = monitorEventLoopDelay({ resolution: 10 })
+  eventLoop.enable()
+  const cpuStart = process.cpuUsage()
+  const simulatorStart = input.simulatorRequestCount()
+  const modelsDevStart = input.modelsDevRequestCount()
+  const wallStartedAt = performance.now()
+
+  const workers: Array<Promise<void>> = []
+  for (let workerIndex = 0; workerIndex < Math.min(input.concurrency, sessionIds.length); workerIndex += 1) {
+    workers.push((async () => {
+      while (true) {
+        const index = nextIndex
+        nextIndex += 1
+        const sessionId = sessionIds[index]
+        if (!sessionId) {
+          return
+        }
+        const timing = await consumeTurn(input.app, sessionId, `benchmark turn ${index}`)
+        headers.push(timing.headersMs)
+        firstTokens.push(timing.firstTokenMs)
+        completions.push(timing.completeMs)
+      }
+    })())
+  }
+  await Promise.all(workers)
+
+  const wallMs = performance.now() - wallStartedAt
+  const cpu = process.cpuUsage(cpuStart)
+  eventLoop.disable()
+  clearInterval(rssSampler)
+  const cpuMs = (cpu.user + cpu.system) / 1_000
+  return {
+    concurrency: input.concurrency,
+    iterations: input.iterations,
+    throughputPerSecond: round(input.iterations / (wallMs / 1_000)),
+    wallMs: round(wallMs),
+    headers: summarize(headers),
+    firstToken: summarize(firstTokens),
+    complete: summarize(completions),
+    cpuMs: round(cpuMs),
+    cpuPercent: round((cpuMs / wallMs) * 100),
+    peakRssMb: round(peakRss / 1024 / 1024),
+    eventLoopP95Ms: round(eventLoop.percentile(95) / 1_000_000),
+    simulatorRequests: input.simulatorRequestCount() - simulatorStart,
+    modelsDevRequests: input.modelsDevRequestCount() - modelsDevStart,
+  }
+}
+
+function printReport(report: BenchmarkReport): void {
+  console.log(JSON.stringify(report, null, 2))
+}
+
+async function main(): Promise<void> {
+  const sessionIterations = readPositiveInteger('CRADLE_BENCH_SESSION_ITERATIONS', 100)
+  const serialTurnIterations = readPositiveInteger('CRADLE_BENCH_SERIAL_ITERATIONS', 80)
+  const concurrentTurnIterations = readPositiveInteger('CRADLE_BENCH_CONCURRENT_ITERATIONS', 160)
+  const concurrencies = readIntegerList('CRADLE_BENCH_CONCURRENCIES', [1, 8, 32, 64])
+  const longSessionTurns = readIntegerList('CRADLE_BENCH_LONG_TURNS', [100, 400])
+  const configuredDistDir = process.env.CRADLE_BENCH_DIST_DIR ?? DEFAULT_DIST_DIR
+  const distDir = isAbsolute(configuredDistDir)
+    ? configuredDistDir
+    : resolve(REPO_ROOT, configuredDistDir)
+  const dataDir = mkdtempSync(join(tmpdir(), 'cradle-session-benchmark-data-'))
+  const previousEnv = {
+    dataDir: process.env.CRADLE_DATA_DIR,
+    credentialSecret: process.env.CRADLE_CREDENTIAL_SECRET,
+    logLevel: process.env.CRADLE_LOG_LEVEL,
+    authRequired: process.env.CRADLE_AUTH_REQUIRED,
+    migrationsDir: process.env.CRADLE_MIGRATIONS_DIR,
+  }
+  process.env.CRADLE_DATA_DIR = dataDir
+  process.env.CRADLE_CREDENTIAL_SECRET = 'session-benchmark-secret'
+  process.env.CRADLE_LOG_LEVEL = 'error'
+  process.env.CRADLE_AUTH_REQUIRED = 'false'
+  process.env.CRADLE_MIGRATIONS_DIR = resolve(REPO_ROOT, 'packages/db/drizzle')
+
+  const simulatorRuntime = createSimulatorRuntime()
+  const simulatorApp = createSimulatorApp(simulatorRuntime, { autoRespond: true })
+  const nativeFetch = globalThis.fetch
+  let modelsDevRequests = 0
+  let modelsDevActiveRequests = 0
+  let modelsDevPeakConcurrency = 0
+  globalThis.fetch = async (input, init) => {
+    const request = new Request(input, init)
+    if (request.url === MODELS_DEV_URL) {
+      modelsDevRequests += 1
+      modelsDevActiveRequests += 1
+      modelsDevPeakConcurrency = Math.max(modelsDevPeakConcurrency, modelsDevActiveRequests)
+      try {
+        await Promise.resolve()
+        return new Response(JSON.stringify({
+          benchmark: {
+            name: 'Benchmark',
+            api: `${SIMULATOR_ORIGIN}/v1`,
+            models: {
+              [MODEL_ID]: {
+                id: MODEL_ID,
+                name: 'GPT Benchmark',
+                limit: { context: 128_000, output: 4_096 },
+                cost: { input: 1, output: 2 },
+              },
+            },
+          },
+        }), { headers: { 'content-type': 'application/json' } })
+      }
+      finally {
+        modelsDevActiveRequests -= 1
+      }
+    }
+    if (new URL(request.url).origin === SIMULATOR_ORIGIN) {
+      const mappedUrl = new URL(request.url)
+      mappedUrl.protocol = 'http:'
+      mappedUrl.host = 'simulator'
+      return simulatorApp.handle(new Request(mappedUrl, request))
+    }
+    throw new Error(`Unexpected network request during benchmark: ${request.method} ${request.url}`)
+  }
+
+  let app: BenchmarkApp | null = null
+  let shutdownRuntime: (() => void) | null = null
+  try {
+    const runtime = await loadProductionRuntime(distDir)
+    shutdownRuntime = runtime.shutdown
+    const appStartedAt = performance.now()
+    app = await runtime.createServerApp({ startBackgroundTasks: false })
+    const appCreateMs = performance.now() - appStartedAt
+
+    const registryStartedAt = performance.now()
+    await runtime.registry.fetchModelsDevData({ forceRefresh: true })
+    const registryWarmupMs = performance.now() - registryStartedAt
+
+    const credentialResponse = await requireOk(await app.handle(new Request(
+      'http://localhost/secrets',
+      jsonRequest('POST', {
+        kind: 'openai-compatible',
+        label: 'Session benchmark key',
+        secret: 'sk-session-benchmark',
+      }),
+    )), 'create benchmark credential')
+    const credential = await credentialResponse.json() as { id: string }
+    const workspaceRoot = join(dataDir, 'workspace')
+    mkdirSync(workspaceRoot)
+    const workspaceResponse = await requireOk(await app.handle(new Request(
+      'http://localhost/workspaces',
+      jsonRequest('POST', {
+        name: 'Session Benchmark Workspace',
+        locator: { hostId: 'local', path: workspaceRoot },
+      }),
+    )), 'create benchmark workspace')
+    const workspace = await workspaceResponse.json() as { id: string }
+    const providerTargetId = 'provider-target-session-benchmark'
+    await requireOk(await app.handle(new Request(
+      `http://localhost/provider-targets/${providerTargetId}`,
+      jsonRequest('PUT', {
+        displayName: 'Session Benchmark Provider',
+        providerKind: 'openai-compatible',
+        enabled: true,
+        connectionConfig: {
+          baseUrl: `${SIMULATOR_ORIGIN}/v1`,
+          model: MODEL_ID,
+          apiMode: 'responses',
+          maxMessages: 50,
+        },
+        credentialRef: credential.id,
+      }),
+    )), 'create benchmark provider target')
+
+    const coldSessionStartedAt = performance.now()
+    await createSession(app, workspace.id, providerTargetId, `bench-session-cold-${randomUUID()}`)
+    const coldSessionMs = performance.now() - coldSessionStartedAt
+    const sessionLatencies: number[] = []
+    const sessionBatchStartedAt = performance.now()
+    for (let index = 0; index < sessionIterations; index += 1) {
+      const startedAt = performance.now()
+      await createSession(app, workspace.id, providerTargetId, `bench-session-warm-${index}-${randomUUID()}`)
+      sessionLatencies.push(performance.now() - startedAt)
+    }
+    const sessionBatchMs = performance.now() - sessionBatchStartedAt
+
+    const warmupSessionId = `bench-turn-warmup-${randomUUID()}`
+    await createSession(app, workspace.id, providerTargetId, warmupSessionId)
+    await consumeTurn(app, warmupSessionId, 'warm up the runtime')
+
+    const firstTurn: ConcurrencyResult[] = []
+    for (const concurrency of concurrencies) {
+      firstTurn.push(await benchmarkConcurrency({
+        app,
+        workspaceId: workspace.id,
+        providerTargetId,
+        concurrency,
+        iterations: concurrency === 1 ? serialTurnIterations : concurrentTurnIterations,
+        simulatorRequestCount: () => simulatorRuntime.controller.requests().length,
+        modelsDevRequestCount: () => modelsDevRequests,
+      }))
+    }
+
+    const longSessionId = `bench-long-${randomUUID()}`
+    await createSession(app, workspace.id, providerTargetId, longSessionId)
+    const longSession: BenchmarkReport['longSession'] = []
+    let completedTurns = 0
+    for (const priorTurns of longSessionTurns.toSorted((left, right) => left - right)) {
+      while (completedTurns < priorTurns) {
+        await consumeTurn(app, longSessionId, `seed turn ${completedTurns + 1}`)
+        completedTurns += 1
+      }
+      const nextTurn = await consumeTurn(app, longSessionId, `measure after ${priorTurns} turns`)
+      completedTurns += 1
+      longSession.push({
+        priorTurns,
+        nextTurn: {
+          headersMs: round(nextTurn.headersMs),
+          firstTokenMs: round(nextTurn.firstTokenMs),
+          completeMs: round(nextTurn.completeMs),
+        },
+      })
+    }
+
+    const report: BenchmarkReport = {
+      schema: 'cradle-session-startup-benchmark/v1',
+      generatedAt: new Date().toISOString(),
+      distDir,
+      node: process.version,
+      configuration: {
+        sessionIterations,
+        serialTurnIterations,
+        concurrentTurnIterations,
+        concurrencies,
+        longSessionTurns,
+      },
+      startup: {
+        appCreateMs: round(appCreateMs),
+        registryWarmupMs: round(registryWarmupMs),
+        modelsDevRequests,
+        modelsDevPeakConcurrency,
+      },
+      sessionCreation: {
+        coldMs: round(coldSessionMs),
+        warm: summarize(sessionLatencies),
+        throughputPerSecond: round(sessionIterations / (sessionBatchMs / 1_000)),
+      },
+      firstTurn,
+      longSession,
+      simulatorRequestsTotal: simulatorRuntime.controller.requests().length,
+    }
+    printReport(report)
+    const outputPath = process.env.CRADLE_BENCH_OUTPUT
+    if (outputPath) {
+      writeFileSync(
+        isAbsolute(outputPath) ? outputPath : resolve(REPO_ROOT, outputPath),
+        `${JSON.stringify(report, null, 2)}\n`,
+      )
+    }
+  }
+  finally {
+    try {
+      shutdownRuntime?.()
+    }
+    finally {
+      globalThis.fetch = nativeFetch
+      simulatorRuntime.controller.close()
+      rmSync(dataDir, { recursive: true, force: true })
+      restoreEnv('CRADLE_DATA_DIR', previousEnv.dataDir)
+      restoreEnv('CRADLE_CREDENTIAL_SECRET', previousEnv.credentialSecret)
+      restoreEnv('CRADLE_LOG_LEVEL', previousEnv.logLevel)
+      restoreEnv('CRADLE_AUTH_REQUIRED', previousEnv.authRequired)
+      restoreEnv('CRADLE_MIGRATIONS_DIR', previousEnv.migrationsDir)
+    }
+  }
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name]
+  }
+  else {
+    process.env[name] = value
+  }
+}
+
+await main()

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -36,6 +36,7 @@ import { linkedChatSessionProxyPlugin } from './modules/chat-runtime/http/linked
 import { registerMessageBlobBackfillMaintenance } from './modules/chat-runtime/message-blob-backfill'
 import { registerMessageSteerSplitBackfillMaintenance } from './modules/chat-runtime/message-steer-split-backfill'
 import { runRegistry } from './modules/chat-runtime/run-registry'
+import { flushRunSnapshotWriteBehind } from './modules/chat-runtime/run-snapshot-journal'
 import { registerTurnCheckpointHooks } from './modules/chat-runtime/turn-checkpoint-hooks'
 import { ClaudeUsageReconciliationScheduler } from './modules/chat-runtime-providers/claude-agent/usage-reconciliation-scheduler'
 import { createOpencodeManagedResourceAdapter } from './modules/chat-runtime-providers/opencode/managed-resource-adapter'
@@ -99,6 +100,7 @@ import { threadHandoff } from './modules/thread-handoff'
 import { turnCheckpoint } from './modules/turn-checkpoint'
 import * as TurnCheckpoint from './modules/turn-checkpoint/service'
 import { usage } from './modules/usage'
+import { flushUsageWriteBehind } from './modules/usage/write-behind'
 import { sessionWork, work } from './modules/work'
 import { workflowRules } from './modules/workflow-rules'
 import { workspace } from './modules/workspace'
@@ -495,6 +497,16 @@ export async function createServerApp(options: CreateServerAppOptions = {}) {
   const runtimeResources = new RuntimeResourceRegistry()
   const claudeUsageReconciliation = new ClaudeUsageReconciliationScheduler()
   const codexUsageReconciliation = new CodexUsageReconciliationScheduler()
+  runtimeResources.register({
+    name: 'run-snapshot-write-behind',
+    phase: 'drain',
+    stop: flushRunSnapshotWriteBehind,
+  })
+  runtimeResources.register({
+    name: 'usage-write-behind',
+    phase: 'drain',
+    stop: flushUsageWriteBehind,
+  })
   runtimeResources.register({
     name: 'download-center',
     phase: 'cancel',

--- a/apps/server/src/benchmark-entry.ts
+++ b/apps/server/src/benchmark-entry.ts
@@ -1,0 +1,12 @@
+import { shutdownInfra } from './infra'
+
+export { createServerApp } from './app'
+export {
+  fetchModelsDevData,
+  warmupModelsDevCache,
+} from './modules/model-registry/model-info-registry'
+
+/** Close the database for the listener-free in-process benchmark harness. */
+export function shutdownBenchmarkRuntime(): void {
+  shutdownInfra()
+}

--- a/apps/server/src/infra.ts
+++ b/apps/server/src/infra.ts
@@ -15,6 +15,7 @@ let _serverConfig: ServerConfig | undefined
 let _logger: Logger | undefined
 let _dbProvider: DbProvider | undefined
 let _infraEnv: InfraEnvSnapshot | undefined
+const beforeDatabaseShutdownHooks = new Set<() => void>()
 
 interface InfraEnvSnapshot {
   host?: string
@@ -57,10 +58,40 @@ function isSameInfraEnv(a: InfraEnvSnapshot, b: InfraEnvSnapshot): boolean {
 }
 
 function clearCachedInfra(): void {
-  _dbProvider?.onApplicationShutdown()
+  const provider = _dbProvider
+  const failures: Error[] = []
+  if (provider) {
+    for (const hook of beforeDatabaseShutdownHooks) {
+      try {
+        hook()
+      }
+      catch (error) {
+        failures.push(error instanceof Error ? error : new Error(String(error)))
+      }
+    }
+    try {
+      provider.onApplicationShutdown()
+    }
+    catch (error) {
+      failures.push(error instanceof Error ? error : new Error(String(error)))
+    }
+  }
   _dbProvider = undefined
   _serverConfig = undefined
   _logger = undefined
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Failed to flush database-owned runtime state')
+  }
+}
+
+/**
+ * Register a synchronous durability hook that runs immediately before the
+ * current SQLite connection closes. Feature modules use this to drain
+ * write-behind journals without making infrastructure depend on them.
+ */
+export function registerBeforeDatabaseShutdown(hook: () => void): () => void {
+  beforeDatabaseShutdownHooks.add(hook)
+  return () => beforeDatabaseShutdownHooks.delete(hook)
 }
 
 function refreshInfraForEnv(): void {

--- a/apps/server/src/modules/chat-runtime-providers/openai-compatible/provider.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/openai-compatible/provider.test.ts
@@ -15,7 +15,7 @@ const engineMocks = vi.hoisted(() => ({
   }),
   createLanguageModel: vi.fn(() => ({ provider: 'mock-model' })),
   detectApiFormat: vi.fn(() => 'openai'),
-  lookupContextWindow: vi.fn(async () => 32_000),
+  getCachedContextWindow: vi.fn(() => 32_000),
 }))
 
 vi.mock('../../chat-runtime-engine/ai-sdk-engine', async (importOriginal) => {
@@ -40,7 +40,7 @@ vi.mock('../../model-registry/model-info-registry', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../model-registry/model-info-registry')>()
   return {
     ...actual,
-    lookupContextWindow: engineMocks.lookupContextWindow,
+    getCachedContextWindow: engineMocks.getCachedContextWindow,
   }
 })
 

--- a/apps/server/src/modules/chat-runtime-providers/openai-compatible/provider.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/openai-compatible/provider.test.ts
@@ -1,13 +1,19 @@
 import type { UIMessage, UIMessageChunk } from 'ai'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { ProviderContext, RuntimeProviderTargetProfile, RuntimeSession } from '../../chat-runtime/runtime-provider-types'
+import type {
+  ProviderContext,
+  RuntimeProviderTargetProfile,
+  RuntimeSession,
+  RuntimeTurnResult,
+} from '../../chat-runtime/runtime-provider-types'
+import type { AiSdkEngineInput } from '../../chat-runtime-engine/ai-sdk-engine'
 import { assertValidProviderChunkSequence } from '../kit/testing/chunk-contract'
 import { OpenAICompatibleProvider } from './provider'
 
 const engineMocks = vi.hoisted(() => ({
   buildModelMessages: vi.fn(async () => [{ role: 'user', content: 'Hello standard' }]),
-  executeAiSdkTurn: vi.fn(async function* () {
+  executeAiSdkTurn: vi.fn(async function* (_input: AiSdkEngineInput) {
     yield { type: 'text-start', id: 'text-1' }
     yield { type: 'text-delta', id: 'text-1', delta: 'Standard answer' }
     yield { type: 'text-end', id: 'text-1' }
@@ -47,6 +53,12 @@ vi.mock('../../model-registry/model-info-registry', async (importOriginal) => {
 describe('openai compatible provider', () => {
   afterEach(() => {
     vi.clearAllMocks()
+    engineMocks.executeAiSdkTurn.mockImplementation(async function* (_input: AiSdkEngineInput) {
+      yield { type: 'text-start', id: 'text-1' }
+      yield { type: 'text-delta', id: 'text-1', delta: 'Standard answer' }
+      yield { type: 'text-end', id: 'text-1' }
+      yield { type: 'finish', finishReason: 'stop' }
+    })
   })
 
   it('streams AI SDK engine chunks as a valid provider chunk sequence', async () => {
@@ -82,6 +94,81 @@ describe('openai compatible provider', () => {
       chatSessionId: 'chat-session-1',
     }))
   })
+
+  it('keeps usage and step results isolated across concurrent turns', async () => {
+    const provider = new OpenAICompatibleProvider(createProviderContext())
+    let callIndex = 0
+    let releaseFirstTurn!: () => void
+    let markFirstUsageReported!: () => void
+    const firstTurnMayFinish = new Promise<void>((resolve) => { releaseFirstTurn = resolve })
+    const firstUsageReported = new Promise<void>((resolve) => { markFirstUsageReported = resolve })
+
+    engineMocks.executeAiSdkTurn.mockImplementation(async function* (input: AiSdkEngineInput) {
+      const turn = ++callIndex
+      const usage = {
+        promptTokens: turn,
+        completionTokens: turn * 10,
+        totalTokens: turn * 11,
+      }
+      input.onUsage?.(usage)
+      input.onStepFinish?.({
+        stepNumber: 0,
+        stepType: 'initial',
+        modelId: `model-${turn}`,
+        usage,
+      })
+      if (turn === 1) {
+        markFirstUsageReported()
+        await firstTurnMayFinish
+      }
+      else {
+        releaseFirstTurn()
+      }
+      yield { type: 'finish', finishReason: 'stop' }
+    })
+
+    const results: RuntimeTurnResult[] = []
+    const consume = async (turn: number): Promise<void> => {
+      for await (const _chunk of provider.streamTurn({
+        runId: `run-${turn}`,
+        runtimeSession: createRuntimeSession(`chat-session-${turn}`),
+        profile: createProfile(),
+        message: createUserMessage(`turn ${turn}`),
+        workspaceId: 'workspace-1',
+        workspacePath: '/tmp/workspace',
+        reportTurnResult: (result) => { results[turn - 1] = result },
+      })) {
+        // Consume the provider stream so the turn result is finalized.
+      }
+    }
+
+    const first = consume(1)
+    await firstUsageReported
+    await Promise.all([first, consume(2)])
+
+    expect(results).toEqual([
+      {
+        modelId: 'gpt-test',
+        usage: { promptTokens: 1, completionTokens: 10, totalTokens: 11 },
+        stepUsages: [{
+          stepNumber: 0,
+          stepType: 'initial',
+          modelId: 'model-1',
+          usage: { promptTokens: 1, completionTokens: 10, totalTokens: 11 },
+        }],
+      },
+      {
+        modelId: 'gpt-test',
+        usage: { promptTokens: 2, completionTokens: 20, totalTokens: 22 },
+        stepUsages: [{
+          stepNumber: 0,
+          stepType: 'initial',
+          modelId: 'model-2',
+          usage: { promptTokens: 2, completionTokens: 20, totalTokens: 22 },
+        }],
+      },
+    ])
+  })
 })
 
 function createProviderContext(): ProviderContext {
@@ -109,10 +196,10 @@ function createProfile(): RuntimeProviderTargetProfile {
   }
 }
 
-function createRuntimeSession(): RuntimeSession {
+function createRuntimeSession(chatSessionId = 'chat-session-1'): RuntimeSession {
   return {
     id: 'runtime-session-1',
-    chatSessionId: 'chat-session-1',
+    chatSessionId,
     providerTargetId: 'profile-standard',
     runtimeKind: 'standard',
     providerSessionId: null,

--- a/apps/server/src/modules/chat-runtime-providers/openai-compatible/provider.ts
+++ b/apps/server/src/modules/chat-runtime-providers/openai-compatible/provider.ts
@@ -19,7 +19,7 @@ import {
 import type { TokenUsage } from '../../chat-runtime-engine/ai-sdk-engine'
 import { buildModelMessages, executeAiSdkTurn } from '../../chat-runtime-engine/ai-sdk-engine'
 import { createLanguageModel, detectApiFormat } from '../../chat-runtime-engine/providers'
-import { lookupContextWindow } from '../../model-registry/model-info-registry'
+import { getCachedContextWindow } from '../../model-registry/model-info-registry'
 import { readTrustedOpenAICompatibleConfig, readTrustedUniversalConfig } from '../../provider-contracts/provider-base'
 import { readProviderStateSnapshot } from '../kit/state-snapshot'
 import {
@@ -128,7 +128,9 @@ export class OpenAICompatibleProvider implements ChatRuntime {
         maxMessages,
       )
 
-      const contextWindow = await lookupContextWindow(effectiveModel) ?? 128_000
+      // Catalog metadata is optional. Never put network or SQLite catalog I/O
+      // on the first-token path; startup warmup populates this in-memory cache.
+      const contextWindow = getCachedContextWindow(effectiveModel) ?? 128_000
 
       yield* executeAiSdkTurn({
         model,

--- a/apps/server/src/modules/chat-runtime-providers/openai-compatible/provider.ts
+++ b/apps/server/src/modules/chat-runtime-providers/openai-compatible/provider.ts
@@ -38,16 +38,6 @@ export class OpenAICompatibleProvider implements ChatRuntime {
   readonly capabilities = STANDARD_RUNTIME_CAPABILITIES
 
   private readonly activeTurns = new Map<string, AbortController>()
-  private _lastUsage: TokenUsage | null = null
-  private _lastStepUsages: RuntimeStepUsage[] = []
-
-  get lastUsage(): TokenUsage | null {
-    return this._lastUsage
-  }
-
-  get lastStepUsages(): RuntimeStepUsage[] {
-    return this._lastStepUsages
-  }
 
   constructor(private readonly deps: ProviderContext) {}
 
@@ -108,8 +98,8 @@ export class OpenAICompatibleProvider implements ChatRuntime {
     const abortController = new AbortController()
     const sessionId = runtimeSession.chatSessionId
     this.activeTurns.set(sessionId, abortController)
-    this._lastUsage = null
-    this._lastStepUsages = []
+    let turnUsage: TokenUsage | null = null
+    const turnStepUsages: RuntimeStepUsage[] = []
 
     try {
       const apiFormat = detectApiFormat(baseUrl)
@@ -143,8 +133,8 @@ export class OpenAICompatibleProvider implements ChatRuntime {
         maxSteps: 1, // single-turn for openai-compatible (no tool execution)
         abortSignal: abortController.signal,
         providerOptions,
-        onUsage: (usage) => { this._lastUsage = usage },
-        onStepFinish: (step) => { this._lastStepUsages.push(step) },
+        onUsage: (usage) => { turnUsage = usage },
+        onStepFinish: (step) => { turnStepUsages.push(step) },
         contextWindow,
         chatSessionId: runtimeSession.chatSessionId,
       })
@@ -156,7 +146,16 @@ export class OpenAICompatibleProvider implements ChatRuntime {
       throw error
     }
     finally {
-      this.releaseTurn(sessionId, abortController)
+      try {
+        input.reportTurnResult?.({
+          modelId: effectiveModel,
+          usage: turnUsage,
+          stepUsages: turnStepUsages,
+        })
+      }
+      finally {
+        this.releaseTurn(sessionId, abortController)
+      }
     }
   }
 

--- a/apps/server/src/modules/chat-runtime/es/commands.ts
+++ b/apps/server/src/modules/chat-runtime/es/commands.ts
@@ -1,16 +1,21 @@
 import type { ChatSessionQueueItem } from '@cradle/db'
-import { chatSessionQueueItems } from '@cradle/db'
-import { and, eq, isNull } from 'drizzle-orm'
+import { backendRuns, chatSessionQueueItems } from '@cradle/db'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 
 import { AppError } from '../../../errors/app-error'
 import { currentUnixSeconds } from '../../../helpers/time'
 import { db } from '../../../infra'
 import type { ChatMessageStatus } from '../run/stream-chunks'
-import { reduceChatSessionEvents } from './aggregate'
+import type { ChatSessionState } from './aggregate'
+import { createInitialChatSessionState, reduceChatSessionEvents } from './aggregate'
 import type { ChatSessionDomainError } from './decide'
 import { decideChatSessionEvents } from './decide'
 import type { ChatRuntimeTx } from './event-store'
-import { appendSessionEvent, readSessionEvents } from './event-store'
+import {
+  appendSessionEvents,
+  readCurrentSessionEventVersion,
+  readSessionEvents,
+} from './event-store'
 import { publishSessionTailEvents } from './event-tail'
 import type {
   ChatSessionEvent,
@@ -98,28 +103,114 @@ export function appendDecidedSessionEvents(
     return []
   }
 
-  const state = reduceChatSessionEvents(readSessionEvents(sessionId, tx))
-  state.aggregateId = sessionId
+  const state = readSessionDecisionState(tx, sessionId, events)
   const decision = decideChatSessionEvents(state, events)
   if (!decision.ok) {
     throwDomainError(decision.error)
   }
 
-  const storedEvents: StoredChatSessionEvent[] = []
-  let expectedVersion = state.version
-  for (const event of decision.events) {
-    const stored = appendSessionEvent(tx, {
-      aggregateId: sessionId,
-      event,
-      expectedVersion,
-    })
+  const storedEvents = appendSessionEvents(tx, {
+    aggregateId: sessionId,
+    events: decision.events,
+    expectedVersion: state.version,
+    knownCurrentVersion: state.version,
+  })
+  for (const stored of storedEvents) {
     if (options.projectEvent?.(stored) ?? true) {
       projectSessionEvent(tx, stored)
     }
-    storedEvents.push(stored)
-    expectedVersion = stored.version
   }
   return storedEvents
+}
+
+/**
+ * Normal commands decide from same-transaction projections instead of
+ * replaying the append-only stream. Recovery and rebuild paths continue to
+ * replay the authoritative facts; these rows are maintained atomically with
+ * every append and provide the minimal state needed by command invariants.
+ */
+function readSessionDecisionState(
+  tx: ChatRuntimeTx,
+  sessionId: string,
+  events: ChatSessionEvent[],
+): ChatSessionState {
+  const state = createInitialChatSessionState(sessionId)
+  state.version = readCurrentSessionEventVersion(tx, sessionId)
+
+  const activeRun = tx
+    .select({
+      id: backendRuns.id,
+      messageId: backendRuns.messageId,
+      origin: backendRuns.origin,
+      startedAt: backendRuns.startedAt,
+    })
+    .from(backendRuns)
+    .where(and(
+      eq(backendRuns.chatSessionId, sessionId),
+      eq(backendRuns.status, 'streaming'),
+    ))
+    .limit(1)
+    .get()
+  if (activeRun) {
+    state.activeRun = {
+      runId: activeRun.id,
+      messageId: activeRun.messageId,
+      queueItemId: null,
+      startedAt: activeRun.startedAt,
+    }
+    state.runOriginById.set(activeRun.id, activeRun.origin)
+    state.runMessageIdById.set(activeRun.id, activeRun.messageId)
+    state.runStatusById.set(activeRun.id, 'streaming')
+  }
+
+  const queueItemIds = readReferencedQueueItemIds(events)
+  if (queueItemIds.length > 0) {
+    const queueItems = tx
+      .select({
+        id: chatSessionQueueItems.id,
+        status: chatSessionQueueItems.status,
+        startedRunId: chatSessionQueueItems.startedRunId,
+      })
+      .from(chatSessionQueueItems)
+      .where(and(
+        eq(chatSessionQueueItems.sessionId, sessionId),
+        inArray(chatSessionQueueItems.id, queueItemIds),
+      ))
+      .all()
+    for (const item of queueItems) {
+      state.queueItemById.set(item.id, {
+        status: item.status,
+        startedRunId: item.startedRunId,
+      })
+    }
+  }
+  return state
+}
+
+function readReferencedQueueItemIds(events: ChatSessionEvent[]): string[] {
+  const ids = new Set<string>()
+  for (const event of events) {
+    switch (event.type) {
+      case 'RunStarted':
+        if (event.payload.queueItemId) {
+          ids.add(event.payload.queueItemId)
+        }
+        break
+      case 'QueueItemClaimed':
+      case 'QueueItemReleased':
+      case 'QueueItemFailed':
+      case 'QueueItemCompleted':
+      case 'QueueItemReordered':
+      case 'QueueItemUpdated':
+      case 'QueueItemProviderTargetCleared':
+      case 'QueueItemCancelled':
+        ids.add(event.payload.queueItemId)
+        break
+      default:
+        break
+    }
+  }
+  return [...ids]
 }
 
 /**
@@ -145,20 +236,19 @@ export function appendValidatedRecoverySessionEvents(
   }
 
   const state = reduceChatSessionEvents(readSessionEvents(sessionId, tx))
-  let expectedVersion = state.version
-  const storedEvents: StoredChatSessionEvent[] = []
   for (const event of input.events) {
     assertRecoveryEventBelongsToRun(event, input)
-    const stored = appendSessionEvent(tx, {
-      aggregateId: sessionId,
-      event,
-      expectedVersion,
-    })
+  }
+  const storedEvents = appendSessionEvents(tx, {
+    aggregateId: sessionId,
+    events: input.events,
+    expectedVersion: state.version,
+    knownCurrentVersion: state.version,
+  })
+  for (const stored of storedEvents) {
     if (input.projectEvent?.(stored) ?? true) {
       projectSessionEvent(tx, stored)
     }
-    storedEvents.push(stored)
-    expectedVersion = stored.version
   }
   return storedEvents
 }

--- a/apps/server/src/modules/chat-runtime/es/event-store.test.ts
+++ b/apps/server/src/modules/chat-runtime/es/event-store.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { db, shutdownInfra } from '../../../infra'
-import { appendSessionEvent } from './event-store'
+import { appendSessionEvent, appendSessionEvents } from './event-store'
 
 function restoreEnv(name: string, previousValue: string | undefined): void {
   if (previousValue === undefined) {
@@ -34,6 +34,30 @@ async function withTempDataDir<T>(callback: () => Promise<T> | T): Promise<T> {
 }
 
 describe('appendSessionEvent', () => {
+  it('allocates versions once across bounded multi-row insert batches', async () => {
+    await withTempDataDir(() => {
+      db().transaction((tx) => {
+        const stored = appendSessionEvents(tx, {
+          aggregateId: 'session-batch',
+          expectedVersion: 0,
+          events: Array.from({ length: 205 }, (_, index) => ({
+            type: 'TitleChanged' as const,
+            payload: {
+              sessionId: 'session-batch',
+              title: `Title ${index}`,
+              titleSource: 'provider' as const,
+              updatedAt: index,
+            },
+          })),
+        })
+        expect(stored).toHaveLength(205)
+        expect(stored.map(event => event.version)).toEqual(
+          Array.from({ length: 205 }, (_, index) => index + 1),
+        )
+      })
+    })
+  })
+
   it('rejects stale expectedVersion values with a typed concurrency conflict', async () => {
     await withTempDataDir(() => {
       db().transaction((tx) => {

--- a/apps/server/src/modules/chat-runtime/es/event-store.ts
+++ b/apps/server/src/modules/chat-runtime/es/event-store.ts
@@ -29,6 +29,17 @@ export interface AppendSessionEventInput {
   occurredAt?: number
 }
 
+export interface AppendSessionEventsInput {
+  aggregateId: string
+  events: ChatSessionEvent[]
+  expectedVersion?: number
+  /** Version read earlier inside the same caller-owned transaction. */
+  knownCurrentVersion?: number
+  occurredAt?: number
+}
+
+const SESSION_EVENT_INSERT_BATCH_SIZE = 100
+
 export function readCurrentSessionEventVersion(
   d: Pick<ChatRuntimeWriteDb, 'select'>,
   aggregateId: string,
@@ -54,32 +65,64 @@ export function appendSessionEvent(
   d: Pick<ChatRuntimeWriteDb, 'select' | 'insert' | 'update'>,
   input: AppendSessionEventInput,
 ): StoredChatSessionEvent {
-  const currentVersion = readCurrentSessionEventVersion(d, input.aggregateId)
+  return appendSessionEvents(d, {
+    aggregateId: input.aggregateId,
+    events: [input.event],
+    expectedVersion: input.expectedVersion,
+    occurredAt: input.occurredAt,
+  })[0]!
+}
+
+/**
+ * Allocate versions once and append a command's facts in bounded multi-row
+ * inserts. Callers own the surrounding transaction so a later chunk failure
+ * rolls back the entire logical append.
+ */
+export function appendSessionEvents(
+  d: Pick<ChatRuntimeWriteDb, 'select' | 'insert' | 'update'>,
+  input: AppendSessionEventsInput,
+): StoredChatSessionEvent[] {
+  if (input.events.length === 0) {
+    return []
+  }
+  const currentVersion = input.knownCurrentVersion
+    ?? readCurrentSessionEventVersion(d, input.aggregateId)
   if (input.expectedVersion !== undefined && currentVersion !== input.expectedVersion) {
     throwConcurrencyConflict(input.aggregateId, input.expectedVersion, currentVersion)
   }
 
-  const version = currentVersion + 1
-  persistEventMessagePayloads(d, input.event)
-  let row
+  for (const event of input.events) {
+    persistEventMessagePayloads(d, event)
+  }
+  const occurredAt = input.occurredAt ?? currentUnixSeconds()
+  const rows = input.events.map((event, index) => ({
+    aggregateId: input.aggregateId,
+    aggregateType: CHAT_SESSION_AGGREGATE_TYPE,
+    version: currentVersion + index + 1,
+    eventType: event.type,
+    payload: serializeChatSessionEventPayload(event),
+    occurredAt,
+  }))
+  const storedRows: Array<typeof sessionEvents.$inferSelect> = []
   try {
-    row = d
-      .insert(sessionEvents)
-      .values({
-        aggregateId: input.aggregateId,
-        aggregateType: CHAT_SESSION_AGGREGATE_TYPE,
-        version,
-        eventType: input.event.type,
-        payload: serializeChatSessionEventPayload(input.event),
-        occurredAt: input.occurredAt ?? currentUnixSeconds(),
-      })
-      .returning()
-      .get()
+    for (let offset = 0; offset < rows.length; offset += SESSION_EVENT_INSERT_BATCH_SIZE) {
+      storedRows.push(...d
+        .insert(sessionEvents)
+        .values(rows.slice(offset, offset + SESSION_EVENT_INSERT_BATCH_SIZE))
+        .returning()
+        .all())
+    }
   }
- catch {
-    throwConcurrencyConflict(input.aggregateId, input.expectedVersion ?? currentVersion, currentVersion)
+  catch {
+    const actualVersion = readCurrentSessionEventVersion(d, input.aggregateId)
+    throwConcurrencyConflict(
+      input.aggregateId,
+      input.expectedVersion ?? currentVersion,
+      actualVersion,
+    )
   }
-  return parseStoredChatSessionEvent(row, payloadId => readMessagePayload(d, payloadId))
+  return storedRows.map(row =>
+    parseStoredChatSessionEvent(row, payloadId => readMessagePayload(d, payloadId)))
 }
 
 export function readSessionEvents(

--- a/apps/server/src/modules/chat-runtime/read-model-projectors.ts
+++ b/apps/server/src/modules/chat-runtime/read-model-projectors.ts
@@ -1,3 +1,5 @@
+import type { BackendRunSnapshotEvent } from '@cradle/db'
+
 import type { ChatRuntimeWriteDb } from './es/event-store'
 
 type ReadModelProjectionDb = Pick<ChatRuntimeWriteDb, 'delete' | 'insert' | 'select' | 'update'>
@@ -10,7 +12,7 @@ export interface ChatRuntimeReadModelProjector {
   projectRun?: (db: ReadModelProjectionDb, input: { runId: string }) => void
   projectRunSnapshotEvent?: (
     db: ReadModelProjectionDb,
-    input: { sourceEventId: string },
+    input: { sourceEvent: BackendRunSnapshotEvent, workspaceId: string | null },
   ) => void
 }
 
@@ -43,8 +45,11 @@ export function projectChatRuntimeRunReadModels(
 
 export function projectChatRuntimeRunSnapshotEventReadModels(
   db: ReadModelProjectionDb,
-  input: { sourceEventId: string },
+  input: { sourceEvent: BackendRunSnapshotEvent, workspaceId: string | null },
 ): void {
+  if (!input.sourceEvent.toolCallId) {
+    return
+  }
   for (const projector of readModelProjectors) {
     projector.projectRunSnapshotEvent?.(db, input)
   }

--- a/apps/server/src/modules/chat-runtime/run-snapshot-compaction.ts
+++ b/apps/server/src/modules/chat-runtime/run-snapshot-compaction.ts
@@ -1,0 +1,38 @@
+import type { BackendRunSnapshotEvent } from '@cradle/db'
+import { z } from 'zod'
+
+export const COMPACTED_SUCCESS_PAYLOAD_SCHEMA = 'cradle.run-snapshot-success-metadata.v1'
+export const COMPACTED_SUCCESS_PAYLOAD_PREFIX = `{"schema":"${COMPACTED_SUCCESS_PAYLOAD_SCHEMA}"`
+const SnapshotPayloadSchema = z
+  .string()
+  .transform(raw => JSON.parse(raw))
+  .pipe(z.record(z.string(), z.unknown()))
+
+export function compactSuccessfulSnapshotEvent(
+  event: BackendRunSnapshotEvent,
+): BackendRunSnapshotEvent {
+  if (event.chunkType === null || isCompactedSuccessPayload(event.payloadJson)) {
+    return event
+  }
+  return {
+    ...event,
+    payloadJson: compactSuccessfulPayload(event.payloadJson),
+  }
+}
+
+export function compactSuccessfulPayload(payloadJson: string): string {
+  const parsed = SnapshotPayloadSchema.safeParse(payloadJson)
+  const coalescedCount
+    = parsed.success && typeof parsed.data.coalescedCount === 'number'
+      ? parsed.data.coalescedCount
+      : undefined
+  return JSON.stringify({
+    schema: COMPACTED_SUCCESS_PAYLOAD_SCHEMA,
+    originalLength: payloadJson.length,
+    ...(coalescedCount !== undefined ? { coalescedCount } : {}),
+  })
+}
+
+export function isCompactedSuccessPayload(payloadJson: string): boolean {
+  return payloadJson.startsWith(COMPACTED_SUCCESS_PAYLOAD_PREFIX)
+}

--- a/apps/server/src/modules/chat-runtime/run-snapshot-journal.ts
+++ b/apps/server/src/modules/chat-runtime/run-snapshot-journal.ts
@@ -6,6 +6,7 @@ import type { db } from '../../infra'
 import { registerBeforeDatabaseShutdown } from '../../infra'
 import { createChildLogger } from '../../logging/logger'
 import { projectChatRuntimeRunSnapshotEventReadModels } from './read-model-projectors'
+import { compactSuccessfulSnapshotEvent } from './run-snapshot-compaction'
 
 type SnapshotDatabase = ReturnType<typeof db>
 export type SnapshotTransaction = Parameters<Parameters<SnapshotDatabase['transaction']>[0]>[0]
@@ -22,7 +23,17 @@ interface SnapshotJournal {
   pendingUpdates: Map<string, SnapshotEventUpdate>
   eventById: Map<string, BackendRunSnapshotEvent>
   workspaceBySnapshotId: Map<string, string | null>
+  persistedSnapshotIds: Set<string>
   timer: ReturnType<typeof setTimeout> | null
+}
+
+interface SnapshotFlushContext {
+  hadPreviouslyPersistedEvents: boolean
+}
+
+interface SnapshotFlushOptions<Result> {
+  compactSuccessfulPayloads?: (result: Result | undefined) => boolean
+  finalSnapshot?: boolean
 }
 
 const logger = createChildLogger({ module: 'chat-runtime.run-snapshot-journal' })
@@ -93,15 +104,21 @@ export function updateQueuedRunSnapshotEvent(
 export function flushRunSnapshotJournalForSnapshot<Result>(
   database: SnapshotDatabase,
   snapshotId: string,
-  withinTransaction?: (transaction: SnapshotTransaction) => Result,
+  withinTransaction?: (
+    transaction: SnapshotTransaction,
+    context: SnapshotFlushContext,
+  ) => Result,
+  options: SnapshotFlushOptions<Result> = {},
 ): Result | undefined {
   const journal = journals.get(database)
   if (!journal) {
-    return withinTransaction ? database.transaction(withinTransaction) : undefined
+    return withinTransaction
+      ? database.transaction(tx => withinTransaction(tx, { hadPreviouslyPersistedEvents: false }))
+      : undefined
   }
   cancelTimer(journal)
   try {
-    return flushJournal(journal, withinTransaction, snapshotId)
+    return flushJournal(journal, withinTransaction, snapshotId, options)
   }
   catch (error) {
     scheduleFlush(journal, RETRY_DELAY_MS)
@@ -132,6 +149,7 @@ export function releaseRunSnapshotContext(database: SnapshotDatabase, snapshotId
     return
   }
   journal.workspaceBySnapshotId.delete(snapshotId)
+  journal.persistedSnapshotIds.delete(snapshotId)
   for (const [eventId, event] of journal.eventById) {
     if (event.snapshotId === snapshotId) {
       journal.eventById.delete(eventId)
@@ -149,6 +167,7 @@ function journalFor(database: SnapshotDatabase): SnapshotJournal {
       pendingUpdates: new Map(),
       eventById: new Map(),
       workspaceBySnapshotId: new Map(),
+      persistedSnapshotIds: new Set(),
       timer: null,
     }
     journals.set(database, journal)
@@ -175,8 +194,12 @@ function scheduleFlush(journal: SnapshotJournal, delayMs: number): void {
 
 function flushJournal<Result>(
   journal: SnapshotJournal,
-  withinTransaction?: (transaction: SnapshotTransaction) => Result,
+  withinTransaction?: (
+    transaction: SnapshotTransaction,
+    context: SnapshotFlushContext,
+  ) => Result,
   snapshotId?: string,
+  options: SnapshotFlushOptions<Result> = {},
 ): Result | undefined {
   const inserts = [...journal.pendingInserts.values()]
     .filter(event => snapshotId === undefined || event.snapshotId === snapshotId)
@@ -185,9 +208,16 @@ function flushJournal<Result>(
       snapshotId === undefined || journal.eventById.get(eventId)?.snapshotId === snapshotId)
   let result: Result | undefined
   journal.database.transaction((tx) => {
-    for (let offset = 0; offset < inserts.length; offset += INSERT_BATCH_SIZE) {
+    result = withinTransaction?.(tx, {
+      hadPreviouslyPersistedEvents: snapshotId !== undefined
+        && journal.persistedSnapshotIds.has(snapshotId),
+    })
+    const persistedInserts = options.compactSuccessfulPayloads?.(result)
+      ? inserts.map(compactSuccessfulSnapshotEvent)
+      : inserts
+    for (let offset = 0; offset < persistedInserts.length; offset += INSERT_BATCH_SIZE) {
       tx.insert(backendRunSnapshotEvents)
-        .values(inserts.slice(offset, offset + INSERT_BATCH_SIZE))
+        .values(persistedInserts.slice(offset, offset + INSERT_BATCH_SIZE))
         .run()
     }
     for (const [eventId, update] of updates) {
@@ -211,13 +241,17 @@ function flushJournal<Result>(
         })
       }
     }
-    result = withinTransaction?.(tx)
   })
   for (const event of inserts) {
     journal.pendingInserts.delete(event.id)
   }
   for (const [eventId] of updates) {
     journal.pendingUpdates.delete(eventId)
+  }
+  if (!options.finalSnapshot) {
+    for (const event of inserts) {
+      journal.persistedSnapshotIds.add(event.snapshotId)
+    }
   }
   if (journal.pendingInserts.size > 0 || journal.pendingUpdates.size > 0) {
     scheduleFlush(journal, FLUSH_DELAY_MS)

--- a/apps/server/src/modules/chat-runtime/run-snapshot-journal.ts
+++ b/apps/server/src/modules/chat-runtime/run-snapshot-journal.ts
@@ -1,0 +1,246 @@
+import type { BackendRunSnapshotEvent } from '@cradle/db'
+import { backendRunSnapshotEvents } from '@cradle/db'
+import { eq } from 'drizzle-orm'
+
+import type { db } from '../../infra'
+import { registerBeforeDatabaseShutdown } from '../../infra'
+import { createChildLogger } from '../../logging/logger'
+import { projectChatRuntimeRunSnapshotEventReadModels } from './read-model-projectors'
+
+type SnapshotDatabase = ReturnType<typeof db>
+export type SnapshotTransaction = Parameters<Parameters<SnapshotDatabase['transaction']>[0]>[0]
+
+interface SnapshotEventUpdate {
+  payloadJson: string
+  occurredAt: number
+  durationMs: number | null
+}
+
+interface SnapshotJournal {
+  database: SnapshotDatabase
+  pendingInserts: Map<string, BackendRunSnapshotEvent>
+  pendingUpdates: Map<string, SnapshotEventUpdate>
+  eventById: Map<string, BackendRunSnapshotEvent>
+  workspaceBySnapshotId: Map<string, string | null>
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+const logger = createChildLogger({ module: 'chat-runtime.run-snapshot-journal' })
+const journals = new Map<SnapshotDatabase, SnapshotJournal>()
+const INSERT_BATCH_SIZE = 40
+const FLUSH_DELAY_MS = 1_000
+const RETRY_DELAY_MS = 1_000
+
+registerBeforeDatabaseShutdown(() => {
+  const failures: Error[] = []
+  for (const journal of journals.values()) {
+    cancelTimer(journal)
+    try {
+      flushJournal(journal)
+    }
+    catch (error) {
+      failures.push(error instanceof Error ? error : new Error(String(error)))
+    }
+    finally {
+      journals.delete(journal.database)
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Failed to flush run snapshot journals')
+  }
+})
+
+export function registerRunSnapshotContext(
+  database: SnapshotDatabase,
+  snapshotId: string,
+  workspaceId: string | null,
+): void {
+  journalFor(database).workspaceBySnapshotId.set(snapshotId, workspaceId)
+}
+
+export function enqueueRunSnapshotEvent(
+  database: SnapshotDatabase,
+  event: BackendRunSnapshotEvent,
+): void {
+  const journal = journalFor(database)
+  journal.pendingInserts.set(event.id, event)
+  journal.eventById.set(event.id, event)
+  scheduleFlush(journal, FLUSH_DELAY_MS)
+}
+
+export function updateQueuedRunSnapshotEvent(
+  database: SnapshotDatabase,
+  eventId: string,
+  update: SnapshotEventUpdate,
+): boolean {
+  const journal = journals.get(database)
+  const event = journal?.eventById.get(eventId)
+  if (!journal || !event) {
+    return false
+  }
+  const updatedEvent: BackendRunSnapshotEvent = { ...event, ...update }
+  journal.eventById.set(eventId, updatedEvent)
+  if (journal.pendingInserts.has(eventId)) {
+    journal.pendingInserts.set(eventId, updatedEvent)
+  }
+  else {
+    journal.pendingUpdates.set(eventId, update)
+  }
+  scheduleFlush(journal, FLUSH_DELAY_MS)
+  return true
+}
+
+export function flushRunSnapshotJournalForSnapshot<Result>(
+  database: SnapshotDatabase,
+  snapshotId: string,
+  withinTransaction?: (transaction: SnapshotTransaction) => Result,
+): Result | undefined {
+  const journal = journals.get(database)
+  if (!journal) {
+    return withinTransaction ? database.transaction(withinTransaction) : undefined
+  }
+  cancelTimer(journal)
+  try {
+    return flushJournal(journal, withinTransaction, snapshotId)
+  }
+  catch (error) {
+    scheduleFlush(journal, RETRY_DELAY_MS)
+    throw error
+  }
+}
+
+export function flushRunSnapshotWriteBehind(): void {
+  const failures: Error[] = []
+  for (const journal of journals.values()) {
+    cancelTimer(journal)
+    try {
+      flushJournal(journal)
+    }
+    catch (error) {
+      scheduleFlush(journal, RETRY_DELAY_MS)
+      failures.push(error instanceof Error ? error : new Error(String(error)))
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Failed to flush run snapshot journals')
+  }
+}
+
+export function releaseRunSnapshotContext(database: SnapshotDatabase, snapshotId: string): void {
+  const journal = journals.get(database)
+  if (!journal) {
+    return
+  }
+  journal.workspaceBySnapshotId.delete(snapshotId)
+  for (const [eventId, event] of journal.eventById) {
+    if (event.snapshotId === snapshotId) {
+      journal.eventById.delete(eventId)
+    }
+  }
+  removeJournalIfIdle(journal)
+}
+
+function journalFor(database: SnapshotDatabase): SnapshotJournal {
+  let journal = journals.get(database)
+  if (!journal) {
+    journal = {
+      database,
+      pendingInserts: new Map(),
+      pendingUpdates: new Map(),
+      eventById: new Map(),
+      workspaceBySnapshotId: new Map(),
+      timer: null,
+    }
+    journals.set(database, journal)
+  }
+  return journal
+}
+
+function scheduleFlush(journal: SnapshotJournal, delayMs: number): void {
+  if (journal.timer) {
+    return
+  }
+  journal.timer = setTimeout(() => {
+    journal.timer = null
+    try {
+      flushJournal(journal)
+    }
+    catch (error) {
+      logger.error('failed to flush run snapshot journal', { error })
+      scheduleFlush(journal, RETRY_DELAY_MS)
+    }
+  }, delayMs)
+  journal.timer.unref?.()
+}
+
+function flushJournal<Result>(
+  journal: SnapshotJournal,
+  withinTransaction?: (transaction: SnapshotTransaction) => Result,
+  snapshotId?: string,
+): Result | undefined {
+  const inserts = [...journal.pendingInserts.values()]
+    .filter(event => snapshotId === undefined || event.snapshotId === snapshotId)
+  const updates = [...journal.pendingUpdates.entries()]
+    .filter(([eventId]) =>
+      snapshotId === undefined || journal.eventById.get(eventId)?.snapshotId === snapshotId)
+  let result: Result | undefined
+  journal.database.transaction((tx) => {
+    for (let offset = 0; offset < inserts.length; offset += INSERT_BATCH_SIZE) {
+      tx.insert(backendRunSnapshotEvents)
+        .values(inserts.slice(offset, offset + INSERT_BATCH_SIZE))
+        .run()
+    }
+    for (const [eventId, update] of updates) {
+      tx.update(backendRunSnapshotEvents)
+        .set(update)
+        .where(eq(backendRunSnapshotEvents.id, eventId))
+        .run()
+    }
+    for (const event of inserts) {
+      projectChatRuntimeRunSnapshotEventReadModels(tx, {
+        sourceEvent: event,
+        workspaceId: journal.workspaceBySnapshotId.get(event.snapshotId) ?? null,
+      })
+    }
+    for (const [eventId] of updates) {
+      const event = journal.eventById.get(eventId)
+      if (event) {
+        projectChatRuntimeRunSnapshotEventReadModels(tx, {
+          sourceEvent: event,
+          workspaceId: journal.workspaceBySnapshotId.get(event.snapshotId) ?? null,
+        })
+      }
+    }
+    result = withinTransaction?.(tx)
+  })
+  for (const event of inserts) {
+    journal.pendingInserts.delete(event.id)
+  }
+  for (const [eventId] of updates) {
+    journal.pendingUpdates.delete(eventId)
+  }
+  if (journal.pendingInserts.size > 0 || journal.pendingUpdates.size > 0) {
+    scheduleFlush(journal, FLUSH_DELAY_MS)
+  }
+  removeJournalIfIdle(journal)
+  return result
+}
+
+function removeJournalIfIdle(journal: SnapshotJournal): void {
+  if (
+    journal.pendingInserts.size === 0
+    && journal.pendingUpdates.size === 0
+    && journal.workspaceBySnapshotId.size === 0
+  ) {
+    cancelTimer(journal)
+    journals.delete(journal.database)
+  }
+}
+
+function cancelTimer(journal: SnapshotJournal): void {
+  if (!journal.timer) {
+    return
+  }
+  clearTimeout(journal.timer)
+  journal.timer = null
+}

--- a/apps/server/src/modules/chat-runtime/run-snapshot.ts
+++ b/apps/server/src/modules/chat-runtime/run-snapshot.ts
@@ -18,6 +18,11 @@ import { OBSERVABILITY_CODES } from '../observability/contract'
 import * as Observability from '../observability/service'
 import { projectChatRuntimeRunSnapshotEventReadModels } from './read-model-projectors'
 import {
+  COMPACTED_SUCCESS_PAYLOAD_PREFIX,
+  compactSuccessfulPayload,
+  isCompactedSuccessPayload,
+} from './run-snapshot-compaction'
+import {
   enqueueRunSnapshotEvent,
   flushRunSnapshotJournalForSnapshot,
   flushRunSnapshotWriteBehind,
@@ -25,6 +30,8 @@ import {
   releaseRunSnapshotContext,
   updateQueuedRunSnapshotEvent,
 } from './run-snapshot-journal'
+
+export { COMPACTED_SUCCESS_PAYLOAD_SCHEMA } from './run-snapshot-compaction'
 
 const logger = createChildLogger({ module: 'chat-runtime.run-snapshot' })
 
@@ -151,8 +158,6 @@ const DEFAULT_SNAPSHOT_EVENTS_READ_LIMIT = 2_000
 const DEFAULT_SNAPSHOT_EVENTS_MAX = 2_000
 const DEFAULT_RETENTION_BATCH_SIZE = 250
 const DEFAULT_COMPACTION_SNAPSHOT_BATCH_SIZE = 25
-export const COMPACTED_SUCCESS_PAYLOAD_SCHEMA = 'cradle.run-snapshot-success-metadata.v1'
-const COMPACTED_SUCCESS_PAYLOAD_PREFIX = `{"schema":"${COMPACTED_SUCCESS_PAYLOAD_SCHEMA}"`
 
 /**
  * Hard cap on how many event rows a single run snapshot may accumulate.
@@ -204,7 +209,7 @@ export function startRunSnapshot(input: StartRunSnapshotInput): ChatRunSnapshot 
     const d = db()
     d.insert(backendRunSnapshots).values(row).run()
     registerRunSnapshotContext(d, id, input.workspaceId ?? null)
-    return toChatRunSnapshot(row as BackendRunSnapshot, [])
+    return toChatRunSnapshot(row as BackendRunSnapshot, [], 0)
   }
  catch (error) {
     logger.error('failed to start run snapshot', { input, error })
@@ -312,7 +317,7 @@ export function finalizeRunSnapshot(input: FinalizeRunSnapshotInput): void {
 
   try {
     const d = db()
-    const { previous, changes } = flushRunSnapshotJournalForSnapshot(d, input.snapshotId, (tx) => {
+    const { previous, changes } = flushRunSnapshotJournalForSnapshot(d, input.snapshotId, (tx, context) => {
       const previous = tx
         .select()
         .from(backendRunSnapshots)
@@ -326,11 +331,18 @@ export function finalizeRunSnapshot(input: FinalizeRunSnapshotInput): void {
             .where(eq(backendRunSnapshots.id, input.snapshotId))
             .run()
 
-      if (result.changes > 0 && input.status === 'complete') {
+      if (
+        result.changes > 0
+        && input.status === 'complete'
+        && context.hadPreviouslyPersistedEvents
+      ) {
         compactSuccessfulRunSnapshotEventPayloads(tx, input.snapshotId)
       }
 
       return { previous, changes: result.changes }
+    }, {
+      compactSuccessfulPayloads: result => input.status === 'complete' && (result?.changes ?? 0) > 0,
+      finalSnapshot: true,
     })!
     releaseRunSnapshotContext(d, input.snapshotId)
     if (changes === 0 && previous && previous.status !== 'running' && previous.status !== input.status) {
@@ -437,8 +449,9 @@ function countSnapshotEvents(snapshotId: string): number {
 function toChatRunSnapshot(
   row: BackendRunSnapshot,
   events: BackendRunSnapshotEvent[],
+  knownEventCount?: number,
 ): ChatRunSnapshot {
-  const eventCount = countSnapshotEvents(row.id)
+  const eventCount = knownEventCount ?? countSnapshotEvents(row.id)
   return {
     id: row.id,
     schemaVersion: row.schemaVersion,
@@ -594,24 +607,6 @@ function compactSuccessfulRunSnapshotEventPayloads(
     compacted += 1
   }
   return compacted
-}
-
-function compactSuccessfulPayload(payloadJson: string): string {
-  const parsed = SnapshotRecordSchema.safeParse(payloadJson)
-  const coalescedCount
-    = parsed.success && typeof parsed.data.coalescedCount === 'number'
-      ? parsed.data.coalescedCount
-      : undefined
-  return JSON.stringify({
-    schema: COMPACTED_SUCCESS_PAYLOAD_SCHEMA,
-    originalLength: payloadJson.length,
-    ...(coalescedCount !== undefined ? { coalescedCount } : {}),
-  })
-}
-
-function isCompactedSuccessPayload(payloadJson: string): boolean {
-  const parsed = SnapshotRecordSchema.safeParse(payloadJson)
-  return parsed.success && parsed.data.schema === COMPACTED_SUCCESS_PAYLOAD_SCHEMA
 }
 
 function readExpiredRunSnapshotIds(d: RunSnapshotMaintenanceDb, now: number): string[] {

--- a/apps/server/src/modules/chat-runtime/run-snapshot.ts
+++ b/apps/server/src/modules/chat-runtime/run-snapshot.ts
@@ -5,7 +5,6 @@ import type {
   BackendRunSnapshot,
   BackendRunSnapshotEvent,
   NewBackendRunSnapshot,
-  NewBackendRunSnapshotEvent,
 } from '@cradle/db'
 import { backendRunSnapshotEvents, backendRunSnapshots } from '@cradle/db'
 import type { SQL } from 'drizzle-orm'
@@ -18,6 +17,14 @@ import { createChildLogger } from '../../logging/logger'
 import { OBSERVABILITY_CODES } from '../observability/contract'
 import * as Observability from '../observability/service'
 import { projectChatRuntimeRunSnapshotEventReadModels } from './read-model-projectors'
+import {
+  enqueueRunSnapshotEvent,
+  flushRunSnapshotJournalForSnapshot,
+  flushRunSnapshotWriteBehind,
+  registerRunSnapshotContext,
+  releaseRunSnapshotContext,
+  updateQueuedRunSnapshotEvent,
+} from './run-snapshot-journal'
 
 const logger = createChildLogger({ module: 'chat-runtime.run-snapshot' })
 
@@ -194,7 +201,9 @@ export function startRunSnapshot(input: StartRunSnapshotInput): ChatRunSnapshot 
 
   try {
     pruneExpiredRunSnapshots()
-    db().insert(backendRunSnapshots).values(row).run()
+    const d = db()
+    d.insert(backendRunSnapshots).values(row).run()
+    registerRunSnapshotContext(d, id, input.workspaceId ?? null)
     return toChatRunSnapshot(row as BackendRunSnapshot, [])
   }
  catch (error) {
@@ -206,7 +215,7 @@ export function startRunSnapshot(input: StartRunSnapshotInput): ChatRunSnapshot 
 export function appendRunSnapshotEvent(
   input: AppendRunSnapshotEventInput,
 ): ChatRunSnapshotEvent | null {
-  const row: NewBackendRunSnapshotEvent = {
+  const row: BackendRunSnapshotEvent = {
     id: randomUUID(),
     snapshotId: input.snapshotId,
     chatSessionId: input.chatSessionId,
@@ -228,9 +237,8 @@ export function appendRunSnapshotEvent(
 
   try {
     const d = db()
-    d.insert(backendRunSnapshotEvents).values(row).run()
-    projectChatRuntimeRunSnapshotEventReadModels(d, { sourceEventId: row.id })
-    return toChatRunSnapshotEvent(row as BackendRunSnapshotEvent)
+    enqueueRunSnapshotEvent(d, row)
+    return toChatRunSnapshotEvent(row)
   }
  catch (error) {
     logger.error('failed to append run snapshot event', { input, error })
@@ -247,17 +255,37 @@ export function appendRunSnapshotEvent(
 export function updateRunSnapshotEventPayload(input: UpdateRunSnapshotEventPayloadInput): void {
   try {
     const d = db()
+    const update = {
+      payloadJson: stringifySnapshotRecord(input.payload),
+      occurredAt: input.occurredAt ?? Date.now(),
+      durationMs: input.durationMs ?? null,
+    }
+    if (updateQueuedRunSnapshotEvent(d, input.eventId, update)) {
+      return
+    }
     const result = d
       .update(backendRunSnapshotEvents)
-      .set({
-        payloadJson: stringifySnapshotRecord(input.payload),
-        occurredAt: input.occurredAt ?? Date.now(),
-        durationMs: input.durationMs ?? null,
-      })
+      .set(update)
       .where(eq(backendRunSnapshotEvents.id, input.eventId))
       .run()
     if (result.changes > 0) {
-      projectChatRuntimeRunSnapshotEventReadModels(d, { sourceEventId: input.eventId })
+      const event = d
+        .select()
+        .from(backendRunSnapshotEvents)
+        .where(eq(backendRunSnapshotEvents.id, input.eventId))
+        .get()
+      const snapshot = event
+        ? d.select({ workspaceId: backendRunSnapshots.workspaceId })
+            .from(backendRunSnapshots)
+            .where(eq(backendRunSnapshots.id, event.snapshotId))
+            .get()
+        : null
+      if (event) {
+        projectChatRuntimeRunSnapshotEventReadModels(d, {
+          sourceEvent: event,
+          workspaceId: snapshot?.workspaceId ?? null,
+        })
+      }
     }
   }
  catch (error) {
@@ -284,30 +312,28 @@ export function finalizeRunSnapshot(input: FinalizeRunSnapshotInput): void {
 
   try {
     const d = db()
-    const { previous, changes } = d.transaction((tx) => {
+    const { previous, changes } = flushRunSnapshotJournalForSnapshot(d, input.snapshotId, (tx) => {
       const previous = tx
         .select()
         .from(backendRunSnapshots)
         .where(eq(backendRunSnapshots.id, input.snapshotId))
         .get()
-      const result = tx
-        .update(backendRunSnapshots)
-        .set(values)
-        .where(
-          and(
-            eq(backendRunSnapshots.id, input.snapshotId),
-            eq(backendRunSnapshots.status, 'running'),
-          ),
-        )
-        .run()
+      const result = previous && previous.status !== 'running' && previous.status !== input.status
+        ? { changes: 0 }
+        : tx
+            .update(backendRunSnapshots)
+            .set(values)
+            .where(eq(backendRunSnapshots.id, input.snapshotId))
+            .run()
 
       if (result.changes > 0 && input.status === 'complete') {
         compactSuccessfulRunSnapshotEventPayloads(tx, input.snapshotId)
       }
 
       return { previous, changes: result.changes }
-    })
-    if (changes === 0 && previous && previous.status !== 'running') {
+    })!
+    releaseRunSnapshotContext(d, input.snapshotId)
+    if (changes === 0 && previous && previous.status !== 'running' && previous.status !== input.status) {
       Observability.record({
         source: 'chat-engine',
         code: OBSERVABILITY_CODES.chatLateRunFinalizationIgnored,
@@ -332,6 +358,7 @@ export function finalizeRunSnapshot(input: FinalizeRunSnapshotInput): void {
 }
 
 export function getRunSnapshots(filter: RunSnapshotFilter = {}): ChatRunSnapshot[] {
+  flushRunSnapshotWriteBehind()
   const conditions: SQL[] = []
   if (filter.chatSessionId) {
     conditions.push(eq(backendRunSnapshots.chatSessionId, filter.chatSessionId))
@@ -368,6 +395,7 @@ export function getRunSnapshots(filter: RunSnapshotFilter = {}): ChatRunSnapshot
 }
 
 export function getRunSnapshot(runId: string): ChatRunSnapshot | null {
+  flushRunSnapshotWriteBehind()
   const row = db()
     .select()
     .from(backendRunSnapshots)
@@ -480,6 +508,7 @@ interface RunSnapshotMaintenanceResult {
 }
 
 export function maintainRunSnapshots(now = Date.now()): RunSnapshotMaintenanceResult {
+  flushRunSnapshotWriteBehind()
   const d = db()
   return d.transaction((tx) => {
     const completedSnapshotIds = tx

--- a/apps/server/src/modules/chat-runtime/run/run-coordinator.ts
+++ b/apps/server/src/modules/chat-runtime/run/run-coordinator.ts
@@ -279,7 +279,7 @@ export async function createRun(
       })
     }
 
-    attachBinding({
+    const binding = attachBinding({
       sessionId: input.sessionId,
       providerTargetId: context.providerTarget?.id ?? null,
       runtimeKind: runtimeSession.runtimeKind,
@@ -297,6 +297,7 @@ export async function createRun(
           : createAssistantMessage(draft.assistantMessageId),
       userMessage: draft.appendUserMessage ? draft.userMessage : undefined,
       queueItemId: input.queueItemId ?? null,
+      bindingId: binding?.id ?? null,
     })
     const activeRun: ActiveRun = {
       runId: run.id,

--- a/apps/server/src/modules/chat-runtime/run/turn-draft.ts
+++ b/apps/server/src/modules/chat-runtime/run/turn-draft.ts
@@ -60,6 +60,7 @@ export interface StartRunInput {
   assistantMessage: UIMessage
   userMessage?: UIMessage
   queueItemId?: string | null
+  bindingId?: string | null
 }
 
 export function annotateContinuationMessage(
@@ -166,11 +167,13 @@ export async function insertCompletedUserMessage(
 }
 
 export async function startRun(input: StartRunInput): Promise<BackendRun> {
-  const binding = readDurableProviderRuntimeBinding(input.sessionId)
+  const bindingId = input.bindingId === undefined
+    ? readDurableProviderRuntimeBinding(input.sessionId)?.id ?? null
+    : input.bindingId
   const now = currentUnixSeconds()
   const run = {
     id: randomUUID(),
-    bindingId: binding?.id ?? null,
+    bindingId,
     chatSessionId: input.sessionId,
     messageId: input.messageId,
     origin: input.origin,

--- a/apps/server/src/modules/chat-runtime/run/turn-executor.ts
+++ b/apps/server/src/modules/chat-runtime/run/turn-executor.ts
@@ -15,6 +15,8 @@ import type {
   RuntimeProviderTargetProfile,
   RuntimeReviewTarget,
   RuntimeSettings,
+  RuntimeStepUsage,
+  RuntimeTurnResult,
   TokenUsage,
 } from '../runtime-provider-types'
 import { attachBinding, isProviderTargetAvailable } from '../runtime-session-context'
@@ -125,6 +127,7 @@ export interface TurnExecutorDeps {
 interface RunStreamPumpResult {
   finalChunk: UIMessageChunk
   failurePayload: SerializedChatError['payload'] | undefined
+  turnResult: RuntimeTurnResult
 }
 
 export async function executeRun(
@@ -160,14 +163,14 @@ export async function executeRun(
         })
       })
     }
-    const { finalChunk, failurePayload } = await pumpRuntimeStream(
+    const { finalChunk, failurePayload, turnResult } = await pumpRuntimeStream(
       activeRun,
       input,
       diagnostics,
       profile,
       deps,
     )
-    const actualModelId = activeRun.runtime.lastModelId ?? activeRun.modelId
+    const actualModelId = turnResult.modelId ?? activeRun.runtime.lastModelId ?? activeRun.modelId
     let handoff: ActiveTurnHandoff = { kind: 'queue' }
     const completion = await deps.completeActiveTurn(activeRun, {
       source: 'normal',
@@ -198,6 +201,7 @@ export async function executeRun(
           failurePayload,
           diagnostics,
           actualModelId,
+          turnResult,
           deps,
         )
         if (activeRun.internalContinuation !== 'runtimeGoal') {
@@ -226,7 +230,7 @@ export async function executeRun(
     const settledFinalChunk = completion.terminalChunk ?? finalChunk
     const usage = activeRun.runtime.usageAccounting === 'provider-events'
       ? activeRun.usageEventAggregate
-      : activeRun.runtime.totalUsage ?? activeRun.runtime.lastUsage ?? null
+      : turnResult.usage ?? activeRun.runtime.totalUsage ?? activeRun.runtime.lastUsage ?? null
     return {
       modelId: actualModelId,
       usage,
@@ -256,6 +260,7 @@ async function pumpRuntimeStream(
 ): Promise<RunStreamPumpResult> {
   let finalChunk: UIMessageChunk = { type: 'finish', finishReason: 'stop' }
   let failurePayload: SerializedChatError['payload'] | undefined
+  let turnResult: RuntimeTurnResult = {}
   const onProviderSyntheticTurnEvent = createProviderSyntheticTurnEventHandler(activeRun, {
     stream: deps.stream,
     completeActiveTurn: deps.completeActiveTurn,
@@ -326,6 +331,13 @@ async function pumpRuntimeStream(
           isTerminalChunk: isTerminalUIMessageChunk,
         }),
       onProviderSyntheticTurnEvent,
+      reportTurnResult: (result) => {
+        turnResult = {
+          ...turnResult,
+          ...result,
+          ...(result.stepUsages ? { stepUsages: [...result.stepUsages] } : {}),
+        }
+      },
     })) {
       if (activeRun.terminalStatus) {
         break
@@ -422,7 +434,7 @@ async function pumpRuntimeStream(
     })
   }
 
-  return { finalChunk, failurePayload }
+  return { finalChunk, failurePayload, turnResult }
 }
 
 function recordRunUsageAndFailure(
@@ -431,6 +443,7 @@ function recordRunUsageAndFailure(
   failurePayload: SerializedChatError['payload'] | undefined,
   diagnostics: TurnOutputDiagnostics,
   actualModelId: string | null,
+  turnResult: RuntimeTurnResult,
   deps: TurnExecutorDeps,
 ): void {
   if (activeRun.cancelRequested) {
@@ -462,7 +475,7 @@ function recordRunUsageAndFailure(
 
       const usage = activeRun.runtime.usageAccounting === 'provider-events'
         ? activeRun.usageEventAggregate
-        : activeRun.runtime?.totalUsage ?? activeRun.runtime?.lastUsage
+        : turnResult.usage ?? activeRun.runtime?.totalUsage ?? activeRun.runtime?.lastUsage
       if (usage) {
         if (activeRun.runtime.usageAccounting !== 'provider-events') {
           insertRunUsage({
@@ -482,12 +495,14 @@ function recordRunUsageAndFailure(
           payload: {
             source: activeRun.runtime.usageAccounting === 'provider-events'
               ? 'runtime.usageEvents'
-              : activeRun.runtime?.totalUsage ? 'runtime.totalUsage' : 'runtime.lastUsage',
+              : turnResult.usage
+                ? 'runtime.turnResult'
+                : activeRun.runtime?.totalUsage ? 'runtime.totalUsage' : 'runtime.lastUsage',
           },
         })
       }
 
-      const steps = activeRun.runtime.lastStepUsages ?? []
+      const steps: RuntimeStepUsage[] = turnResult.stepUsages ?? activeRun.runtime.lastStepUsages ?? []
       if (steps.length > 0) {
         const fallbackModelId = actualModelId ?? UNKNOWN_MODEL_ID
         const recordedSteps = insertRuntimeStepUsages({
@@ -560,8 +575,9 @@ function recordRunCompletion(
   actualModelId: string | null,
   deps: TurnExecutorDeps,
 ): ActiveTurnHandoff {
+  let persistedBinding: ReturnType<typeof attachBinding>
   try {
-    attachBinding({
+    persistedBinding = attachBinding({
       sessionId: activeRun.sessionId,
       providerTargetId: activeRun.providerTargetId,
       runtimeKind: activeRun.runtimeSession.runtimeKind,
@@ -579,7 +595,9 @@ function recordRunCompletion(
     },
     finalChunk,
   )
-  const binding = readDurableProviderRuntimeBinding(activeRun.sessionId)
+  const binding = activeRun.runtime.goalContinuation
+    ? persistedBinding ?? readDurableProviderRuntimeBinding(activeRun.sessionId)
+    : undefined
   const shouldContinueRuntimeGoal = shouldScheduleRuntimeGoalContinuation({
     run: {
       sessionId: activeRun.sessionId,

--- a/apps/server/src/modules/chat-runtime/run/usage.ts
+++ b/apps/server/src/modules/chat-runtime/run/usage.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from 'node:crypto'
 
-import { stepUsage as stepUsageTable, usageLogs } from '@cradle/db'
+import type { stepUsage as stepUsageTable } from '@cradle/db'
 
 import { currentUnixSeconds } from '../../../helpers/time'
-import { db } from '../../../infra'
 import { estimateCost } from '../../usage/pricing'
+import { enqueueStepUsage, enqueueUsageLog } from '../../usage/write-behind'
 import type { RuntimeStepUsage, TokenUsage } from '../runtime-provider-types'
 
 export type RuntimeStepUsageInput = RuntimeStepUsage
@@ -34,21 +34,21 @@ export function insertRunUsage(input: {
   modelId: string | null
   usage: TokenUsage
 }): void {
-  db()
-    .insert(usageLogs)
-    .values({
-      id: randomUUID(),
-      runId: input.runId,
-      sessionId: input.sessionId,
-      messageId: input.messageId,
-      providerTargetId: input.providerTargetId,
-      modelId: input.modelId,
-      promptTokens: input.usage.promptTokens,
-      completionTokens: input.usage.completionTokens,
-      totalTokens: input.usage.totalTokens,
-      createdAt: currentUnixSeconds(),
-    })
-    .run()
+  enqueueUsageLog({
+    id: randomUUID(),
+    runId: input.runId,
+    sessionId: input.sessionId,
+    messageId: input.messageId,
+    providerTargetId: input.providerTargetId,
+    modelId: input.modelId,
+    promptTokens: input.usage.promptTokens,
+    cachedInputTokens: input.usage.cachedInputTokens ?? 0,
+    cacheWriteInputTokens: input.usage.cacheWriteInputTokens ?? 0,
+    completionTokens: input.usage.completionTokens,
+    reasoningOutputTokens: input.usage.reasoningOutputTokens ?? 0,
+    totalTokens: input.usage.totalTokens,
+    createdAt: currentUnixSeconds(),
+  })
 }
 
 export function estimateRunUsageCost(modelId: string | null, usage: TokenUsage): number | null {
@@ -61,12 +61,19 @@ export function insertRuntimeStepUsages(input: {
   fallbackModelId: string
   steps: RuntimeStepUsageInput[]
 }): RecordedRuntimeStepUsage[] {
-  return input.steps.map((step) => {
+  const createdAt = currentUnixSeconds()
+  const rows = input.steps.map((step) => {
     const modelId = step.modelId ?? input.fallbackModelId
     const estimatedCostUsd = estimateCost(modelId, step.usage)
-    db()
-      .insert(stepUsageTable)
-      .values({
+    return {
+      recorded: {
+        stepNumber: step.stepNumber,
+        stepType: step.stepType,
+        modelId,
+        usage: step.usage,
+        estimatedCostUsd,
+      },
+      row: {
         id: randomUUID(),
         runId: input.runId,
         sessionId: input.sessionId,
@@ -77,15 +84,10 @@ export function insertRuntimeStepUsages(input: {
         completionTokens: step.usage.completionTokens,
         totalTokens: step.usage.totalTokens,
         estimatedCostUsd,
-        createdAt: currentUnixSeconds(),
-      })
-      .run()
-    return {
-      stepNumber: step.stepNumber,
-      stepType: step.stepType,
-      modelId,
-      usage: step.usage,
-      estimatedCostUsd,
+        createdAt,
+      } satisfies typeof stepUsageTable.$inferInsert,
     }
   })
+  enqueueStepUsage(rows.map(entry => entry.row))
+  return rows.map(entry => entry.recorded)
 }

--- a/apps/server/src/modules/chat-runtime/runtime-session-context.ts
+++ b/apps/server/src/modules/chat-runtime/runtime-session-context.ts
@@ -38,6 +38,10 @@ import type {
 } from './runtime-provider-types'
 
 const runtimeSessionLogger = createChildLogger({ module: 'chat-runtime.runtime-session' })
+const bindingByRuntimeSession = new WeakMap<RuntimeSession, {
+  signature: string
+  binding: BackendSessionBinding | undefined
+}>()
 
 export interface SessionRunContext {
   session: Session
@@ -225,7 +229,19 @@ export function attachBinding(input: {
   runtimeSession: RuntimeSession
   requestedModelId: string | null
 }): BackendSessionBinding | undefined {
-  return persistProviderRuntimeResolution({
+  const signature = JSON.stringify([
+    input.sessionId,
+    input.providerTargetId,
+    input.runtimeKind,
+    input.runtimeSession.providerSessionId,
+    input.runtimeSession.providerStateSnapshot,
+    input.requestedModelId,
+  ])
+  const cached = bindingByRuntimeSession.get(input.runtimeSession)
+  if (cached?.signature === signature) {
+    return cached.binding
+  }
+  const binding = persistProviderRuntimeResolution({
     chatSessionId: input.sessionId,
     providerTargetId: input.providerTargetId,
     runtimeKind: input.runtimeKind,
@@ -233,6 +249,8 @@ export function attachBinding(input: {
     requestedModelId: input.requestedModelId,
     durable: true,
   })
+  bindingByRuntimeSession.set(input.runtimeSession, { signature, binding })
+  return binding
 }
 
 export async function resolveExistingRuntimeSessionForContext(input: {

--- a/apps/server/src/modules/model-registry/model-info-registry.ts
+++ b/apps/server/src/modules/model-registry/model-info-registry.ts
@@ -2,7 +2,7 @@ import { kvCache, modelRegistryMappings } from '@cradle/db'
 import { eq } from 'drizzle-orm'
 import { z } from 'zod'
 
-import { db } from '../../infra'
+import { db, registerBeforeDatabaseShutdown } from '../../infra'
 import type { ModelCapabilities, ModelDescriptor } from '../provider-contracts/types'
 import { aggregateModelsDevRecords } from './model-info-aggregation'
 
@@ -123,6 +123,12 @@ let memCache: ModelsDevData | null = null
 /** Wall-clock ms when the in-memory snapshot was fetched from the network. */
 let memFetchedAt = 0
 let refreshInFlight: Promise<ModelsDevData | null> | null = null
+let cacheGeneration = 0
+let dbCacheLoaded = false
+let mappingCacheLoaded = false
+const mappingCache = new Map<string, ModelRegistryMappingEntry>()
+const costCache = new Map<string, ModelsDevCost | null>()
+const contextWindowCache = new Map<string, number | null>()
 const DATE_SUFFIX_RE = /-\d{8}$/
 const VERSION_SUFFIX_RE = /-\d{4}-\d{2}-\d{2}$/
 const SEP_RE = /[.\-]+/
@@ -172,6 +178,25 @@ const ModelsDevDataJsonSchema = z.string()
   .transform(raw => JSON.parse(raw))
   .pipe(ModelsDevDataSchema)
 
+interface ModelsDevCost {
+  input: number
+  output: number
+  cacheRead?: number
+  cacheWrite?: number
+}
+
+registerBeforeDatabaseShutdown(() => {
+  cacheGeneration += 1
+  refreshInFlight = null
+  memCache = null
+  memFetchedAt = 0
+  dbCacheLoaded = false
+  mappingCacheLoaded = false
+  mappingCache.clear()
+  costCache.clear()
+  contextWindowCache.clear()
+})
+
 async function fetchFromNetwork(): Promise<ModelsDevData | null> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 8000)
@@ -218,10 +243,14 @@ function writeDbCache(data: ModelsDevData): void {
   }
 }
 
-function getLocalCache(): { data: ModelsDevData, fetchedAt: number } | null {
+function loadDbCacheIntoMemory(): { data: ModelsDevData, fetchedAt: number } | null {
   if (memCache) {
     return { data: memCache, fetchedAt: memFetchedAt }
   }
+  if (dbCacheLoaded) {
+    return null
+  }
+  dbCacheLoaded = true
   const fromDb = readDbCache()
   if (!fromDb) {
     return null
@@ -231,17 +260,52 @@ function getLocalCache(): { data: ModelsDevData, fetchedAt: number } | null {
   return fromDb
 }
 
+function getInMemoryCache(): { data: ModelsDevData, fetchedAt: number } | null {
+  return memCache ? { data: memCache, fetchedAt: memFetchedAt } : null
+}
+
+function loadMappingCache(): void {
+  if (mappingCacheLoaded) {
+    return
+  }
+  mappingCacheLoaded = true
+  try {
+    for (const row of db().select().from(modelRegistryMappings).all()) {
+      mappingCache.set(row.modelId, {
+        modelId: row.modelId,
+        registryModelId: row.registryModelId,
+        matchType: row.matchType,
+        ...(row.modelJson
+          ? { model: ModelsDevModelSchema.parse(JSON.parse(row.modelJson)) }
+          : {}),
+        updatedAt: row.updatedAt,
+      })
+    }
+  }
+  catch {
+    mappingCache.clear()
+  }
+}
+
+function invalidateDerivedModelCaches(): void {
+  costCache.clear()
+  contextWindowCache.clear()
+}
+
 function applyFresh(data: ModelsDevData): ModelsDevData {
   memCache = data
   memFetchedAt = Date.now()
+  dbCacheLoaded = true
+  invalidateDerivedModelCaches()
   writeDbCache(data)
   return data
 }
 
 async function refreshFromNetwork(): Promise<ModelsDevData | null> {
+  const generation = cacheGeneration
   try {
     const fresh = await fetchFromNetwork()
-    if (fresh) {
+    if (fresh && generation === cacheGeneration) {
       return applyFresh(fresh)
     }
   }
@@ -251,11 +315,21 @@ async function refreshFromNetwork(): Promise<ModelsDevData | null> {
   return null
 }
 
-function scheduleBackgroundRefresh(): void {
+function refreshModelsDevData(): Promise<ModelsDevData | null> {
   if (refreshInFlight) {
-    return
+    return refreshInFlight
   }
-  refreshInFlight = refreshFromNetwork().finally(() => {
+  const promise = refreshFromNetwork().finally(() => {
+    if (refreshInFlight === promise) {
+      refreshInFlight = null
+    }
+  })
+  refreshInFlight = promise
+  return promise
+}
+
+function scheduleBackgroundRefresh(): void {
+  void refreshModelsDevData().catch(() => {
     refreshInFlight = null
   })
 }
@@ -267,11 +341,11 @@ function scheduleBackgroundRefresh(): void {
  * - age ≥ hard (or miss) → await network; fall back to stale on failure
  */
 export async function fetchModelsDevData(options?: { forceRefresh?: boolean }): Promise<ModelsDevData | null> {
+  const cached = loadDbCacheIntoMemory()
   if (options?.forceRefresh) {
-    return (await refreshFromNetwork()) ?? getLocalCache()?.data ?? null
+    return (await refreshModelsDevData()) ?? cached?.data ?? getInMemoryCache()?.data ?? null
   }
 
-  const cached = getLocalCache()
   if (cached) {
     const age = Date.now() - cached.fetchedAt
     if (age < SOFT_TTL_MS) {
@@ -281,15 +355,17 @@ export async function fetchModelsDevData(options?: { forceRefresh?: boolean }): 
       scheduleBackgroundRefresh()
       return cached.data
     }
-    return (await refreshFromNetwork()) ?? cached.data
+    return (await refreshModelsDevData()) ?? cached.data
   }
 
-  return refreshFromNetwork()
+  return refreshModelsDevData()
 }
 
-/** Force-refresh models.dev on server startup (fire and forget; falls back to stale cache). */
+/** Load the durable snapshot once, then refresh models.dev without blocking requests. */
 export function warmupModelsDevCache(): void {
-  void fetchModelsDevData({ forceRefresh: true })
+  loadDbCacheIntoMemory()
+  loadMappingCache()
+  scheduleBackgroundRefresh()
 }
 
 /**
@@ -300,55 +376,89 @@ export function warmupModelsDevCache(): void {
  *  2. Fuzzy match modelId on local cache (DB-backed, falls back to in-memory).
  * Returns null if no cost data is found.
  */
-export function getCachedModelsDevCost(modelId: string): {
-  input: number
-  output: number
-  cacheRead?: number
-  cacheWrite?: number
-} | null {
-  try {
-    const row = db().select().from(modelRegistryMappings).where(eq(modelRegistryMappings.modelId, modelId)).get()
-    if (row) {
-      if (row.modelJson) {
-        const parsed = ModelsDevModelSchema.parse(JSON.parse(row.modelJson))
-        const cost = parsed.cost
+export function getCachedModelsDevCost(modelId: string): ModelsDevCost | null {
+  if (costCache.has(modelId)) {
+    return costCache.get(modelId) ?? null
+  }
+
+  loadMappingCache()
+  const mapping = mappingCache.get(modelId)
+  if (mapping) {
+    try {
+      if (mapping.model) {
+        const cost = mapping.model.cost
         if (cost && (cost.input != null || cost.output != null)) {
-          return projectModelsDevCost(cost)
+          const result = projectModelsDevCost(cost)
+          costCache.set(modelId, result)
+          return result
         }
       }
-      // Mapping has a registryModelId but no usable cost in modelJson — resolve from registry cache
-      if (row.registryModelId) {
-        const local = getLocalCache()
+      if (mapping.registryModelId) {
+        const local = getInMemoryCache()
         if (local) {
-          const exact = findModel(local.data, row.registryModelId)
+          const exact = findModel(local.data, mapping.registryModelId)
           const exactCost = exact?.cost
           if (exactCost && (exactCost.input != null || exactCost.output != null)) {
-            return projectModelsDevCost(exactCost)
+            const result = projectModelsDevCost(exactCost)
+            costCache.set(modelId, result)
+            return result
           }
-          const fuzzy = findModelFuzzy(local.data, row.registryModelId)
+          const fuzzy = findModelFuzzy(local.data, mapping.registryModelId)
           const fuzzyCost = fuzzy?.model?.cost
           if (fuzzyCost && (fuzzyCost.input != null || fuzzyCost.output != null)) {
-            return projectModelsDevCost(fuzzyCost)
+            const result = projectModelsDevCost(fuzzyCost)
+            costCache.set(modelId, result)
+            return result
           }
         }
       }
     }
-  }
-  catch {
-    // non-critical, fall through
+    catch {
+      // Invalid optional mapping metadata must not break usage persistence.
+    }
   }
 
-  // Fuzzy match on modelId using DB-backed local cache (not mem-only)
-  const local = getLocalCache()
+  const local = getInMemoryCache()
   if (!local) {
+    costCache.set(modelId, null)
     return null
   }
   const result = findModelFuzzy(local.data, modelId)
   const cost = result?.model?.cost
   if (!cost || (cost.input == null && cost.output == null)) {
+    costCache.set(modelId, null)
     return null
   }
-  return projectModelsDevCost(cost)
+  const projected = projectModelsDevCost(cost)
+  costCache.set(modelId, projected)
+  return projected
+}
+
+export function getCachedContextWindow(modelId: string): number | null {
+  if (contextWindowCache.has(modelId)) {
+    return contextWindowCache.get(modelId) ?? null
+  }
+  const data = getInMemoryCache()?.data
+  const contextWindow = data
+    ? findModelFuzzy(data, modelId)?.model.limit?.context ?? null
+    : null
+  contextWindowCache.set(modelId, contextWindow)
+  return contextWindow
+}
+
+export function updateCachedModelRegistryMapping(
+  modelId: string,
+  mapping: ModelRegistryMappingEntry | null,
+): void {
+  loadMappingCache()
+  if (mapping) {
+    mappingCache.set(modelId, mapping)
+  }
+  else {
+    mappingCache.delete(modelId)
+  }
+  costCache.delete(modelId)
+  contextWindowCache.delete(modelId)
 }
 
 function projectModelsDevCost(cost: NonNullable<ModelsDevModel['cost']>): {

--- a/apps/server/src/modules/model-registry/service.ts
+++ b/apps/server/src/modules/model-registry/service.ts
@@ -6,7 +6,11 @@ import { z } from 'zod'
 import { AppError } from '../../errors/app-error'
 import { db } from '../../infra'
 import type { ModelRegistryMappingEntry, ModelsDevModel } from '../model-registry/model-info-registry'
-import { lookupModelRaw, ModelsDevModelSchema } from '../model-registry/model-info-registry'
+import {
+  lookupModelRaw,
+  ModelsDevModelSchema,
+  updateCachedModelRegistryMapping,
+} from '../model-registry/model-info-registry'
 
 const nonEmptyTrimmedString = z.string().trim().min(1)
 
@@ -118,10 +122,19 @@ export async function upsertMapping(rawInput: {
     })
     .run()
 
-  return getMapping(input.modelId)!
+  const mapping = getMapping(input.modelId)!
+  updateCachedModelRegistryMapping(mapping.modelId, {
+    modelId: mapping.modelId,
+    registryModelId: mapping.registryModelId,
+    matchType: mapping.matchType,
+    ...(mapping.model ? { model: mapping.model } : {}),
+    updatedAt: mapping.updatedAt,
+  })
+  return mapping
 }
 
 export function deleteMapping(modelId: string): void {
   const id = nonEmptyTrimmedString.parse(modelId)
   db().delete(modelRegistryMappings).where(eq(modelRegistryMappings.modelId, id)).run()
+  updateCachedModelRegistryMapping(id, null)
 }

--- a/apps/server/src/modules/provider-runtime/directory.ts
+++ b/apps/server/src/modules/provider-runtime/directory.ts
@@ -5,7 +5,7 @@ import { backendSessionBindings } from '@cradle/db'
 import { and, eq } from 'drizzle-orm'
 
 import { currentUnixSeconds } from '../../helpers/time'
-import { db } from '../../infra'
+import { db, registerBeforeDatabaseShutdown } from '../../infra'
 import type { RuntimeKind } from '../provider-contracts/types'
 
 export interface ProviderRuntimeBindingWrite {
@@ -19,12 +19,47 @@ export interface ProviderRuntimeBindingWrite {
 
 export type ProviderRuntimeBindingDirectoryWriter = Pick<ReturnType<typeof db>, 'update'>
 
+type ProviderRuntimeDatabase = ReturnType<typeof db>
+const absentBindings = new Map<ProviderRuntimeDatabase, Set<string>>()
+const MAX_ABSENT_BINDINGS = 4_096
+
+registerBeforeDatabaseShutdown(() => absentBindings.clear())
+
+function absentBindingIdsFor(database: ProviderRuntimeDatabase): Set<string> {
+  let sessionIds = absentBindings.get(database)
+  if (!sessionIds) {
+    sessionIds = new Set()
+    absentBindings.set(database, sessionIds)
+  }
+  return sessionIds
+}
+
+function rememberAbsentBinding(database: ProviderRuntimeDatabase, chatSessionId: string): void {
+  const sessionIds = absentBindingIdsFor(database)
+  if (sessionIds.size >= MAX_ABSENT_BINDINGS) {
+    const oldestSessionId = sessionIds.values().next().value
+    if (oldestSessionId) {
+      sessionIds.delete(oldestSessionId)
+    }
+  }
+  sessionIds.add(chatSessionId)
+}
+
 export function readProviderRuntimeBinding(chatSessionId: string): BackendSessionBinding | undefined {
-  return db()
+  const database = db()
+  const absentSessionIds = absentBindingIdsFor(database)
+  if (absentSessionIds.has(chatSessionId)) {
+    return undefined
+  }
+  const binding = database
     .select()
     .from(backendSessionBindings)
     .where(eq(backendSessionBindings.chatSessionId, chatSessionId))
     .get()
+  if (!binding) {
+    rememberAbsentBinding(database, chatSessionId)
+  }
+  return binding
 }
 
 export function listProviderRuntimeBindingsByProviderSession(input: {
@@ -74,15 +109,22 @@ export function isResumableProviderRuntimeBinding(binding: BackendSessionBinding
 }
 
 export function deleteProviderRuntimeBinding(chatSessionId: string): void {
-  db()
+  const database = db()
+  const absentSessionIds = absentBindingIdsFor(database)
+  if (absentSessionIds.has(chatSessionId)) {
+    return
+  }
+  database
     .delete(backendSessionBindings)
     .where(eq(backendSessionBindings.chatSessionId, chatSessionId))
     .run()
+  rememberAbsentBinding(database, chatSessionId)
 }
 
 export function writeProviderRuntimeBinding(input: ProviderRuntimeBindingWrite): BackendSessionBinding {
   const now = currentUnixSeconds()
-  return db()
+  const database = db()
+  const binding = database
     .insert(backendSessionBindings)
     .values({
       id: randomUUID(),
@@ -108,4 +150,6 @@ export function writeProviderRuntimeBinding(input: ProviderRuntimeBindingWrite):
     })
     .returning()
     .get()
+  absentBindingIdsFor(database).delete(input.chatSessionId)
+  return binding
 }

--- a/apps/server/src/modules/provider-runtime/directory.ts
+++ b/apps/server/src/modules/provider-runtime/directory.ts
@@ -82,28 +82,6 @@ export function deleteProviderRuntimeBinding(chatSessionId: string): void {
 
 export function writeProviderRuntimeBinding(input: ProviderRuntimeBindingWrite): BackendSessionBinding {
   const now = currentUnixSeconds()
-  const existing = readProviderRuntimeBinding(input.chatSessionId)
-
-  if (existing) {
-    db()
-      .update(backendSessionBindings)
-      .set({
-        providerTargetId: input.providerTargetId,
-        runtimeKind: input.runtimeKind,
-        backendSessionId: input.providerSessionId,
-        backendStateSnapshot: input.providerStateSnapshot,
-        requestedModelId: input.requestedModelId,
-        updatedAt: now,
-      })
-      .where(eq(backendSessionBindings.id, existing.id))
-      .run()
-    return db()
-      .select()
-      .from(backendSessionBindings)
-      .where(eq(backendSessionBindings.id, existing.id))
-      .get()!
-  }
-
   return db()
     .insert(backendSessionBindings)
     .values({
@@ -116,6 +94,17 @@ export function writeProviderRuntimeBinding(input: ProviderRuntimeBindingWrite):
       requestedModelId: input.requestedModelId,
       createdAt: now,
       updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: backendSessionBindings.chatSessionId,
+      set: {
+        providerTargetId: input.providerTargetId,
+        runtimeKind: input.runtimeKind,
+        backendSessionId: input.providerSessionId,
+        backendStateSnapshot: input.providerStateSnapshot,
+        requestedModelId: input.requestedModelId,
+        updatedAt: now,
+      },
     })
     .returning()
     .get()

--- a/apps/server/src/modules/recall/index.ts
+++ b/apps/server/src/modules/recall/index.ts
@@ -13,7 +13,7 @@ import { RecallModel } from './model'
 import {
   projectRecallMessage,
   projectRecallRun,
-  projectRecallToolEvent,
+  projectRecallToolEventRecord,
   rebuildRecallProjection,
   reconcileRecallProjection,
 } from './service'
@@ -83,7 +83,7 @@ export function initializeRecallProjection(): void {
     registerChatRuntimeReadModelProjector({
       projectMessage: projectRecallMessage,
       projectRun: projectRecallRun,
-      projectRunSnapshotEvent: projectRecallToolEvent,
+      projectRunSnapshotEvent: projectRecallToolEventRecord,
     })
     recallProjectorRegistered = true
   }

--- a/apps/server/src/modules/recall/service.ts
+++ b/apps/server/src/modules/recall/service.ts
@@ -34,6 +34,11 @@ export interface RecallToolEventProjectionInput {
   sourceEventId: string
 }
 
+export interface RecallToolEventRecordProjectionInput {
+  sourceEvent: typeof backendRunSnapshotEvents.$inferSelect
+  workspaceId: string | null
+}
+
 export interface RecallProjectionReconciliationResult {
   projectedMessages: number
   projectedRuns: number
@@ -144,51 +149,66 @@ export function projectRecallToolEvent(
     return
   }
 
+  projectRecallToolEventRecord(d, {
+    sourceEvent: row.event,
+    workspaceId: row.workspaceId,
+  })
+}
+
+export function projectRecallToolEventRecord(
+  d: RecallProjectionDb,
+  input: RecallToolEventRecordProjectionInput,
+): void {
+  const event = input.sourceEvent
+  if (!event.chatSessionId || !event.toolCallId) {
+    return
+  }
+
   d.insert(recallToolEvents)
     .values({
-      id: row.event.id,
-      runId: row.event.runId,
-      sessionId: row.event.chatSessionId,
-      workspaceId: row.workspaceId,
-      sourceEventId: row.event.id,
-      toolCallId: row.event.toolCallId,
-      toolName: row.event.toolName,
-      phase: row.event.phase,
-      isFailure: isFailureEvent(row.event.phase, row.event.payloadJson) ? 1 : 0,
+      id: event.id,
+      runId: event.runId,
+      sessionId: event.chatSessionId,
+      workspaceId: input.workspaceId,
+      sourceEventId: event.id,
+      toolCallId: event.toolCallId,
+      toolName: event.toolName,
+      phase: event.phase,
+      isFailure: isFailureEvent(event.phase, event.payloadJson) ? 1 : 0,
       summary: truncate(
-        `${row.event.toolName ?? row.event.chunkType ?? row.event.phase}: ${row.event.payloadJson}`,
+        `${event.toolName ?? event.chunkType ?? event.phase}: ${event.payloadJson}`,
       ),
-      occurredAt: row.event.occurredAt,
+      occurredAt: event.occurredAt,
     })
     .onConflictDoUpdate({
       target: recallToolEvents.sourceEventId,
       set: {
-        runId: row.event.runId,
-        toolCallId: row.event.toolCallId,
-        toolName: row.event.toolName,
-        phase: row.event.phase,
-        isFailure: isFailureEvent(row.event.phase, row.event.payloadJson) ? 1 : 0,
+        runId: event.runId,
+        toolCallId: event.toolCallId,
+        toolName: event.toolName,
+        phase: event.phase,
+        isFailure: isFailureEvent(event.phase, event.payloadJson) ? 1 : 0,
         summary: truncate(
-          `${row.event.toolName ?? row.event.chunkType ?? row.event.phase}: ${row.event.payloadJson}`,
+          `${event.toolName ?? event.chunkType ?? event.phase}: ${event.payloadJson}`,
         ),
-        occurredAt: row.event.occurredAt,
+        occurredAt: event.occurredAt,
       },
     })
     .run()
 
-  d.delete(recallFileTouches).where(eq(recallFileTouches.toolEventId, row.event.id)).run()
-  const paths = extractRecallFileTouchPaths(row.event)
+  d.delete(recallFileTouches).where(eq(recallFileTouches.toolEventId, event.id)).run()
+  const paths = extractRecallFileTouchPaths(event)
   if (paths.length === 0) {
     return
   }
   d.insert(recallFileTouches)
     .values(paths.map(path => ({
-      id: `${row.event.id}:${path}`,
-      toolEventId: row.event.id,
-      sessionId: row.event.chatSessionId!,
-      workspaceId: row.workspaceId,
+      id: `${event.id}:${path}`,
+      toolEventId: event.id,
+      sessionId: event.chatSessionId!,
+      workspaceId: input.workspaceId,
       path,
-      occurredAt: row.event.occurredAt,
+      occurredAt: event.occurredAt,
     })))
     .onConflictDoNothing()
     .run()

--- a/apps/server/src/modules/usage/index.ts
+++ b/apps/server/src/modules/usage/index.ts
@@ -3,11 +3,15 @@ import { Elysia, t } from 'elysia'
 import { UsageModel } from './model'
 import { getRuntimePerformanceOverview } from './performance'
 import * as Usage from './service'
+import { flushUsageWriteBehind } from './write-behind'
 
 export const usage = new Elysia({
   prefix: '/usage',
   detail: { tags: ['usage'] },
 })
+  .onBeforeHandle(() => {
+    flushUsageWriteBehind()
+  })
   .post('/reconcile/claude', ({ query }) => Usage.reconcileCompletedClaudeUsage(query.maxBindings), {
     detail: {
       'summary': 'Backfill completed Claude usage from Cradle-owned transcripts',

--- a/apps/server/src/modules/usage/pricing.ts
+++ b/apps/server/src/modules/usage/pricing.ts
@@ -39,14 +39,14 @@ const FALLBACK_PRICING: Record<string, ModelPricing> = {
   'deepseek-chat': { input: 0.27, output: 1.10 },
   'deepseek-reasoner': { input: 0.55, output: 2.19 },
 }
+const FALLBACK_PRICING_KEYS = Object.keys(FALLBACK_PRICING).sort((a, b) => b.length - a.length)
 
 function findFallbackPricing(modelId: string): ModelPricing | null {
   if (FALLBACK_PRICING[modelId]) {
     return FALLBACK_PRICING[modelId]!
   }
   // Longest prefix match
-  const sortedKeys = Object.keys(FALLBACK_PRICING).sort((a, b) => b.length - a.length)
-  for (const key of sortedKeys) {
+  for (const key of FALLBACK_PRICING_KEYS) {
     if (modelId.startsWith(key)) {
       return FALLBACK_PRICING[key]!
     }

--- a/apps/server/src/modules/usage/write-behind.test.ts
+++ b/apps/server/src/modules/usage/write-behind.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { sessions, stepUsage, usageLogs } from '@cradle/db'
+import { describe, expect, it } from 'vitest'
+
+import { db, shutdownInfra } from '../../infra'
+import {
+  enqueueStepUsage,
+  enqueueUsageLog,
+  flushUsageWriteBehind,
+} from './write-behind'
+
+function restoreDataDir(previousDataDir: string | undefined): void {
+  if (previousDataDir === undefined) {
+    delete process.env.CRADLE_DATA_DIR
+  }
+  else {
+    process.env.CRADLE_DATA_DIR = previousDataDir
+  }
+}
+
+function seedSession(sessionId: string): void {
+  db().insert(sessions).values({
+    id: sessionId,
+    title: 'Usage write-behind test',
+    runtimeKind: 'standard',
+  }).run()
+}
+
+describe('usage write-behind', () => {
+  it('keeps writes off the caller stack and flushes large queues in bounded batches', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'cradle-usage-write-behind-'))
+    const previousDataDir = process.env.CRADLE_DATA_DIR
+    process.env.CRADLE_DATA_DIR = dataDir
+
+    try {
+      seedSession('session-batched')
+      for (let index = 0; index < 125; index += 1) {
+        enqueueUsageLog({
+          id: `usage-${index}`,
+          sessionId: 'session-batched',
+          modelId: 'test-model',
+          promptTokens: index,
+          completionTokens: 1,
+          totalTokens: index + 1,
+          createdAt: 1_700_000_000 + index,
+        })
+        enqueueStepUsage([{
+          id: `step-${index}`,
+          runId: 'run-batched',
+          sessionId: 'session-batched',
+          stepNumber: index,
+          stepType: 'model',
+          modelId: 'test-model',
+          promptTokens: index,
+          completionTokens: 1,
+          totalTokens: index + 1,
+          estimatedCostUsd: 0,
+          createdAt: 1_700_000_000 + index,
+        }])
+      }
+
+      expect(db().select().from(usageLogs).all()).toHaveLength(0)
+      expect(db().select().from(stepUsage).all()).toHaveLength(0)
+
+      flushUsageWriteBehind()
+
+      expect(db().select().from(usageLogs).all()).toHaveLength(125)
+      expect(db().select().from(stepUsage).all()).toHaveLength(125)
+    }
+    finally {
+      shutdownInfra()
+      restoreDataDir(previousDataDir)
+      rmSync(dataDir, { recursive: true, force: true })
+    }
+  })
+
+  it('drains the old database journal before an environment-driven database switch', () => {
+    const firstDataDir = mkdtempSync(join(tmpdir(), 'cradle-usage-first-'))
+    const secondDataDir = mkdtempSync(join(tmpdir(), 'cradle-usage-second-'))
+    const previousDataDir = process.env.CRADLE_DATA_DIR
+    process.env.CRADLE_DATA_DIR = firstDataDir
+
+    try {
+      seedSession('session-first')
+      enqueueUsageLog({
+        id: 'usage-before-switch',
+        sessionId: 'session-first',
+        modelId: 'test-model',
+        promptTokens: 10,
+        completionTokens: 2,
+        totalTokens: 12,
+        createdAt: 1_700_000_000,
+      })
+
+      process.env.CRADLE_DATA_DIR = secondDataDir
+      expect(db().select().from(usageLogs).all()).toHaveLength(0)
+
+      process.env.CRADLE_DATA_DIR = firstDataDir
+      expect(db().select().from(usageLogs).all()).toEqual([
+        expect.objectContaining({ id: 'usage-before-switch', totalTokens: 12 }),
+      ])
+    }
+    finally {
+      shutdownInfra()
+      restoreDataDir(previousDataDir)
+      rmSync(firstDataDir, { recursive: true, force: true })
+      rmSync(secondDataDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/apps/server/src/modules/usage/write-behind.ts
+++ b/apps/server/src/modules/usage/write-behind.ts
@@ -1,0 +1,137 @@
+import { stepUsage, usageLogs } from '@cradle/db'
+
+import { db, registerBeforeDatabaseShutdown } from '../../infra'
+import { createChildLogger } from '../../logging/logger'
+
+type UsageDatabase = ReturnType<typeof db>
+type UsageLogInsert = typeof usageLogs.$inferInsert
+type StepUsageInsert = typeof stepUsage.$inferInsert
+
+interface UsageWriteJournal {
+  database: UsageDatabase
+  usageRows: UsageLogInsert[]
+  stepRows: StepUsageInsert[]
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+const logger = createChildLogger({ module: 'usage.write-behind' })
+const journals = new Map<UsageDatabase, UsageWriteJournal>()
+const INSERT_BATCH_SIZE = 50
+const RETRY_DELAY_MS = 1_000
+
+registerBeforeDatabaseShutdown(() => {
+  const failures: Error[] = []
+  for (const journal of journals.values()) {
+    cancelTimer(journal)
+    try {
+      flushJournal(journal)
+    }
+    catch (error) {
+      failures.push(error instanceof Error ? error : new Error(String(error)))
+    }
+    finally {
+      journals.delete(journal.database)
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Failed to flush usage write-behind journals')
+  }
+})
+
+export function enqueueUsageLog(row: UsageLogInsert): void {
+  const journal = currentJournal()
+  journal.usageRows.push(row)
+  scheduleFlush(journal, 0)
+}
+
+export function enqueueStepUsage(rows: StepUsageInsert[]): void {
+  if (rows.length === 0) {
+    return
+  }
+  const journal = currentJournal()
+  journal.stepRows.push(...rows)
+  scheduleFlush(journal, 0)
+}
+
+/** Read-your-writes boundary for Usage APIs and graceful shutdown. */
+export function flushUsageWriteBehind(): void {
+  const failures: Error[] = []
+  for (const journal of journals.values()) {
+    cancelTimer(journal)
+    try {
+      flushJournal(journal)
+    }
+    catch (error) {
+      scheduleFlush(journal, RETRY_DELAY_MS)
+      failures.push(error instanceof Error ? error : new Error(String(error)))
+    }
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Failed to flush usage write-behind journals')
+  }
+}
+
+function currentJournal(): UsageWriteJournal {
+  const database = db()
+  let journal = journals.get(database)
+  if (!journal) {
+    journal = { database, usageRows: [], stepRows: [], timer: null }
+    journals.set(database, journal)
+  }
+  return journal
+}
+
+function scheduleFlush(journal: UsageWriteJournal, delayMs: number): void {
+  if (journal.timer) {
+    return
+  }
+  journal.timer = setTimeout(() => {
+    journal.timer = null
+    try {
+      flushJournal(journal)
+    }
+    catch (error) {
+      logger.error('failed to flush usage write-behind journal', { error })
+      scheduleFlush(journal, RETRY_DELAY_MS)
+    }
+  }, delayMs)
+  journal.timer.unref?.()
+}
+
+function flushJournal(journal: UsageWriteJournal): void {
+  if (journal.usageRows.length === 0 && journal.stepRows.length === 0) {
+    journals.delete(journal.database)
+    return
+  }
+
+  const usageCount = journal.usageRows.length
+  const stepCount = journal.stepRows.length
+  journal.database.transaction((tx) => {
+    for (let offset = 0; offset < usageCount; offset += INSERT_BATCH_SIZE) {
+      tx.insert(usageLogs)
+        .values(journal.usageRows.slice(offset, Math.min(offset + INSERT_BATCH_SIZE, usageCount)))
+        .run()
+    }
+    for (let offset = 0; offset < stepCount; offset += INSERT_BATCH_SIZE) {
+      tx.insert(stepUsage)
+        .values(journal.stepRows.slice(offset, Math.min(offset + INSERT_BATCH_SIZE, stepCount)))
+        .run()
+    }
+  })
+  journal.usageRows.splice(0, usageCount)
+  journal.stepRows.splice(0, stepCount)
+  if (journal.usageRows.length === 0 && journal.stepRows.length === 0) {
+    journals.delete(journal.database)
+  }
+  else {
+    scheduleFlush(journal, 0)
+  }
+}
+
+function cancelTimer(journal: UsageWriteJournal): void {
+  if (!journal.timer) {
+    return
+  }
+  clearTimeout(journal.timer)
+  journal.timer = null
+}

--- a/apps/server/tests/model-registry.test.ts
+++ b/apps/server/tests/model-registry.test.ts
@@ -10,6 +10,7 @@ import { db, shutdownInfra } from '../src/infra'
 import type { ModelRegistryMappingEntry, ModelsDevModel } from '../src/modules/model-registry/model-info-registry'
 import {
   enrichModelsWithRegistryData,
+  fetchModelsDevData,
   getCachedModelsDevCost,
   resolveModelEnrichment,
 } from '../src/modules/model-registry/model-info-registry'
@@ -427,6 +428,44 @@ describe('models.dev reasoning_options projection', () => {
 })
 
 // ── DB-backed tests ───────────────────────────────────────────────────────────
+
+describe('fetchModelsDevData concurrency', () => {
+  it('coalesces concurrent cache misses and forced refreshes into one request', async () => {
+    const dataDir = makeTempDir('cradle-data-model-refresh-')
+    const previousDataDir = process.env.CRADLE_DATA_DIR
+    process.env.CRADLE_DATA_DIR = dataDir
+    let requestCount = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = new Request(input).url
+      if (url !== MODELS_DEV_URL) {
+        throw new Error(`Unexpected fetch: ${url}`)
+      }
+      requestCount += 1
+      await new Promise(resolve => setTimeout(resolve, 5))
+      return new Response(JSON.stringify(makeModelsDevData({
+        'single-flight-model': { limit: { context: 32_768 } },
+      })), { status: 200, headers: { 'content-type': 'application/json' } })
+    })
+
+    try {
+      const requests: Array<ReturnType<typeof fetchModelsDevData>> = []
+      for (let index = 0; index < 64; index += 1) {
+        requests.push(fetchModelsDevData({ forceRefresh: true }))
+      }
+      const results = await Promise.all(requests)
+
+      expect(requestCount).toBe(1)
+      expect(results.every(result => result?.['test-provider']?.models['single-flight-model'])).toBe(true)
+    }
+    finally {
+      shutdownInfra()
+      if (previousDataDir !== undefined) { process.env.CRADLE_DATA_DIR = previousDataDir }
+      else { delete process.env.CRADLE_DATA_DIR }
+      rmSync(dataDir, { recursive: true, force: true })
+      vi.restoreAllMocks()
+    }
+  })
+})
 
 describe('getCachedModelsDevCost (DB-backed)', () => {
   it('returns cost from mapping.modelJson when present', async () => {

--- a/apps/server/tests/run-snapshot.test.ts
+++ b/apps/server/tests/run-snapshot.test.ts
@@ -27,6 +27,7 @@ import { createFinalMessageProjectionState } from '../src/modules/chat-runtime/r
 import type { ActiveRun } from '../src/modules/chat-runtime/run-registry'
 import {
   COMPACTED_SUCCESS_PAYLOAD_SCHEMA,
+  finalizeRunSnapshot,
   getRunSnapshot,
   getRunSnapshots,
   maintainRunSnapshots,
@@ -158,6 +159,44 @@ function setUpRun(sessionId: string, runId: string): ActiveRun {
 }
 
 describe('run snapshot recording', () => {
+  it('defers event inserts until a snapshot read requires read-your-writes', async () => {
+    await withTempDataDir(() => {
+      const sessionId = `session-${randomUUID()}`
+      const runId = `run-${randomUUID()}`
+      setUpRun(sessionId, runId)
+
+      expect(db().select().from(backendRunSnapshotEvents).all()).toHaveLength(0)
+
+      const snapshot = getRunSnapshot(runId)
+      expect(snapshot?.events.map(event => event.phase)).toContain('run_started')
+      expect(db().select().from(backendRunSnapshotEvents).all()).toHaveLength(1)
+    })
+  })
+
+  it('finalizes one snapshot without flushing events for concurrent runs', async () => {
+    await withTempDataDir(() => {
+      const firstRunId = `run-${randomUUID()}`
+      const secondRunId = `run-${randomUUID()}`
+      const first = setUpRun(`session-${randomUUID()}`, firstRunId)
+      const second = setUpRun(`session-${randomUUID()}`, secondRunId)
+
+      finalizeRunSnapshot({
+        snapshotId: first.runSnapshotId!,
+        status: 'complete',
+        completionReason: 'stop',
+      })
+
+      expect(db().select().from(backendRunSnapshotEvents)
+        .where(eq(backendRunSnapshotEvents.snapshotId, first.runSnapshotId!)).all())
+        .toHaveLength(1)
+      expect(db().select().from(backendRunSnapshotEvents)
+        .where(eq(backendRunSnapshotEvents.snapshotId, second.runSnapshotId!)).all())
+        .toHaveLength(0)
+
+      expect(getRunSnapshot(secondRunId)?.events).toHaveLength(1)
+    })
+  })
+
   it('coalesces repeated tool-output-available chunks for the same toolCallId onto one row', async () => {
     await withTempDataDir(() => {
       const sessionId = `session-${randomUUID()}`

--- a/apps/server/tests/run-snapshot.test.ts
+++ b/apps/server/tests/run-snapshot.test.ts
@@ -354,6 +354,56 @@ describe('run snapshot recording', () => {
     })
   })
 
+  it('compacts successful payloads that were flushed before finalization', async () => {
+    await withTempDataDir(() => {
+      const sessionId = `session-${randomUUID()}`
+      const runId = `run-${randomUUID()}`
+      const activeRun = setUpRun(sessionId, runId)
+
+      recordActiveRunSnapshotEvent(activeRun, {
+        phase: 'tool_call_output_available',
+        chunk: {
+          type: 'tool-output-available',
+          toolCallId: 'toolu_preflushed',
+          output: { stdout: 'payload flushed before completion' },
+        },
+      })
+      expect(getRunSnapshot(runId)?.events).toHaveLength(2)
+
+      finalizeActiveRunSnapshot(
+        activeRun,
+        { type: 'finish', finishReason: 'stop' },
+        {
+          modelId: 'gpt-4o-mini',
+          diagnostics: {
+            emittedEventCount: 1,
+            assistantBoundaryCount: 0,
+            assistantTextCharCount: 0,
+            reasoningTextCharCount: 0,
+            toolInputDeltaCharCount: 0,
+            toolEventCount: 1,
+            otherOutputEventCount: 0,
+          },
+          profile: {
+            enabled: false,
+            streamStartedAtMs: 0,
+            streamFinishedAtMs: null,
+            finalizeStartedAtMs: null,
+            finalizeFinishedAtMs: null,
+            finalMessageJsonBytes: null,
+          },
+        },
+      )
+
+      const toolEvent = getRunSnapshot(runId)?.events.find(event => event.toolCallId === 'toolu_preflushed')
+      expect(toolEvent?.payload).toEqual(expect.objectContaining({
+        schema: COMPACTED_SUCCESS_PAYLOAD_SCHEMA,
+        originalLength: expect.any(Number),
+      }))
+      expect(JSON.stringify(toolEvent?.payload)).not.toContain('payload flushed before completion')
+    })
+  })
+
   it('retains runtime chunk payloads after failed finalization', async () => {
     await withTempDataDir(() => {
       const sessionId = `session-${randomUUID()}`

--- a/apps/server/vite.benchmark.config.ts
+++ b/apps/server/vite.benchmark.config.ts
@@ -1,0 +1,26 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'vite'
+
+import serverConfig from './vite.config'
+
+const currentDirectory = dirname(fileURLToPath(import.meta.url))
+const sourceDirectory = process.env.CRADLE_BENCH_SOURCE_DIR
+  ? resolve(process.env.CRADLE_BENCH_SOURCE_DIR)
+  : currentDirectory
+
+export default defineConfig({
+  ...serverConfig,
+  build: {
+    ...serverConfig.build,
+    outDir: process.env.CRADLE_BENCH_OUT_DIR ?? 'dist-benchmark',
+    emptyOutDir: true,
+    rollupOptions: {
+      ...serverConfig.build?.rollupOptions,
+      input: {
+        'benchmark-app': resolve(sourceDirectory, 'src/benchmark-entry.ts'),
+      },
+    },
+  },
+})

--- a/packages/chat-runtime-contracts/src/index.ts
+++ b/packages/chat-runtime-contracts/src/index.ts
@@ -1275,6 +1275,7 @@ export interface StreamTurnInput {
   onUsageEvent?: (event: RuntimeUsageEvent) => void | Promise<void>
   onProviderThreadEvent?: (event: ProviderThreadEvent) => void
   onProviderSyntheticTurnEvent?: (event: ProviderSyntheticTurnEvent) => void | Promise<void>
+  reportTurnResult?: (result: RuntimeTurnResult) => void
 }
 
 export interface RuntimeUsageEvent {
@@ -1533,6 +1534,13 @@ export interface RuntimeStepUsage {
   stepType: string
   modelId?: string
   usage: TokenUsage
+}
+
+/** Metrics produced by one concrete turn. Owned by the turn, never by a shared runtime. */
+export interface RuntimeTurnResult {
+  modelId?: string | null
+  usage?: TokenUsage | null
+  stepUsages?: RuntimeStepUsage[]
 }
 
 export interface ChatRuntime {


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Starting a server-backed chat session performed synchronous SQLite work on the request and first-token paths for every event, usage record, model-registry lookup, and runtime binding check. The cost compounded with session history and concurrency: the baseline benchmark dropped from 36.54 turns/s at c1 to 12.98 turns/s at c64, and the next turn after 400 prior turns took 190.78ms.

Profiling also found shared provider-level usage state. Concurrent OpenAI-compatible turns could read another turn's accumulated step usage, multiplying durable `step_usage` and snapshot rows.

## Summary

- Adds a reproducible session-startup benchmark covering app startup, session creation, c1/c8/c32/c64 first turns, and 100/400-turn histories.
- Moves chat event, usage, Recall, and snapshot persistence to bounded write-behind journals with lifecycle flushing and read-your-writes boundaries.
- Warms and caches model metadata off the first-token path.
- Batches snapshot inserts and pre-compacts successful pending payloads, avoiding a select plus per-row update pass when no earlier events were flushed.
- Carries the already-resolved runtime binding into run creation, skips completion reads for runtimes without goal continuation, and bounds negative binding caching.
- Introduces turn-owned runtime results and migrates the OpenAI-compatible provider away from shared `lastUsage` / `lastStepUsages` state.
- Adds regression coverage for concurrent turn result isolation, write-behind recovery, model-registry behavior, and both pending/pre-flushed snapshot compaction paths.

A clean baseline/recovered benchmark measured:

| Concurrency | Baseline turns/s | Recovered turns/s |
| ---: | ---: | ---: |
| 1 | 36.54 | 63.69 |
| 8 | 32.89 | 73.43 |
| 32 | 21.75 | 69.64 |
| 64 | 12.98 | 70.79 |

Long-session next-turn completion fell from 66.24ms to 13.59ms after 100 prior turns, and from 190.78ms to 11.64ms after 400 prior turns. A later isolated c64 run including the finalization follow-up measured 81.94 turns/s; full-matrix reruns were CPU-contended in this container, so the table retains the directly comparable baseline/recovered run.

## Test plan

Passed:

- `node node_modules/typescript/bin/tsc --noEmit -p apps/server/tsconfig.json`
- ESLint over every changed file
- `node --import tsx scripts/check-module-boundaries.ts`
- Focused Vitest suites for provider runtime, session, completed runs, OpenAI-compatible concurrency, and run snapshots (41 tests)
- Final focused regression set (32 tests)
- `node ../../node_modules/vite/bin/vite.js build`
- Session-startup benchmark at c1/c8/c32/c64 plus 100/400-turn histories
- Full server suite: 1684 tests passed, 2 skipped

Full-suite environment-only failures (9 tests) remain:

- real relay e2e cannot spawn `go` / bind its local relay in this container;
- Claude CLI rejects `--dangerously-skip-permissions` under root;
- sandbox denies test writes under `/root/.cradle` and `/root/Documents`.

The focused suites covering this diff pass independently.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is denied or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** N/A — private author-side context omitted.
- **Constraints / non-goals:** N/A — review from the published pressure, summary, tests, and diff.
- **Decision rationale:** N/A.
- **Deliberately not done:** Other providers retain the compatibility fallback for instance-level run summaries; this PR migrates the profiled OpenAI-compatible path.
- **Unknowns / confidence:** High confidence in the profiled standard-runtime path. Real relay and Claude CLI integration remain unverified in this root/sandbox environment.

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->