### PR TITLE
fix(chat-runtime): stop snapshot journal FK retry loop

### DIFF
--- a/apps/server/src/modules/chat-runtime/run-snapshot-journal.ts
+++ b/apps/server/src/modules/chat-runtime/run-snapshot-journal.ts
@@ -1,6 +1,11 @@
 import type { BackendRunSnapshotEvent } from '@cradle/db'
-import { backendRunSnapshotEvents } from '@cradle/db'
-import { eq } from 'drizzle-orm'
+import {
+  backendRunSnapshotEvents,
+  backendRunSnapshots,
+  backendRuns,
+  sessions,
+} from '@cradle/db'
+import { eq, inArray } from 'drizzle-orm'
 
 import type { db } from '../../infra'
 import { registerBeforeDatabaseShutdown } from '../../infra'
@@ -34,6 +39,14 @@ interface SnapshotFlushContext {
 interface SnapshotFlushOptions<Result> {
   compactSuccessfulPayloads?: (result: Result | undefined) => boolean
   finalSnapshot?: boolean
+}
+
+interface PreparedSnapshotEventInserts {
+  events: BackendRunSnapshotEvent[]
+  dropped: Array<{
+    event: BackendRunSnapshotEvent
+    reason: 'snapshot-missing'
+  }>
 }
 
 const logger = createChildLogger({ module: 'chat-runtime.run-snapshot-journal' })
@@ -148,10 +161,18 @@ export function releaseRunSnapshotContext(database: SnapshotDatabase, snapshotId
   if (!journal) {
     return
   }
+  for (const [eventId, event] of journal.pendingInserts) {
+    if (event.snapshotId === snapshotId) {
+      journal.pendingInserts.delete(eventId)
+      journal.pendingUpdates.delete(eventId)
+      journal.eventById.delete(eventId)
+    }
+  }
   journal.workspaceBySnapshotId.delete(snapshotId)
   journal.persistedSnapshotIds.delete(snapshotId)
   for (const [eventId, event] of journal.eventById) {
     if (event.snapshotId === snapshotId) {
+      journal.pendingUpdates.delete(eventId)
       journal.eventById.delete(eventId)
     }
   }
@@ -207,14 +228,19 @@ function flushJournal<Result>(
     .filter(([eventId]) =>
       snapshotId === undefined || journal.eventById.get(eventId)?.snapshotId === snapshotId)
   let result: Result | undefined
+  let droppedEvents: PreparedSnapshotEventInserts['dropped'] = []
+  let persistedInserts: BackendRunSnapshotEvent[] = []
   journal.database.transaction((tx) => {
     result = withinTransaction?.(tx, {
       hadPreviouslyPersistedEvents: snapshotId !== undefined
         && journal.persistedSnapshotIds.has(snapshotId),
     })
-    const persistedInserts = options.compactSuccessfulPayloads?.(result)
+    const compactedInserts = options.compactSuccessfulPayloads?.(result)
       ? inserts.map(compactSuccessfulSnapshotEvent)
       : inserts
+    const prepared = prepareSnapshotEventInserts(tx, compactedInserts)
+    droppedEvents = prepared.dropped
+    persistedInserts = prepared.events
     for (let offset = 0; offset < persistedInserts.length; offset += INSERT_BATCH_SIZE) {
       tx.insert(backendRunSnapshotEvents)
         .values(persistedInserts.slice(offset, offset + INSERT_BATCH_SIZE))
@@ -226,7 +252,12 @@ function flushJournal<Result>(
         .where(eq(backendRunSnapshotEvents.id, eventId))
         .run()
     }
-    for (const event of inserts) {
+    const persistedEventById = new Map(persistedInserts.map(event => [event.id, event]))
+    for (const insert of inserts) {
+      const event = persistedEventById.get(insert.id)
+      if (!event) {
+        continue
+      }
       projectChatRuntimeRunSnapshotEventReadModels(tx, {
         sourceEvent: event,
         workspaceId: journal.workspaceBySnapshotId.get(event.snapshotId) ?? null,
@@ -242,14 +273,31 @@ function flushJournal<Result>(
       }
     }
   })
+  for (const dropped of droppedEvents) {
+    logger.warn('dropping run snapshot event with missing snapshot parent', {
+      eventId: dropped.event.id,
+      snapshotId: dropped.event.snapshotId,
+      chatSessionId: dropped.event.chatSessionId,
+      runId: dropped.event.runId,
+      reason: dropped.reason,
+    })
+  }
   for (const event of inserts) {
     journal.pendingInserts.delete(event.id)
+    const persistedEvent = persistedInserts.find(candidate => candidate.id === event.id)
+    if (persistedEvent) {
+      journal.eventById.set(event.id, persistedEvent)
+    }
+    else {
+      journal.eventById.delete(event.id)
+      journal.pendingUpdates.delete(event.id)
+    }
   }
   for (const [eventId] of updates) {
     journal.pendingUpdates.delete(eventId)
   }
   if (!options.finalSnapshot) {
-    for (const event of inserts) {
+    for (const event of persistedInserts) {
       journal.persistedSnapshotIds.add(event.snapshotId)
     }
   }
@@ -258,6 +306,70 @@ function flushJournal<Result>(
   }
   removeJournalIfIdle(journal)
   return result
+}
+
+function prepareSnapshotEventInserts(
+  tx: SnapshotTransaction,
+  events: BackendRunSnapshotEvent[],
+): PreparedSnapshotEventInserts {
+  if (events.length === 0) {
+    return { events: [], dropped: [] }
+  }
+
+  const snapshotIds = new Set(
+    tx
+      .select({ id: backendRunSnapshots.id })
+      .from(backendRunSnapshots)
+      .where(inArray(backendRunSnapshots.id, events.map(event => event.snapshotId)))
+      .all()
+      .map(row => row.id),
+  )
+  const sessionIdValues = [...new Set(
+    events.flatMap(event => event.chatSessionId ? [event.chatSessionId] : []),
+  )]
+  const sessionIds = sessionIdValues.length === 0
+    ? new Set<string>()
+    : new Set(
+        tx
+          .select({ id: sessions.id })
+          .from(sessions)
+          .where(inArray(sessions.id, sessionIdValues))
+          .all()
+          .map(row => row.id),
+      )
+  const runIdValues = [...new Set(
+    events.flatMap(event => event.runId ? [event.runId] : []),
+  )]
+  const runIds = runIdValues.length === 0
+    ? new Set<string>()
+    : new Set(
+        tx
+          .select({ id: backendRuns.id })
+          .from(backendRuns)
+          .where(inArray(backendRuns.id, runIdValues))
+          .all()
+          .map(row => row.id),
+      )
+
+  const persisted: BackendRunSnapshotEvent[] = []
+  const dropped: PreparedSnapshotEventInserts['dropped'] = []
+  for (const event of events) {
+    if (!snapshotIds.has(event.snapshotId)) {
+      dropped.push({ event, reason: 'snapshot-missing' })
+      continue
+    }
+    persisted.push({
+      ...event,
+      // These relationships are nullable in the schema. A parent can be
+      // deleted between enqueue and flush, so preserve the snapshot event
+      // while allowing SQLite's intended SET NULL semantics to apply.
+      chatSessionId: event.chatSessionId && sessionIds.has(event.chatSessionId)
+        ? event.chatSessionId
+        : null,
+      runId: event.runId && runIds.has(event.runId) ? event.runId : null,
+    })
+  }
+  return { events: persisted, dropped }
 }
 
 function removeJournalIfIdle(journal: SnapshotJournal): void {

--- a/apps/server/src/modules/chat-runtime/run-snapshot-journal.ts
+++ b/apps/server/src/modules/chat-runtime/run-snapshot-journal.ts
@@ -2,8 +2,6 @@ import type { BackendRunSnapshotEvent } from '@cradle/db'
 import {
   backendRunSnapshotEvents,
   backendRunSnapshots,
-  backendRuns,
-  sessions,
 } from '@cradle/db'
 import { eq, inArray } from 'drizzle-orm'
 
@@ -316,57 +314,34 @@ function prepareSnapshotEventInserts(
     return { events: [], dropped: [] }
   }
 
-  const snapshotIds = new Set(
+  const snapshotParents = new Map(
     tx
-      .select({ id: backendRunSnapshots.id })
+      .select({
+        id: backendRunSnapshots.id,
+        chatSessionId: backendRunSnapshots.chatSessionId,
+        runId: backendRunSnapshots.runId,
+      })
       .from(backendRunSnapshots)
       .where(inArray(backendRunSnapshots.id, events.map(event => event.snapshotId)))
       .all()
-      .map(row => row.id),
+      .map(row => [row.id, row] as const),
   )
-  const sessionIdValues = [...new Set(
-    events.flatMap(event => event.chatSessionId ? [event.chatSessionId] : []),
-  )]
-  const sessionIds = sessionIdValues.length === 0
-    ? new Set<string>()
-    : new Set(
-        tx
-          .select({ id: sessions.id })
-          .from(sessions)
-          .where(inArray(sessions.id, sessionIdValues))
-          .all()
-          .map(row => row.id),
-      )
-  const runIdValues = [...new Set(
-    events.flatMap(event => event.runId ? [event.runId] : []),
-  )]
-  const runIds = runIdValues.length === 0
-    ? new Set<string>()
-    : new Set(
-        tx
-          .select({ id: backendRuns.id })
-          .from(backendRuns)
-          .where(inArray(backendRuns.id, runIdValues))
-          .all()
-          .map(row => row.id),
-      )
 
   const persisted: BackendRunSnapshotEvent[] = []
   const dropped: PreparedSnapshotEventInserts['dropped'] = []
   for (const event of events) {
-    if (!snapshotIds.has(event.snapshotId)) {
+    const parent = snapshotParents.get(event.snapshotId)
+    if (!parent) {
       dropped.push({ event, reason: 'snapshot-missing' })
       continue
     }
     persisted.push({
       ...event,
-      // These relationships are nullable in the schema. A parent can be
-      // deleted between enqueue and flush, so preserve the snapshot event
-      // while allowing SQLite's intended SET NULL semantics to apply.
-      chatSessionId: event.chatSessionId && sessionIds.has(event.chatSessionId)
-        ? event.chatSessionId
-        : null,
-      runId: event.runId && runIds.has(event.runId) ? event.runId : null,
+      // These relationships are nullable in the schema. The snapshot parent
+      // is the canonical owner of both values, and SQLite sets them to NULL
+      // when the session or run is deleted before this event is flushed.
+      chatSessionId: parent.chatSessionId,
+      runId: parent.runId,
     })
   }
   return { events: persisted, dropped }

--- a/apps/server/tests/run-snapshot.test.ts
+++ b/apps/server/tests/run-snapshot.test.ts
@@ -32,6 +32,10 @@ import {
   getRunSnapshots,
   maintainRunSnapshots,
 } from '../src/modules/chat-runtime/run-snapshot'
+import {
+  flushRunSnapshotWriteBehind,
+  releaseRunSnapshotContext,
+} from '../src/modules/chat-runtime/run-snapshot-journal'
 import { createRunChunkSequencer } from '../src/modules/chat-runtime/stream/run-chunk-sequencer'
 
 function restoreEnv(name: string, previousValue: string | undefined): void {
@@ -194,6 +198,54 @@ describe('run snapshot recording', () => {
         .toHaveLength(0)
 
       expect(getRunSnapshot(secondRunId)?.events).toHaveLength(1)
+    })
+  })
+
+  it('drops queued events when a snapshot context is released before write-behind flush', async () => {
+    await withTempDataDir(() => {
+      const runId = `run-${randomUUID()}`
+      const activeRun = setUpRun(`session-${randomUUID()}`, runId)
+
+      releaseRunSnapshotContext(db(), activeRun.runSnapshotId!)
+
+      expect(() => flushRunSnapshotWriteBehind()).not.toThrow()
+      expect(db().select().from(backendRunSnapshotEvents).all()).toHaveLength(0)
+    })
+  })
+
+  it('nulls deleted session and run foreign keys instead of failing a queued event batch', async () => {
+    await withTempDataDir(() => {
+      const sessionId = `session-${randomUUID()}`
+      const runId = `run-${randomUUID()}`
+      const activeRun = setUpRun(sessionId, runId)
+
+      db().delete(sessions).where(eq(sessions.id, sessionId)).run()
+
+      const snapshots = getRunSnapshots({ includeEvents: true })
+      expect(snapshots).toHaveLength(1)
+      expect(snapshots[0].events).toHaveLength(1)
+      expect(snapshots[0].events[0]).toEqual(expect.objectContaining({
+        snapshotId: activeRun.runSnapshotId!,
+        chatSessionId: null,
+        runId: null,
+      }))
+    })
+  })
+
+  it('drops an orphaned snapshot event without blocking other snapshots in the batch', async () => {
+    await withTempDataDir(() => {
+      const first = setUpRun(`session-${randomUUID()}`, `run-${randomUUID()}`)
+      const second = setUpRun(`session-${randomUUID()}`, `run-${randomUUID()}`)
+
+      db()
+        .delete(backendRunSnapshots)
+        .where(eq(backendRunSnapshots.id, first.runSnapshotId!))
+        .run()
+
+      const snapshots = getRunSnapshots({ includeEvents: true })
+      expect(snapshots).toHaveLength(1)
+      expect(snapshots[0].id).toBe(second.runSnapshotId)
+      expect(snapshots[0].events).toHaveLength(1)
     })
   })
 


### PR DESCRIPTION
## Summary

- Remove queued snapshot events when a snapshot context is released before write-behind flush.
- Normalize deleted nullable session/run references to `NULL` instead of failing the event insert.
- Drop orphaned events whose snapshot parent no longer exists, with structured warning logs.
- Prevent orphaned events from blocking other snapshots in the same flush batch.
- Add regression coverage for cleanup races, deleted parents, and mixed valid/orphaned batches.

Fixes #172

## Validation

- `git diff --check` passes.
- Added focused server regression tests in `apps/server/tests/run-snapshot.test.ts`.
- Local dependency installation was blocked by the environment's network approval, so Vitest/typecheck will be verified by GitHub Actions.