### PR TITLE
fix(chat): dispatch bang commands from new chat

### DIFF
--- a/apps/web/src/features/chat/session/optimistic-bang-command.test.ts
+++ b/apps/web/src/features/chat/session/optimistic-bang-command.test.ts
@@ -1,0 +1,84 @@
+import type { UIMessage } from 'ai'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useChatStore } from '~/store/chat'
+
+import { readBangCommandMetadata, readBangResultMetadata } from '../commands/bang-command-metadata'
+import { executeOptimisticBangCommand } from './optimistic-bang-command'
+
+const mocks = vi.hoisted(() => ({
+  executeBangCommand: vi.fn(),
+}))
+
+vi.mock('../commands/chat-response-command', () => ({
+  executeBangCommand: mocks.executeBangCommand,
+}))
+
+function resetChatStore(): void {
+  useChatStore.setState(state => ({
+    ...state,
+    messagesMap: new Map(),
+    hydratedSessionIds: new Set(),
+    runStateMap: new Map(),
+    activeAbortControllers: new Map(),
+    runDisplayMetaMap: new Map(),
+    errorMap: new Map(),
+    assistantDisplaySplitMap: new Map(),
+  }))
+}
+
+function message(id: string, text: string): UIMessage {
+  return {
+    id,
+    role: 'user',
+    parts: [{ type: 'text', text }],
+  }
+}
+
+describe('executeOptimisticBangCommand', () => {
+  beforeEach(() => {
+    resetChatStore()
+    mocks.executeBangCommand.mockReset()
+  })
+
+  it('replaces the optimistic driver with the persisted command and result', async () => {
+    mocks.executeBangCommand.mockResolvedValue({
+      command: 'printf hello',
+      stdout: 'hello',
+      stderr: '',
+      exitCode: 0,
+      durationMs: 12,
+      timedOut: false,
+      truncated: false,
+      userMessageId: 'user-persisted',
+      resultMessageId: 'result-persisted',
+      userMessage: message('user-persisted', '!printf hello'),
+      resultMessage: message('result-persisted', 'hello'),
+    })
+    const onSuccess = vi.fn()
+
+    await executeOptimisticBangCommand({
+      sessionId: 'session-1',
+      command: 'printf hello',
+      onSuccess,
+    })
+
+    expect(mocks.executeBangCommand).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'session-1',
+      command: 'printf hello',
+    }))
+    const messages = useChatStore.getState().messagesMap.get('session-1') ?? []
+    expect(messages.map(item => item.id)).toEqual(['user-persisted', 'result-persisted'])
+    expect(readBangCommandMetadata(messages[0]!)).toEqual({ command: 'printf hello' })
+    expect(readBangResultMetadata(messages[1]!)).toEqual({
+      command: 'printf hello',
+      stdout: 'hello',
+      stderr: '',
+      exitCode: 0,
+      durationMs: 12,
+      timedOut: false,
+      truncated: false,
+    })
+    expect(onSuccess).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/web/src/features/chat/session/optimistic-bang-command.ts
+++ b/apps/web/src/features/chat/session/optimistic-bang-command.ts
@@ -1,0 +1,98 @@
+import { useChatStore } from '~/store/chat'
+
+import { annotateBangCommandMessage, annotateBangResultMessage } from '../commands/bang-command-metadata'
+import { executeBangCommand } from '../commands/chat-response-command'
+import { BANG_COMMAND_DRIVER_PREFIX } from './use-chat-session-types'
+
+interface ExecuteOptimisticBangCommandInput {
+  sessionId: string
+  command: string
+  runtimeBusy?: boolean
+  onSuccess?: () => void
+  onError?: (error: unknown) => void
+}
+
+export async function executeOptimisticBangCommand({
+  sessionId,
+  command,
+  runtimeBusy = false,
+  onSuccess,
+  onError,
+}: ExecuteOptimisticBangCommandInput): Promise<void> {
+  const controller = new AbortController()
+  const driverMessageId = `${BANG_COMMAND_DRIVER_PREFIX}-${Date.now()}`
+  const store = useChatStore.getState()
+  store.appendMessage(sessionId, annotateBangCommandMessage(
+    {
+      id: driverMessageId,
+      role: 'user',
+      parts: [{ type: 'text', text: `!${command}` }],
+    },
+    command,
+  ))
+  if (!runtimeBusy) {
+    store.startGeneration(sessionId, driverMessageId, controller)
+  }
+
+  try {
+    const result = await executeBangCommand({
+      sessionId,
+      command,
+      signal: controller.signal,
+    })
+    useChatStore.getState().removeMessage(sessionId, driverMessageId)
+    const latestMessages = useChatStore.getState().messagesMap.get(sessionId) ?? []
+    const userMessage = annotateBangCommandMessage(result.userMessage, result.command)
+    const resultMessage = annotateBangResultMessage(result.resultMessage, {
+      command: result.command,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+      durationMs: result.durationMs,
+      timedOut: result.timedOut,
+      truncated: result.truncated,
+    })
+    if (latestMessages.some(message => message.id === userMessage.id)) {
+      useChatStore.getState().updateMessage(sessionId, userMessage.id, current => annotateBangCommandMessage(current, result.command))
+    }
+    else {
+      useChatStore.getState().appendMessage(sessionId, userMessage)
+    }
+    if (latestMessages.some(message => message.id === resultMessage.id)) {
+      useChatStore.getState().updateMessage(sessionId, resultMessage.id, current => annotateBangResultMessage(current, {
+        command: result.command,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode,
+        durationMs: result.durationMs,
+        timedOut: result.timedOut,
+        truncated: result.truncated,
+      }))
+    }
+    else {
+      useChatStore.getState().appendMessage(sessionId, resultMessage)
+    }
+    useChatStore.getState().finishGeneration(driverMessageId)
+    onSuccess?.()
+  }
+  catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      if (!runtimeBusy) {
+        useChatStore.getState().finishGeneration(driverMessageId)
+      }
+      return
+    }
+
+    const errorMessage = error instanceof Error ? error.message : 'Bang command failed'
+    if (runtimeBusy) {
+      useChatStore.getState().updateMessage(sessionId, driverMessageId, message => ({
+        ...message,
+        parts: [{ type: 'text', text: `!${command}\n\n${errorMessage}` }],
+      }))
+    }
+    else {
+      useChatStore.getState().failGeneration(driverMessageId, errorMessage)
+    }
+    onError?.(error)
+  }
+}

