### PR TITLE
fix(web): restore diff and sidebar scrolling

### DIFF
--- a/apps/web/src/components/layout/app-sidebar.tsx
+++ b/apps/web/src/components/layout/app-sidebar.tsx
@@ -58,12 +58,12 @@ const AppSidebarContent = memo(({
         </div>
       )}
       <div
-        className="relative flex flex-col flex-1 overflow-hidden"
+        className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
         <m.div
           className={cn(
-            'absolute inset-0 flex flex-col overflow-hidden',
+            'absolute inset-0 flex min-h-0 flex-col overflow-hidden',
             isSettings ? 'pointer-events-auto' : 'pointer-events-none',
           )}
           data-testid="settings-sidebar-pane"
@@ -84,7 +84,7 @@ const AppSidebarContent = memo(({
         </m.div>
         <m.div
           className={cn(
-            'absolute inset-0 flex flex-col overflow-hidden',
+            'absolute inset-0 flex min-h-0 flex-col overflow-hidden',
             isSettings ? 'pointer-events-none' : 'pointer-events-auto',
           )}
           data-testid="workspace-sidebar-pane"
@@ -173,7 +173,7 @@ export function AppSidebar() {
   return (
     <>
       <m.aside
-        className="flex flex-col shrink-0 bg-sidebar text-sidebar-foreground overflow-hidden"
+        className="flex h-full min-h-0 shrink-0 flex-col overflow-hidden bg-sidebar text-sidebar-foreground"
         animate={{ width: currentWidth }}
         transition={dragWidth === null ? SIDEBAR_SPRING : INSTANT}
         style={{ width: currentWidth }}

--- a/apps/web/src/features/diff-review/review-detail/diff-stage.tsx
+++ b/apps/web/src/features/diff-review/review-detail/diff-stage.tsx
@@ -264,7 +264,7 @@ export function DiffStage({
   })
 
   return (
-    <div className="relative min-h-0 flex-1 overflow-hidden">
+    <div className="relative h-full min-h-0 flex-1 overflow-hidden">
       {visibleItems.length === 0
         ? (
             <div className="flex h-full items-center justify-center p-4 text-center">

--- a/apps/web/src/features/settings/settings-sidebar-view.tsx
+++ b/apps/web/src/features/settings/settings-sidebar-view.tsx
@@ -102,7 +102,7 @@ export function SettingsSidebarView({
         )}
       </div>
 
-      <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto px-2 pb-2 pt-1">
+      <nav className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2 pb-2 pt-1">
         {filteredSections.map(section => (
           <div key={section.id} className="flex flex-col gap-0.5">
             <span className="select-none px-2.5 py-1.5 text-[11px] font-medium text-muted-foreground">

--- a/apps/web/src/features/workspace/workspace-sidebar.tsx
+++ b/apps/web/src/features/workspace/workspace-sidebar.tsx
@@ -1591,7 +1591,7 @@ export const WorkspaceSidebar = memo(({ collapsed = false }: { collapsed?: boole
   }, [githubFeaturesDisabled])
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <WorkspaceSidebarNavigationView
         collapsed={collapsed}
         pullRequestsActive={pullRequestsActive}


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

The diff review CodeView and the app sidebar could expand to their content height instead of staying constrained to the available viewport, so their nested overflow containers had no scrollable height.

## Summary

- Give DiffStage a definite full height so CodeView can scroll within the review reading surface.
- Complete the sidebar's vertical flex constraint chain with `h-full` and `min-h-0` across the app shell panes, workspace sidebar, and settings navigation.
- Keep scrolling owned by the existing CodeView, ScrollArea, and settings nav containers.

## Test plan

- `pnpm exec eslint apps/web/src/features/diff-review/review-detail/diff-stage.tsx apps/web/src/components/layout/app-sidebar.tsx apps/web/src/features/workspace/workspace-sidebar.tsx apps/web/src/features/settings/settings-sidebar-view.tsx`
- `pnpm --filter @cradle/web typecheck`
- `git diff --check`
- Browser automation not run, following the repository instruction to avoid browser-based testing unless explicitly requested.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is declined or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** See Problem / pressure. Detailed directive transcript not attached (author-side sharing consent pending).
- **Constraints / non-goals:** N/A
- **Decision rationale:** N/A
- **Deliberately not done:** N/A
- **Unknowns / confidence:** N/A

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)