### PR TITLE
fix(workspace): make session rows fully clickable

### DIFF
--- a/apps/web/src/features/workspace/workspace-session-item-view.tsx
+++ b/apps/web/src/features/workspace/workspace-session-item-view.tsx
@@ -216,27 +216,22 @@ export function WorkspaceSessionItemView({
           )
         : (
             <>
-              <div
+              <button
+                type="button"
+                onClick={onOpen}
+                onDoubleClick={canOpenInNewWindow
+                  ? openNewWindow
+                  : undefined}
+                onFocus={onPrefetch}
+                onPointerDown={onPrepareOpen}
+                data-testid={`session-open-${session.id}`}
                 className={cn(
-                  'flex min-w-0 items-center',
-                  workspace ? 'w-full' : 'flex-1',
+                  'relative z-10 flex w-full min-w-0 flex-1 flex-col items-stretch overflow-hidden rounded-lg text-sidebar-foreground/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring',
+                  dimmed
+                  && 'opacity-60 transition-opacity group-hover:opacity-100 focus-visible:opacity-100',
                 )}
               >
-                <button
-                  type="button"
-                  onClick={onOpen}
-                  onDoubleClick={canOpenInNewWindow
-                    ? openNewWindow
-                    : undefined}
-                  onFocus={onPrefetch}
-                  onPointerDown={onPrepareOpen}
-                  data-testid={`session-open-${session.id}`}
-                  className={cn(
-                    'relative z-10 flex min-w-0 flex-1 items-center gap-2 overflow-hidden px-2.5 py-1.5 text-sidebar-foreground/80',
-                    dimmed
-                    && 'opacity-60 transition-opacity group-hover:opacity-100 focus-visible:opacity-100',
-                  )}
-                >
+                <span className="flex w-full min-w-0 items-center gap-2 px-2.5 py-1.5 pr-8">
                 {work
                   ? (
                       <span
@@ -371,31 +366,31 @@ export function WorkspaceSessionItemView({
                         {relativeTime}
                       </span>
                     )}
-                </button>
-                <div className="group/menu relative z-10 mr-0.5 size-6 shrink-0">
-                  <button
-                    type="button"
-                    className="absolute inset-0 grid place-items-center rounded-md text-muted-foreground/50 opacity-0 hover:bg-accent/80 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100"
-                    onClick={openButtonMenu}
-                    aria-haspopup="menu"
-                    aria-label={t('session.aria.menu')}
-                    data-testid={`session-menu-trigger-${session.id}`}
-                  >
-                    <MoreHorizontalIcon className="size-3" aria-hidden="true" />
-                  </button>
-                </div>
-              </div>
-              {workspace
-                ? (
-                    <div
+                </span>
+                {workspace
+                  ? (
+                    <span
                       className="flex min-w-0 items-center gap-1.5 px-2.5 pb-1.5 pl-8 text-[11px] text-muted-foreground"
                       data-testid={`session-workspace-${session.id}`}
                     >
                       <FolderIcon className="size-3 shrink-0" aria-hidden="true" />
                       <span className="min-w-0 truncate">{workspace.name}</span>
-                    </div>
-                  )
-                : null}
+                    </span>
+                    )
+                  : null}
+              </button>
+              <div className="group/menu absolute right-0.5 top-0.5 z-20 size-6">
+                <button
+                  type="button"
+                  className="absolute inset-0 grid place-items-center rounded-md text-muted-foreground/50 opacity-0 hover:bg-accent/80 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100"
+                  onClick={openButtonMenu}
+                  aria-haspopup="menu"
+                  aria-label={t('session.aria.menu')}
+                  data-testid={`session-menu-trigger-${session.id}`}
+                >
+                  <MoreHorizontalIcon className="size-3" aria-hidden="true" />
+                </button>
+              </div>
             </>
           )}
     </div>


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Recent-session rows visually present the title and workspace metadata as one item, but only the title line opened the session. Clicking the workspace line did nothing, making the sidebar interaction feel inconsistent.

## Summary

- Make the session open button own both the title row and optional workspace metadata row.
- Keep the overflow menu as an independently layered button so its click remains isolated from navigation.
- Add a rounded, inset focus-visible ring to the full-row navigation target.

## Test plan

- `pnpm --filter @cradle/web typecheck`
- Pre-commit `lint-staged` / `eslint --cache --fix`
- `git diff --check`
- Browser-based testing was not run, per repository guidance.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is declined or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** See Problem / pressure. Detailed directive transcript not attached (author-side sharing consent pending).
- **Constraints / non-goals:** N/A
- **Decision rationale:** N/A
- **Deliberately not done:** N/A
- **Unknowns / confidence:** N/A

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)