### PR TITLE
fix(chat): use generated SDK for quick questions

### DIFF
--- a/apps/web/src/features/chat/commands/chat-response-command.ts
+++ b/apps/web/src/features/chat/commands/chat-response-command.ts
@@ -13,6 +13,7 @@ import {
   postChatSessionsBySessionIdMessagesByMessageIdPlanImplementationApproval,
   postChatSessionsBySessionIdQueue,
   postChatSessionsBySessionIdQueueReorder,
+  postChatSessionsBySessionIdQuickQuestion,
   postChatSessionsBySessionIdSideChat,
   postChatSessionsBySessionIdSteer,
   postChatSessionsBySessionIdToolApprovalByRequestId,
@@ -310,12 +311,20 @@ export async function startQuickQuestion(args: {
   sessionId: string
   body: ChatQuickQuestionRequestBody
   signal?: AbortSignal
-}): Promise<Response> {
-  return requestChatRuntimeSse({
-    sessionId: args.sessionId,
-    route: 'quick-question',
+}) {
+  return postChatSessionsBySessionIdQuickQuestion({
+    path: { sessionId: args.sessionId },
     body: args.body,
     signal: args.signal,
+    // A quick question is a single ephemeral turn. Do not reconnect it as a
+    // new provider request after a transport failure.
+    sseMaxRetryAttempts: 1,
+    onSseError: error => {
+      if (args.signal?.aborted) {
+        return
+      }
+      throw error instanceof Error ? error : new Error(String(error))
+    },
   })
 }
 

--- a/apps/web/src/features/chat/commands/chat-response-command.ts
+++ b/apps/web/src/features/chat/commands/chat-response-command.ts
@@ -319,7 +319,7 @@ export async function startQuickQuestion(args: {
     // A quick question is a single ephemeral turn. Do not reconnect it as a
     // new provider request after a transport failure.
     sseMaxRetryAttempts: 1,
-    onSseError: error => {
+    onSseError: (error) => {
       if (args.signal?.aborted) {
         return
       }

--- a/apps/web/src/features/chat/composer/composer-slots/quick-question-slot-state.tsx
+++ b/apps/web/src/features/chat/composer/composer-slots/quick-question-slot-state.tsx
@@ -20,7 +20,6 @@ import { STREAMDOWN_RENDER_OPTIONS } from '~/store/streamdown'
 
 import { startQuickQuestion } from '../../commands/chat-response-command'
 import { MarkdownFileLink } from '../../rendering/markdown-file-link'
-import { buildRawUIMessageChunkStreamFromResponse } from '../../transport/sse-chat-transport'
 import { ComposerSlotIconAction, ComposerSlotShell } from './composer-slot-shell'
 import type { ComposerQuickQuestionSlotActions } from './types'
 
@@ -44,30 +43,37 @@ export function QuickQuestionSlotState({
       return
     }
 
-    const abortController = new AbortController()
     setContent('')
     setErrorText(null)
     setStreaming(true)
 
-    void streamQuickQuestion({
-      question,
-      sessionId: quickQuestion.sessionId,
-      signal: abortController.signal,
-      onTextDelta: delta => setContent(prev => prev + delta),
-    })
-      .catch((error) => {
-        if (error instanceof Error && error.name === 'AbortError') {
-          return
-        }
-        setErrorText(error instanceof Error ? error.message : 'Failed to stream quick question.')
+    let abortController: AbortController | null = null
+    const startTimer = window.setTimeout(() => {
+      const controller = new AbortController()
+      abortController = controller
+      void streamQuickQuestion({
+        question,
+        sessionId: quickQuestion.sessionId,
+        signal: controller.signal,
+        onTextDelta: delta => setContent(prev => prev + delta),
       })
-      .finally(() => {
-        if (!abortController.signal.aborted) {
-          setStreaming(false)
-        }
-      })
+        .catch((error) => {
+          if (error instanceof Error && error.name === 'AbortError') {
+            return
+          }
+          setErrorText(error instanceof Error ? error.message : 'Failed to stream quick question.')
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setStreaming(false)
+          }
+        })
+    }, 0)
 
-    return () => abortController.abort()
+    return () => {
+      window.clearTimeout(startTimer)
+      abortController?.abort()
+    }
   }, [quickQuestion.open, quickQuestion.sessionId, question])
 
   useEffect(() => {
@@ -155,28 +161,15 @@ async function streamQuickQuestion({
   signal: AbortSignal
   onTextDelta: (delta: string) => void
 }) {
-  const response = await startQuickQuestion({
+  const { stream } = await startQuickQuestion({
     sessionId,
     body: { question },
     signal,
   })
-  if (!response.ok) {
-    const body = await response.text().catch(() => '')
-    throw new Error(`Failed to start quick question: ${response.status} ${body}`)
-  }
-
-  const reader = buildRawUIMessageChunkStreamFromResponse(response).getReader()
-  try {
-    while (true) {
-      const result = await reader.read()
-      if (result.done) {
-        break
-      }
-      readQuickQuestionChunk(result.value, onTextDelta)
-    }
-  }
-  finally {
-    reader.releaseLock()
+  for await (const chunk of stream) {
+    // The OpenAPI response is intentionally represented as an opaque SSE
+    // payload; the generated client has already decoded each data frame.
+    readQuickQuestionChunk(chunk as UIMessageChunk, onTextDelta)
   }
 }
 

--- a/apps/web/src/features/chat/composer/composer-slots/quick-question-slot-state.tsx
+++ b/apps/web/src/features/chat/composer/composer-slots/quick-question-slot-state.tsx
@@ -10,8 +10,8 @@ import {
   QuestionLine as MessageCircleQuestionIcon,
   WarningLine as AlertTriangleIcon,
 } from '@mingcute/react'
-import { uiMessageChunkSchema } from 'ai'
 import type { UIMessageChunk } from 'ai'
+import { uiMessageChunkSchema } from 'ai'
 import type { AnchorHTMLAttributes } from 'react'
 import { useEffect, useRef, useState } from 'react'
 

--- a/apps/web/src/features/chat/composer/composer-slots/quick-question-slot-state.tsx
+++ b/apps/web/src/features/chat/composer/composer-slots/quick-question-slot-state.tsx
@@ -10,6 +10,7 @@ import {
   QuestionLine as MessageCircleQuestionIcon,
   WarningLine as AlertTriangleIcon,
 } from '@mingcute/react'
+import { uiMessageChunkSchema } from 'ai'
 import type { UIMessageChunk } from 'ai'
 import type { AnchorHTMLAttributes } from 'react'
 import { useEffect, useRef, useState } from 'react'
@@ -167,10 +168,29 @@ async function streamQuickQuestion({
     signal,
   })
   for await (const chunk of stream) {
-    // The OpenAPI response is intentionally represented as an opaque SSE
-    // payload; the generated client has already decoded each data frame.
-    readQuickQuestionChunk(chunk as UIMessageChunk, onTextDelta)
+    const parsedChunk = await parseQuickQuestionChunk(chunk)
+    if (parsedChunk) {
+      readQuickQuestionChunk(parsedChunk, onTextDelta)
+    }
   }
+}
+
+async function parseQuickQuestionChunk(value: unknown): Promise<UIMessageChunk | null> {
+  if (value === '[DONE]') {
+    return null
+  }
+
+  const schema = uiMessageChunkSchema()
+  if (!schema.validate) {
+    throw new Error('AI SDK UIMessageChunk schema is unavailable.')
+  }
+
+  const input = typeof value === 'string' ? JSON.parse(value) as unknown : value
+  const result = await schema.validate(input)
+  if (!result.success) {
+    throw result.error
+  }
+  return result.value
 }
 
 function readQuickQuestionChunk(


### PR DESCRIPTION
## Summary

- fix React StrictMode replay causing duplicate Codex `/btw` requests
- route quick-question through the generated `api-gen` SSE SDK
- keep quick-question turns single-shot by disabling SSE reconnects
- preserve abort and stream error handling

## Validation

- `git diff --check` passes
- local typecheck/E2E could not run because dependencies are not installed and network approval was unavailable