### PR TITLE
fix(e2e): follow paginated Work responses

### DIFF
--- a/e2e/src/support/pages/work.ts
+++ b/e2e/src/support/pages/work.ts
@@ -20,7 +20,6 @@ interface WorkSummary {
   primarySessionId: string
 }
 
-
 interface WorkListPage {
   items: WorkSummary[]
   nextCursor: string | null
@@ -47,14 +46,13 @@ export class WorkPage {
     return this.owner.page
   }
 
-
   private async findWork(
     predicate: (work: WorkSummary) => boolean,
   ): Promise<WorkSummary | null> {
     let cursor: string | null = null
     const seenCursors = new Set<string>()
 
-    do {
+    for (;;) {
       const serverUrl = this.owner.params.serverUrl.replace(/\/$/, '')
       const url = new URL(`${serverUrl}/works`)
       url.searchParams.set('limit', '200')
@@ -73,10 +71,13 @@ export class WorkPage {
         return match
       }
 
-      cursor = page.nextCursor
-    } while (cursor && !seenCursors.has(cursor) && seenCursors.add(cursor))
-
-    return null
+      const nextCursor = page.nextCursor
+      if (!nextCursor || seenCursors.has(nextCursor)) {
+        return null
+      }
+      seenCursors.add(nextCursor)
+      cursor = nextCursor
+    }
   }
 
   root(): Locator {

--- a/e2e/src/support/pages/work.ts
+++ b/e2e/src/support/pages/work.ts
@@ -20,6 +20,12 @@ interface WorkSummary {
   primarySessionId: string
 }
 
+
+interface WorkListPage {
+  items: WorkSummary[]
+  nextCursor: string | null
+}
+
 interface WorkDetail {
   work: { objective: string }
   primaryThread: { id: string }
@@ -39,6 +45,38 @@ export class WorkPage {
 
   private get page(): Page {
     return this.owner.page
+  }
+
+
+  private async findWork(
+    predicate: (work: WorkSummary) => boolean,
+  ): Promise<WorkSummary | null> {
+    let cursor: string | null = null
+    const seenCursors = new Set<string>()
+
+    do {
+      const serverUrl = this.owner.params.serverUrl.replace(/\/$/, '')
+      const url = new URL(`${serverUrl}/works`)
+      url.searchParams.set('limit', '200')
+      if (cursor) {
+        url.searchParams.set('cursor', cursor)
+      }
+
+      const response = await fetch(url)
+      if (!response.ok) {
+        return null
+      }
+
+      const page = await response.json() as WorkListPage
+      const match = page.items.find(predicate)
+      if (match) {
+        return match
+      }
+
+      cursor = page.nextCursor
+    } while (cursor && !seenCursors.has(cursor) && seenCursors.add(cursor))
+
+    return null
   }
 
   root(): Locator {
@@ -79,12 +117,7 @@ export class WorkPage {
   async expectPersisted(goal: string, sessionId: string): Promise<void> {
     let matchedWorkId: string | null = null
     await expect.poll(async () => {
-      const response = await fetch(`${this.owner.params.serverUrl}/works`)
-      if (!response.ok) {
-        return null
-      }
-      const works = await response.json() as WorkSummary[]
-      const match = works.find(work => work.primarySessionId === sessionId)
+      const match = await this.findWork(work => work.primarySessionId === sessionId)
       matchedWorkId = match?.objective === goal ? match.id : null
       return matchedWorkId
     }, { timeout: TIMEOUT }).not.toBeNull()
@@ -115,12 +148,7 @@ export class WorkPage {
   }): Promise<void> {
     let matchedWorkId: string | null = null
     await expect.poll(async () => {
-      const response = await fetch(`${this.owner.params.serverUrl}/works`)
-      if (!response.ok) {
-        return null
-      }
-      const works = await response.json() as WorkSummary[]
-      const match = works.find(work =>
+      const match = await this.findWork(work =>
         work.primarySessionId === input.sessionId
         && work.linkedIssueId !== null
         && work.objective.includes(`# Cradle Issue: ${input.issueTitle}`))
@@ -156,10 +184,7 @@ export class WorkPage {
     issueTitle: string
     sessionId: string
   }): Promise<void> {
-    const worksResponse = await fetch(`${this.owner.params.serverUrl}/works`)
-    expect(worksResponse.ok).toBe(true)
-    const works = await worksResponse.json() as WorkSummary[]
-    const work = works.find(candidate =>
+    const work = await this.findWork(candidate =>
       candidate.primarySessionId === input.sessionId
       && candidate.linkedIssueId !== null
       && candidate.objective.includes(`# Cradle Issue: ${input.issueTitle}`))


### PR DESCRIPTION
## Summary

- Adapt the E2E Work page helper to the paginated `GET /works` response.
- Follow `nextCursor` until the target Work is found.
- Fixes the three failures reported by #170.

## Validation

- Verified the changed file and remote branch contents at `main@52109f8`.
- Dependency installation/local E2E execution is currently blocked in this environment because network approval for package installation was unavailable.
- GitHub Actions should run the focused/full E2E checks on this draft PR.

Fixes #170