### PR TITLE
fix(web): tighten slash command sections

### DIFF
--- a/apps/web/src/features/chat/slash-commands/slash-command-input.test.ts
+++ b/apps/web/src/features/chat/slash-commands/slash-command-input.test.ts
@@ -19,7 +19,7 @@ function command(
 }
 
 describe('slash command panel grouping', () => {
-  it('partitions product commands above runtime controls', () => {
+  it('partitions runtime controls above product commands', () => {
     const items = partitionSlashCommandPanelItems([
       command({ id: 'runtime:goal', name: 'goal', source: 'runtime', iconKey: 'goal' }),
       command({ id: 'cradle:review', name: 'review', source: 'cradle', iconKey: 'code-review' }),
@@ -28,7 +28,7 @@ describe('slash command panel grouping', () => {
       command({ id: 'cradle:side', name: 'side', source: 'cradle', iconKey: 'side-chat' }),
     ])
 
-    expect(items.map(item => item.name)).toEqual(['review', 'btw', 'side', 'goal', 'terminal'])
+    expect(items.map(item => item.name)).toEqual(['goal', 'terminal', 'review', 'btw', 'side'])
   })
 
   it('groups side and btw together under Commands by product semantics', () => {
@@ -41,19 +41,19 @@ describe('slash command panel grouping', () => {
 
     expect(sections).toEqual([
       {
+        id: 'runtime',
+        label: 'Runtime',
+        items: [
+          expect.objectContaining({ name: 'goal' }),
+        ],
+      },
+      {
         id: 'commands',
         label: 'Commands',
         items: [
           expect.objectContaining({ name: 'btw' }),
           expect.objectContaining({ name: 'side' }),
           expect.objectContaining({ name: 'commit' }),
-        ],
-      },
-      {
-        id: 'runtime',
-        label: 'Runtime',
-        items: [
-          expect.objectContaining({ name: 'goal' }),
         ],
       },
     ])

--- a/apps/web/src/features/chat/slash-commands/slash-command-input.ts
+++ b/apps/web/src/features/chat/slash-commands/slash-command-input.ts
@@ -113,7 +113,7 @@ export function getSlashCommandPanelSectionLabel(sectionId: SlashCommandPanelSec
   return sectionId === 'commands' ? 'Commands' : 'Runtime'
 }
 
-/** Keep product Commands above Runtime controls while preserving relative order within each section. */
+/** Keep Runtime controls above product Commands while preserving relative order within each section. */
 export function partitionSlashCommandPanelItems(
   items: ChatComposerSlashCommand[],
 ): ChatComposerSlashCommand[] {
@@ -127,7 +127,7 @@ export function partitionSlashCommandPanelItems(
       runtimeItems.push(item)
     }
   }
-  return [...commandItems, ...runtimeItems]
+  return [...runtimeItems, ...commandItems]
 }
 
 export function groupSlashCommandPanelItems(

--- a/apps/web/src/features/chat/slash-commands/slash-command-panel.tsx
+++ b/apps/web/src/features/chat/slash-commands/slash-command-panel.tsx
@@ -388,10 +388,7 @@ export function SlashCommandPanel({
           <Fragment key={section.id}>
             <li
               role="presentation"
-              className={cn(
-                'px-2.5 pb-1 pt-1.5 text-[10px] font-medium tracking-wide text-muted-foreground/70',
-                section.rows[0]?.index > 0 && 'mt-0.5 border-t border-border/60 pt-2',
-              )}
+              className="px-2.5 pb-1 pt-1.5 text-[10px] font-medium tracking-wide text-muted-foreground/70"
             >
               {section.label}
             </li>


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Problem / pressure: The slash-command menu gave product Commands priority over Runtime controls and used a hard divider plus extra spacing between the two sections, making the hierarchy feel inverted and overly separated.

Summary:
- Order Runtime controls before product Commands while preserving relative order inside each section.
- Remove the section border and additional top margin/padding so Runtime and Commands read as one compact menu.
- Update the grouping contract test for the Runtime-first order.

Agent handoff:
- Author type: Agent.
- Constraints / non-goals: Kept existing section labels, command-row styling, keyboard ordering, and command classification unchanged.
- Decision rationale: The design system prefers spatial separation over visible dividers; uniform header spacing provides sufficient grouping without a hard rule.
- Deliberately not done: No broader slash-command redesign or browser-based testing.

## Summary

Problem / pressure: The slash-command menu gave product Commands priority over Runtime controls and used a hard divider plus extra spacing between the two sections, making the hierarchy feel inverted and overly separated.

Summary:
- Order Runtime controls before product Commands while preserving relative order inside each section.
- Remove the section border and additional top margin/padding so Runtime and Commands read as one compact menu.
- Update the grouping contract test for the Runtime-first order.

Agent handoff:
- Author type: Agent.
- Constraints / non-goals: Kept existing section labels, command-row styling, keyboard ordering, and command classification unchanged.
- Decision rationale: The design system prefers spatial separation over visible dividers; uniform header spacing provides sufficient grouping without a hard rule.
- Deliberately not done: No broader slash-command redesign or browser-based testing.

## Test plan

- `pnpm exec vitest run --config vite.config.ts --environment jsdom src/features/chat/slash-commands/slash-command-input.test.ts` (from `apps/web`) — 2 tests passed.
- `pnpm exec eslint apps/web/src/features/chat/slash-commands/slash-command-input.ts apps/web/src/features/chat/slash-commands/slash-command-panel.tsx apps/web/src/features/chat/slash-commands/slash-command-input.test.ts` — passed.
- `pnpm --filter @cradle/web typecheck` — passed.
- `pnpm --filter @cradle/design-system check` — passed.
- Browser-based testing skipped per repository guidance for this focused layout change.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is declined or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** See Problem / pressure. Detailed directive transcript not attached (author-side sharing consent pending).
- **Constraints / non-goals:** N/A
- **Decision rationale:** N/A
- **Deliberately not done:** N/A
- **Unknowns / confidence:** N/A

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)