### PR TITLE
fix(e2e): stabilize workspace and UI journeys

### DIFF
--- a/apps/web/src/features/diff-review/review/review-file-rail.tsx
+++ b/apps/web/src/features/diff-review/review/review-file-rail.tsx
@@ -131,6 +131,7 @@ export function ReviewFileRail({
       className="flex min-h-0 shrink-0 flex-col border-r border-[var(--rv-line)] bg-[var(--rv-bg-subtle)]"
       style={{ width }}
       aria-label="Changed files"
+      data-testid="review-file-list"
     >
       <div className="flex h-9 shrink-0 items-center gap-2 border-b border-[var(--rv-line)] px-3">
         <SearchIcon className="size-3.5 shrink-0 text-[var(--rv-fg-subtle)]" aria-hidden />

--- a/apps/web/src/features/onboarding/credential-setup-dialog.tsx
+++ b/apps/web/src/features/onboarding/credential-setup-dialog.tsx
@@ -25,14 +25,13 @@ import type { FirstRunSetupStepKey } from './credential-setup-store'
 import {
   areAllFirstRunSetupStepsCompleted,
   isFirstRunSetupStepCompleted,
+  isProviderSetupSatisfied,
   resolvePendingFirstRunSetupSteps,
   useFirstRunSetupStore,
 } from './credential-setup-store'
 import { useOnboardingStore } from './onboarding-store'
 
 type DialogStep = FirstRunSetupStepKey | 'done'
-
-const CC_SWITCH_SOURCE_ID = 'cc-switch'
 
 /**
  * First-run setup dialog keyed by step.
@@ -50,19 +49,15 @@ export function CredentialSetupDialog() {
   const completeSteps = useFirstRunSetupStore(s => s.completeSteps)
 
   const { providerOptions, isSuccess: targetsReady } = useProviderTargets()
-  const { data: externalSources = [], isSuccess: sourcesReady } = useQuery(getExternalProviderSourcesOptions())
+  const { isSuccess: sourcesReady } = useQuery(getExternalProviderSourcesOptions())
   const { data: externalRecords = [], isSuccess: recordsReady } = useQuery(getExternalProviderSourcesRecordsOptions())
   const github = useGithubAppConnectionController()
 
-  const hasExternalProviderData = useMemo(() => {
-    const sources = externalSources as Array<{ sourceId?: string }>
-    const records = externalRecords as Array<{ sourceKind?: string, sourceKey?: string }>
-    return records.length > 0
-      || sources.some(source => source.sourceId === CC_SWITCH_SOURCE_ID)
-      || records.some(record => record.sourceKind === CC_SWITCH_SOURCE_ID || record.sourceKey === CC_SWITCH_SOURCE_ID)
-  }, [externalRecords, externalSources])
-
-  const providerSatisfied = targetsReady && (providerOptions.length > 0 || hasExternalProviderData)
+  const providerSatisfied = isProviderSetupSatisfied({
+    targetsReady,
+    providerOptionCount: providerOptions.length,
+    externalProviderRecordCount: externalRecords.length,
+  })
   const githubSatisfied = github.isConnected
   const inventoryReady = targetsReady && sourcesReady && recordsReady && !github.loading
 

--- a/apps/web/src/features/onboarding/credential-setup-store.test.ts
+++ b/apps/web/src/features/onboarding/credential-setup-store.test.ts
@@ -1,6 +1,37 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolvePendingFirstRunSetupSteps } from './credential-setup-store'
+import {
+  isProviderSetupSatisfied,
+  resolvePendingFirstRunSetupSteps,
+} from './credential-setup-store'
+
+describe('isProviderSetupSatisfied', () => {
+  it('requires a usable provider option or an external provider record', () => {
+    expect(isProviderSetupSatisfied({
+      targetsReady: true,
+      providerOptionCount: 0,
+      externalProviderRecordCount: 0,
+    })).toBe(false)
+    expect(isProviderSetupSatisfied({
+      targetsReady: true,
+      providerOptionCount: 1,
+      externalProviderRecordCount: 0,
+    })).toBe(true)
+    expect(isProviderSetupSatisfied({
+      targetsReady: true,
+      providerOptionCount: 0,
+      externalProviderRecordCount: 1,
+    })).toBe(true)
+  })
+
+  it('waits for provider targets before satisfying the setup step', () => {
+    expect(isProviderSetupSatisfied({
+      targetsReady: false,
+      providerOptionCount: 1,
+      externalProviderRecordCount: 1,
+    })).toBe(false)
+  })
+})
 
 describe('resolvePendingFirstRunSetupSteps', () => {
   it('returns both steps when nothing is completed or satisfied', () => {

--- a/apps/web/src/features/onboarding/credential-setup-store.ts
+++ b/apps/web/src/features/onboarding/credential-setup-store.ts
@@ -25,6 +25,15 @@ export function isFirstRunSetupStepCompleted(
   return completedSteps[key] === true
 }
 
+export function isProviderSetupSatisfied(input: {
+  targetsReady: boolean
+  providerOptionCount: number
+  externalProviderRecordCount: number
+}): boolean {
+  return input.targetsReady
+    && (input.providerOptionCount > 0 || input.externalProviderRecordCount > 0)
+}
+
 /**
  * Steps still owed by the user, after subtracting environmentally satisfied
  * capabilities (existing providers / connected GitHub).

--- a/e2e/src/features/provider.feature
+++ b/e2e/src/features/provider.feature
@@ -19,6 +19,7 @@
     那么 Provider 状态应为成功
     而且 Provider 列表中应显示名为"E2E UI Claude"的 profile
     当 我为 UI 创建的 Provider 准备真实 Claude 回复
+    而且 我关闭设置并返回首页
     而且 我已添加了一个工作区
     而且 我点击"新建聊天"导航项
     而且 我在新建聊天选择名为"E2E UI Claude"的 Claude Agent Provider

--- a/e2e/src/steps/chat.steps.ts
+++ b/e2e/src/steps/chat.steps.ts
@@ -353,7 +353,7 @@ Then('聊天错误提示应显示{string}', async function (this: CradleWorld, t
 When('我重新加载当前页面', async function (this: CradleWorld) {
   await this.page.reload()
   await this.page.waitForLoadState('domcontentloaded')
-  await this.chat.waitVisible()
+  await expect(this.page.locator('[data-testid="app-sidebar"]')).toBeVisible({ timeout: CHAT_STATUS_TIMEOUT })
 })
 
 Then('会话{string}应显示为已置顶', async function (this: CradleWorld, alias: string) {

--- a/e2e/src/support/pages/diff.ts
+++ b/e2e/src/support/pages/diff.ts
@@ -23,7 +23,7 @@ export class DiffPage {
   }
 
   async expectFile(path: string): Promise<void> {
-    await expect(this.page.locator('[data-testid="file-list-aside"]').getByText(path, { exact: true }))
+    await expect(this.workingTree().locator('[data-testid="review-file-list"]').getByText(path, { exact: true }))
       .toBeVisible({ timeout: TIMEOUT })
   }
 

--- a/e2e/src/support/pages/workspace.ts
+++ b/e2e/src/support/pages/workspace.ts
@@ -46,7 +46,10 @@ export class WorkspacePage {
 
   async dismissTransientOverlays(): Promise<void> {
     await dismissGlobalTransientOverlays(this.page)
-    await this.page.getByRole('button', { name: /Later|稍后/i }).first().click().catch(() => undefined)
+    const laterButton = this.page.getByRole('button', { name: /Later|稍后/i }).first()
+    if (await laterButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await laterButton.click()
+    }
     await this.page.keyboard.press('Escape').catch(() => undefined)
     await this.page.locator('[data-slot="dialog-overlay"][data-state="open"]')
       .waitFor({ state: 'hidden', timeout: 3_000 })
@@ -169,6 +172,12 @@ export class WorkspacePage {
   async addWorkspaceFromPicker(fixture: WorkspaceFixture): Promise<void> {
     await this.dismissTransientOverlays()
 
+    const beforeResponse = await fetch(`${this.owner.params.serverUrl}/workspaces`)
+    if (!beforeResponse.ok) {
+      throw new Error(`Failed to list workspaces before add: ${beforeResponse.status} ${await beforeResponse.text()}`)
+    }
+    const beforeWorkspaces = await beforeResponse.json() as ServerWorkspace[]
+
     const sidebar = this.page.locator('[data-testid="app-sidebar"]')
     await expect(sidebar).toBeVisible({ timeout: SIDEBAR_TIMEOUT })
 
@@ -205,18 +214,43 @@ export class WorkspacePage {
 
     await this.owner.selectDirectoryInBrowser(fixture.dir)
 
-    // Import may rename/display based on folder basename; wait for a project row then sync fixture.
-    await expect(this.workspaceGroups()).toHaveCount(1, { timeout: WORKSPACE_TIMEOUT })
-    const listRes = await fetch(`${this.owner.params.serverUrl}/workspaces`)
-    if (listRes.ok) {
-      const workspaces = await listRes.json() as Array<{ id: string, name?: string | null, path?: string | null }>
-      const match = workspaces.find(ws => ws.path === fixture.dir) ?? workspaces[0]
-      if (match?.name) {
-        fixture.name = match.name
+    // Other setup steps may already have created workspaces. Wait for this exact
+    // directory and assert that importing it adds one server record.
+    await expect.poll(async () => {
+      const response = await fetch(`${this.owner.params.serverUrl}/workspaces`)
+      if (!response.ok) {
+        return null
       }
+      const workspaces = await response.json() as ServerWorkspace[]
+      const match = workspaces.find(workspace => workspace.path === fixture.dir)
+      return match && workspaces.length === beforeWorkspaces.length + 1 ? match.id : null
+    }, { timeout: WORKSPACE_TIMEOUT }).not.toBeNull()
+
+    const afterResponse = await fetch(`${this.owner.params.serverUrl}/workspaces`)
+    if (!afterResponse.ok) {
+      throw new Error(`Failed to list workspaces after add: ${afterResponse.status} ${await afterResponse.text()}`)
     }
-    this.rememberFixtures([fixture])
+    const afterWorkspaces = await afterResponse.json() as ServerWorkspace[]
+    const addedWorkspace = afterWorkspaces.find(workspace => workspace.path === fixture.dir)
+    if (!addedWorkspace) {
+      throw new Error(`Workspace import completed without the requested path: ${fixture.dir}`)
+    }
+    if (addedWorkspace.name) {
+      fixture.name = addedWorkspace.name
+    }
+
+    const rememberedFixtures = this.recallFixtures()
+    const fixtureIndex = rememberedFixtures.findIndex(remembered => remembered.dir === fixture.dir)
+    if (fixtureIndex >= 0) {
+      rememberedFixtures[fixtureIndex] = fixture
+    }
+    else {
+      rememberedFixtures.push(fixture)
+    }
+    this.rememberFixtures(rememberedFixtures)
     this.setCurrentWorkspace(fixture)
+
+    await expect(this.workspaceGroups()).toHaveCount(afterWorkspaces.length, { timeout: WORKSPACE_TIMEOUT })
     await expect(this.workspaceButtonByName(fixture.name)).toBeVisible({ timeout: WORKSPACE_TIMEOUT })
   }
 


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Daily E2E issue #151 reported nine failures. Artifact and trace inspection showed that six of the failing scenarios were caused by one first-run product regression plus stale or state-unsafe E2E assumptions:

- an installed but empty external provider source skipped the provider setup step;
- workspace helpers hard-coded a total of one workspace and overwrote remembered fixtures;
- the provider journey interacted with the main sidebar while Settings was still active;
- the generic reload step required a chat view even on Settings;
- the diff journey targeted a retired file-list component;
- an absent transient “Later” button incurred the default Playwright timeout.

This PR addresses only that non-runtime cluster. Codex rollback, bang command persistence, and usage accounting remain deliberately out of scope and #151 should stay open.

## Summary

- Require a usable provider option or a real external provider record before considering first-run provider setup satisfied.
- Add focused unit coverage for provider setup satisfaction.
- Make workspace picker assertions relative to the server inventory and match the exact imported directory.
- Preserve all remembered workspace fixtures across repeated picker additions.
- Exit Settings before the provider scenario uses workspace navigation.
- Make the generic reload step wait for the app shell rather than a chat-only surface.
- Add a stable test id to the current review file rail and update the diff page object.
- Avoid waiting for a nonexistent transient “Later” button.

## Test plan

- `node ../../node_modules/vitest/vitest.mjs run --config vite.config.ts --environment jsdom src/features/onboarding/credential-setup-store.test.ts` from `apps/web`
  - 1 file passed, 6 tests passed.
- `node node_modules/typescript/bin/tsc --noEmit -p apps/web/tsconfig.json`
  - passed.
- ESLint on all changed TypeScript files
  - 0 errors; one pre-existing Fast Refresh warning in `credential-setup-dialog.tsx`.
- Cucumber dry-run for the six affected scenario tags
  - 6 scenarios and 84 steps resolved successfully.
- `git diff --check`
  - passed.
- Full browser E2E was not run locally because this environment has no Chromium binary and could not provision one. CI should run the affected real browser journeys.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is denied or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** N/A — author-side directive context was not shared.
- **Constraints / non-goals:** N/A — see the public scope in Problem / pressure.
- **Decision rationale:** N/A.
- **Deliberately not done:** N/A — see the public scope in Problem / pressure.
- **Unknowns / confidence:** N/A — see Test plan for residual verification risk.

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

Part of #151.