--- a/apps/web/src/features/chat/session/use-chat-actions.ts
+++ b/apps/web/src/features/chat/session/use-chat-actions.ts
@@ -10,8 +10,7 @@ import { chatSelectors, useChatStore } from '~/store/chat'
 
 import { runtimeUiSlotStatesQueryKey } from '../capabilities/chat-capabilities'
 import { readBangCommand } from '../commands/bang-command'
-import { annotateBangCommandMessage, annotateBangResultMessage } from '../commands/bang-command-metadata'
-import { cancelChatResponse, createSideChat, enqueueChatSessionQueueItem, executeBangCommand, resolvePlanImplementationApproval, steerChatSessionTurn, submitRuntimeToolApproval, submitRuntimeUserInput } from '../commands/chat-response-command'
+import { cancelChatResponse, createSideChat, enqueueChatSessionQueueItem, resolvePlanImplementationApproval, steerChatSessionTurn, submitRuntimeToolApproval, submitRuntimeUserInput } from '../commands/chat-response-command'
 import { rollbackLastTurn as rollbackLastTurnCommand } from '../commands/rollback-last-turn-command'
 import type { RuntimeSessionStatus } from '../commands/runtime-session-status-command'
 import { runtimeSettingsQueryKey, updateSessionRuntimeSettings } from '../commands/runtime-settings-command'
@@ -20,13 +19,13 @@ import { setCodexThreadGoal } from '../runtime/codex-app-server-bridge'
 import { runtimeSessionStatusQueryKey, runtimeSessionStatusQueryOptions } from '../runtime/use-runtime-session-status'
 import { startChatResponseStream } from '../transport/chat-stream-transport'
 import { ChatStreamingHandler } from '../transport/chat-streaming-handler'
