### PR TITLE
fix(chat-runtime): support workspace-less Jarvis skills

### DIFF
--- a/apps/server/src/modules/chat-runtime-providers/codex/provider.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/provider.test.ts
@@ -15,7 +15,6 @@ import type {
   RuntimeUserInputRequest,
   RuntimeUserInputResolution,
 } from '../../chat-runtime/runtime-provider-types'
-import { resolveRuntimeSkillPaths } from '../../chat-runtime/chat-runtime-provider-registry'
 import {
   RUNTIME_CODE_REVIEW_COMMAND_ACTION_ID,
   RUNTIME_USAGE_COMMAND_ACTION_ID,
@@ -770,7 +769,8 @@ function createForkedNonSubagentThreadRecord() {
 describe('codexProvider app-server integration', () => {
   it('streams a Codex turn for a workspace-less Jarvis session', async () => {
     const client = new FakeCodexAppServerClient({})
-    const provider = createProviderWithClients([client], resolveRuntimeSkillPaths)
+    const resolveSkillPaths = vi.fn(() => ['/tmp/cradle-skill'])
+    const provider = createProviderWithClients([client], resolveSkillPaths)
 
     const stream = provider.streamTurn({
       runId: 'run-jarvis-codex-no-workspace',
@@ -804,7 +804,8 @@ describe('codexProvider app-server integration', () => {
     })
 
     await drainPromise
-    expect(client.skillExtraRootsRequests).toHaveLength(1)
+    expect(resolveSkillPaths).toHaveBeenCalledWith('')
+    expect(client.skillExtraRootsRequests).toEqual([{ extraRoots: ['/tmp/cradle-skill'] }])
   })
 
   it('projects Codex app-server capabilities into provider-owned UI slots', async () => {

--- a/apps/server/src/modules/chat-runtime-providers/codex/provider.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/provider.test.ts
@@ -15,6 +15,7 @@ import type {
   RuntimeUserInputRequest,
   RuntimeUserInputResolution,
 } from '../../chat-runtime/runtime-provider-types'
+import { resolveRuntimeSkillPaths } from '../../chat-runtime/chat-runtime-provider-registry'
 import {
   RUNTIME_CODE_REVIEW_COMMAND_ACTION_ID,
   RUNTIME_USAGE_COMMAND_ACTION_ID,
@@ -565,7 +566,11 @@ function createProfile(config: Record<string, unknown> = {}): RuntimeProviderTar
   }
 }
 
-function createRuntimeSession(providerSessionId: string | null = null, chatSessionId = 'chat-session-1'): RuntimeSession {
+function createRuntimeSession(
+  providerSessionId: string | null = null,
+  chatSessionId = 'chat-session-1',
+  workspacePath: string | null = '/tmp/cradle-workspace',
+): RuntimeSession {
   return {
     id: chatSessionId,
     chatSessionId,
@@ -573,7 +578,7 @@ function createRuntimeSession(providerSessionId: string | null = null, chatSessi
     runtimeKind: 'codex',
     providerSessionId,
     providerStateSnapshot: JSON.stringify({
-      workspacePath: '/tmp/cradle-workspace',
+      ...(workspacePath !== null ? { workspacePath } : {}),
       models: { currentModelId: null },
     }),
   }
@@ -625,11 +630,14 @@ function createProvider(client: FakeCodexAppServerClient): CodexProvider {
   return createProviderWithClients([client])
 }
 
-function createProviderWithClients(clients: FakeCodexAppServerClient[]): CodexProvider {
+function createProviderWithClients(
+  clients: FakeCodexAppServerClient[],
+  resolveSkillPaths: (workspacePath: string) => string[] = () => ['/tmp/cradle-skill'],
+): CodexProvider {
   let index = 0
   return new CodexProvider({
     readSecret: () => 'sk-secret',
-    resolveSkillPaths: () => ['/tmp/cradle-skill'],
+    resolveSkillPaths,
     recordObservability: vi.fn(),
     createAppServerClient: (options) => {
       const client = clients[Math.min(index, clients.length - 1)]!
@@ -760,6 +768,45 @@ function createForkedNonSubagentThreadRecord() {
 }
 
 describe('codexProvider app-server integration', () => {
+  it('streams a Codex turn for a workspace-less Jarvis session', async () => {
+    const client = new FakeCodexAppServerClient({})
+    const provider = createProviderWithClients([client], resolveRuntimeSkillPaths)
+
+    const stream = provider.streamTurn({
+      runId: 'run-jarvis-codex-no-workspace',
+      runtimeSession: createRuntimeSession(null, 'jarvis-session-1', null),
+      profile: createProfile(),
+      message: createUserMessage('Hello from Jarvis'),
+      workspaceId: null,
+      workspacePath: '',
+    })
+    const drainPromise = drainStream(stream)
+
+    await vi.waitFor(() => {
+      expect(client.requests.map(request => request.method)).toContain('turn/start')
+    })
+
+    client.pushNotification({
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'codex-thread-1',
+        turnId: 'codex-turn-1',
+        itemId: 'jarvis-assistant-message-1',
+        delta: 'Hello',
+      },
+    })
+    client.pushNotification({
+      method: 'turn/completed',
+      params: {
+        threadId: 'codex-thread-1',
+        turn: { id: 'codex-turn-1', status: 'completed' },
+      },
+    })
+
+    await drainPromise
+    expect(client.skillExtraRootsRequests).toHaveLength(1)
+  })
+
   it('projects Codex app-server capabilities into provider-owned UI slots', async () => {
     const client = new FakeCodexAppServerClient({})
     const provider = createProvider(client)

--- a/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-turn-context.ts
+++ b/apps/server/src/modules/chat-runtime-providers/codex/turn/stream-turn-context.ts
@@ -93,7 +93,7 @@ export function resolveCodexStreamTurnContext(
   }
 
   const snapshot = readWorkspaceProviderStateSnapshot(input.runtimeSession.providerStateSnapshot)
-  const workspacePath = snapshot.workspacePath ?? '.'
+  const workspacePath = snapshot.workspacePath ?? input.workspacePath ?? '.'
   const agentId = input.agentId ?? snapshot.agentId ?? null
   const runtimeContext = resolveCodexRuntimeContext(workspacePath, agentId)
   const runtimeSettings = input.providerOptions?.runtimeSettings

--- a/apps/server/src/modules/chat-runtime/chat-runtime-provider-registry.test.ts
+++ b/apps/server/src/modules/chat-runtime/chat-runtime-provider-registry.test.ts
@@ -15,12 +15,12 @@ function createTempDir(): string {
   return tempDir
 }
 
-function createSkillPackage(root: string): string {
-  const skillDir = join(root, 'plugin-extra-root')
+function createSkillPackage(root: string, name = 'plugin-extra-root'): string {
+  const skillDir = join(root, name)
   fs.mkdirSync(skillDir, { recursive: true })
   fs.writeFileSync(join(skillDir, 'SKILL.md'), [
     '---',
-    'name: plugin-extra-root',
+    `name: ${name}`,
     'description: Plugin extra root',
     '---',
     '',
@@ -54,6 +54,22 @@ describe('runtime skill path resolution', () => {
 
     resetPluginSkillRegistry()
     expect(resolveRuntimeSkillPaths(workspacePath)).not.toContain(skillDir)
+  })
+
+  it('skips the workspace skill scope for workspace-less runtime sessions', () => {
+    const root = createTempDir()
+    const workspacePath = join(root, 'workspace')
+    const pluginSkillDir = createSkillPackage(root)
+    const workspaceSkillDir = createSkillPackage(join(workspacePath, '.cradle', 'skills'), 'workspace-only')
+    registerPluginSkill('@cradle/plugin-extra-root', {
+      name: 'plugin-extra-root',
+      description: 'Plugin extra root',
+      skillFile: join(pluginSkillDir, 'SKILL.md'),
+    })
+
+    expect(resolveRuntimeSkillPaths('')).toContain(pluginSkillDir)
+    expect(resolveRuntimeSkillPaths('')).not.toContain(workspaceSkillDir)
+    expect(resolveRuntimeSkillPaths(workspacePath)).toContain(workspaceSkillDir)
   })
 })
 

--- a/apps/server/src/modules/chat-runtime/chat-runtime-provider-registry.ts
+++ b/apps/server/src/modules/chat-runtime/chat-runtime-provider-registry.ts
@@ -412,10 +412,10 @@ export function resolveRuntimeSkillPaths(workspacePath: string): string[] {
     return [...cached.paths]
   }
 
-  const roots = [
-    resolveScopeRoot('builtin', {}),
-    resolveScopeRoot('workspace', { workspacePath }),
-  ]
+  const roots = [resolveScopeRoot('builtin', {})]
+  if (workspacePath.trim().length > 0) {
+    roots.push(resolveScopeRoot('workspace', { workspacePath }))
+  }
   const paths: string[] = []
   const seenPaths = new Set<string>()
   const pushPath = (skillDir: string): void => {


### PR DESCRIPTION
## Summary

- Skip the workspace skill scope when a runtime session has no workspace while preserving builtin and plugin skills.
- Preserve the turn-provided empty workspace path when older Codex snapshots omit `workspacePath`, instead of falling back immediately to the server working directory.
- Add resolver coverage and a Codex app-server regression test for a workspace-less Jarvis session.

## Root cause

Jarvis can be configured to use the Codex runtime and creates hidden chat sessions with `workspaceId: null`. Session context projects that state as an empty workspace path, but runtime skill discovery unconditionally resolved the workspace skill scope. `resolveScopeRoot('workspace', ...)` then threw `workspacePath is required for workspace skills` before the Codex turn could start.

Older provider snapshots could also omit `workspacePath`; the Codex stream context ignored the empty turn input and fell back to `.`, which risked treating the server working directory as the Jarvis workspace.

## Impact

Workspace-less Jarvis sessions can start Codex turns without crashing during skill initialization. Builtin and plugin skills remain available, and Cradle does not project server-local workspace skills into Jarvis.

## Validation

- `git diff --check`
- Remote comparison confirms one commit and exactly four modified files.
- Added focused server regression tests for empty workspace skill resolution and `workspaceId: null` Jarvis/Codex streaming.
- The local checkout has no installed dependencies; dependency resolution was blocked by the environment's network approval, so Vitest/typecheck are left to GitHub Actions.