+import { executeOptimisticBangCommand } from './optimistic-bang-command'
 import { buildOptimisticUserMessage, readGoalCommandObjective } from './optimistic-chat-turn'
 import type { UserMessageDraft } from './read-user-message-draft'
 import { readUserMessageDraft } from './read-user-message-draft'
 import type { ChatSessionRuntimeControls } from './use-chat-session-runtime-controls'
 import type { RuntimeUserInputSubmitInput, SendMessageOptions, SendMessageResult, ToolApprovalResponseInput } from './use-chat-session-types'
 import {
-  BANG_COMMAND_DRIVER_PREFIX,
   CODEX_PLAN_IMPLEMENTATION_PROMPT_PREFIX,
   isMatchingApprovalPart,
   isMatchingToolPart,
@@ -148,83 +147,16 @@ export function useChatActions(input: UseChatActionsInput) {
     }
 
     if (bangCommand) {
-      const controller = new AbortController()
-      const driverMessageId = `${BANG_COMMAND_DRIVER_PREFIX}-${Date.now()}`
-      const store = useChatStore.getState()
-      store.appendMessage(chatSessionId, annotateBangCommandMessage(
-        {
-          id: driverMessageId,
-          role: 'user',
-          parts: [{ type: 'text', text: `!${bangCommand}` }],
-        },
-        bangCommand,
-      ))
-      if (!isBusy) {
-        store.startGeneration(chatSessionId, driverMessageId, controller)
-      }
       updateSessionInSessionLists(queryClient, { id: chatSessionId }, { promote: true })
-
-      try {
-        const result = await executeBangCommand({
-          sessionId: chatSessionId,
-          command: bangCommand,
-          signal: controller.signal,
-        })
-        useChatStore.getState().removeMessage(chatSessionId, driverMessageId)
-        const latestMessages = useChatStore.getState().messagesMap.get(chatSessionId) ?? []
-        const userMessage = annotateBangCommandMessage(result.userMessage, result.command)
-        const resultMessage = annotateBangResultMessage(result.resultMessage, {
-          command: result.command,
-          stdout: result.stdout,
-          stderr: result.stderr,
-          exitCode: result.exitCode,
-          durationMs: result.durationMs,
-          timedOut: result.timedOut,
-          truncated: result.truncated,
-        })
-        if (latestMessages.some(message => message.id === userMessage.id)) {
-          useChatStore.getState().updateMessage(chatSessionId, userMessage.id, current => annotateBangCommandMessage(current, result.command))
-        }
-        else {
-          useChatStore.getState().appendMessage(chatSessionId, userMessage)
-        }
-        if (latestMessages.some(message => message.id === resultMessage.id)) {
-          useChatStore.getState().updateMessage(chatSessionId, resultMessage.id, current => annotateBangResultMessage(current, {
-            command: result.command,
-            stdout: result.stdout,
-            stderr: result.stderr,
-            exitCode: result.exitCode,
-            durationMs: result.durationMs,
-            timedOut: result.timedOut,
-            truncated: result.truncated,
-          }))
-        }
-        else {
-          useChatStore.getState().appendMessage(chatSessionId, resultMessage)
-        }
-        useChatStore.getState().finishGeneration(driverMessageId)
-        scheduleSnapshotRefresh(0)
-        refreshSessionLists()
-      }
-      catch (err) {
-        if (err instanceof DOMException && err.name === 'AbortError') {
-          if (!isBusy) {
-            useChatStore.getState().finishGeneration(driverMessageId)
-          }
-        }
-        else {
-          const errorMessage = err instanceof Error ? err.message : 'Bang command failed'
-          if (isBusy) {
-            useChatStore.getState().updateMessage(chatSessionId, driverMessageId, message => ({
-              ...message,
-              parts: [{ type: 'text', text: `!${bangCommand}\n\n${errorMessage}` }],
-            }))
-          }
-          else {
-            useChatStore.getState().failGeneration(driverMessageId, errorMessage)
-          }
-        }
-      }
+      await executeOptimisticBangCommand({
+        sessionId: chatSessionId,
+        command: bangCommand,
+        runtimeBusy: isBusy,
+        onSuccess: () => {
+          scheduleSnapshotRefresh(0)
+          refreshSessionLists()
+        },
+      })
       return
     }
 

--- a/apps/web/src/features/new-chat/new-chat-entry-point.tsx
+++ b/apps/web/src/features/new-chat/new-chat-entry-point.tsx
@@ -7,6 +7,7 @@ import { postSessions, postSessionsByIdIsolationStart } from '~/api-gen/sdk.gen'
 import type { PostSessionsData } from '~/api-gen/types.gen'
 import { useRegisterLayoutSlots } from '~/components/layout/use-layout-slots'
 import { runtimeComposerUsesCollapsedInput, useRuntimeCatalog } from '~/features/agent-runtime/use-runtime-catalog'
+import { readBangCommand } from '~/features/chat/commands/bang-command'
 import { describeChatExecutionError } from '~/features/chat/commands/chat-execution-errors'
 import type { DraftChatComposerSubmitOptions } from '~/features/chat/composer/containers/draft-chat-composer-container'
 import { DraftChatComposerWithState } from '~/features/chat/composer/containers/draft-chat-composer-container'
@@ -18,6 +19,7 @@ import {
   readRunRuntimeSettingsPatch,
   resolveRuntimeCatalogItem,
 } from '~/features/chat/runtime/runtime-settings-presenter'
+import { executeOptimisticBangCommand } from '~/features/chat/session/optimistic-bang-command'
 import { startOptimisticChatResponse } from '~/features/chat/session/optimistic-chat-turn'
 import { useComposerState } from '~/features/composer-toolbar'
 import type { IssueIsolationStartChoice } from '~/features/new-chat/issue-isolation-start-dialog'
@@ -285,28 +287,48 @@ function useNewChatPageOwner(
         runtimeKind: options.runtimeKind,
         sessionGroupId,
       }, { promote: true })
-      startOptimisticChatResponse({
-        sessionId: session.id,
-        queryClient,
-        body: {
-          text: trimmedText,
-          files,
-          contextParts,
-          modelId: options.modelId,
-          thinkingEffort: options.thinkingEffort,
-          runtimeSettings: readRunRuntimeSettingsPatch(options.runtimeSettings),
-          reviewTarget: options.reviewTarget,
-        },
-        onAccepted: () => {
-          void Promise.all([
-            queryClient.invalidateQueries({ queryKey: sessionsQueryKey(session.workspaceId ?? selectedProjectWorkspaceId) }),
-            queryClient.invalidateQueries({ queryKey: sessionsQueryKey() }),
-          ])
-        },
-        onError: (err) => {
-          console.error('[NewChatPage] start response failed:', describeChatExecutionError(err) ?? err)
-        },
-      })
+      const bangCommand = files.length === 0 && contextParts.length === 0
+        ? readBangCommand(text)
+        : null
+      if (bangCommand) {
+        void executeOptimisticBangCommand({
+          sessionId: session.id,
+          command: bangCommand,
+          onSuccess: () => {
+            void Promise.all([
+              queryClient.invalidateQueries({ queryKey: sessionsQueryKey(session.workspaceId ?? selectedProjectWorkspaceId) }),
+              queryClient.invalidateQueries({ queryKey: sessionsQueryKey() }),
+            ])
+          },
+          onError: (error) => {
+            console.error('[NewChatPage] bang command failed:', describeChatExecutionError(error) ?? error)
+          },
+        })
+      }
+      else {
+        startOptimisticChatResponse({
+          sessionId: session.id,
+          queryClient,
+          body: {
+            text: trimmedText,
+            files,
+            contextParts,
+            modelId: options.modelId,
+            thinkingEffort: options.thinkingEffort,
+            runtimeSettings: readRunRuntimeSettingsPatch(options.runtimeSettings),
+            reviewTarget: options.reviewTarget,
+          },
+          onAccepted: () => {
+            void Promise.all([
+              queryClient.invalidateQueries({ queryKey: sessionsQueryKey(session.workspaceId ?? selectedProjectWorkspaceId) }),
+              queryClient.invalidateQueries({ queryKey: sessionsQueryKey() }),
+            ])
+          },
+          onError: (err) => {
+            console.error('[NewChatPage] start response failed:', describeChatExecutionError(err) ?? err)
+          },
+        })
+      }
       void Promise.all([
         queryClient.invalidateQueries({ queryKey: sessionsQueryKey(session.workspaceId ?? selectedProjectWorkspaceId) }),
         queryClient.invalidateQueries({ queryKey: sessionsQueryKey() }),


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

The Daily E2E run linked from #151 shows new-chat Bang commands being sent to the selected model instead of being intercepted and executed locally. The existing interception only lived in the established-session submit hook, while the new-chat entry point bypassed it after creating the session.

## Summary

- Extract the optimistic Bang execution flow into a shared session helper.
- Route recognized Bang commands from both established chats and the new-chat entry point through that helper.
- Preserve normal message dispatch when attachments or explicit context make the input ineligible for Bang interception.
- Add a store-level regression test covering optimistic replacement with the persisted command and result messages.

## Test plan

- `pnpm --filter @cradle/web exec vitest run --config vite.config.ts --environment jsdom src/features/chat/session/optimistic-bang-command.test.ts`
- `pnpm --filter @cradle/web typecheck`
- ESLint on the four changed files
- `git diff --check`
- Browser E2E was attempted after rebuilding `better-sqlite3`, but Playwright Chromium was unavailable and its CDN download repeatedly returned a truncated archive. CI should run the existing `@CRADLE-BANG-001` coverage.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is denied or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** N/A / redacted
- **Constraints / non-goals:** N/A / redacted
- **Decision rationale:** N/A / redacted
- **Deliberately not done:** N/A / redacted
- **Unknowns / confidence:** Browser E2E could not run locally because the Playwright browser download was truncated; focused regression coverage and static checks pass.

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [x] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->