### PR TITLE
fix(server): repair CI lifecycle regressions

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -38,6 +38,7 @@ import { registerMessageBlobBackfillMaintenance } from './modules/chat-runtime/m
 import { registerMessageSteerSplitBackfillMaintenance } from './modules/chat-runtime/message-steer-split-backfill'
 import { runRegistry } from './modules/chat-runtime/run-registry'
 import { flushRunSnapshotWriteBehind } from './modules/chat-runtime/run-snapshot-journal'
+import { registerChatRuntimeSessionLifecycleHandlers } from './modules/chat-runtime/runtime'
 import { registerTurnCheckpointHooks } from './modules/chat-runtime/turn-checkpoint-hooks'
 import { ClaudeUsageReconciliationScheduler } from './modules/chat-runtime-providers/claude-agent/usage-reconciliation-scheduler'
 import { readCodexChatgptAuthCredential } from './modules/chat-runtime-providers/codex/app-server/chatgpt-auth'
@@ -168,6 +169,7 @@ async function runBootstrapPhase<T>(
 }
 
 export async function createServerContractApp(options: CreateServerContractAppOptions = {}) {
+  registerChatRuntimeSessionLifecycleHandlers()
   configureProviderExtensionHost({
     findActiveRunId: (providerTargetId) => {
       const activeRun = runRegistry.listActiveRuns()

--- a/apps/server/src/modules/chat-runtime/run-snapshot-journal.ts
+++ b/apps/server/src/modules/chat-runtime/run-snapshot-journal.ts
@@ -154,6 +154,17 @@ export function flushRunSnapshotWriteBehind(): void {
   }
 }
 
+/**
+ * Discard server-local write-behind state before the test reset capability
+ * removes its owning database rows.
+ */
+export function discardRunSnapshotWriteBehind(): void {
+  for (const journal of journals.values()) {
+    cancelTimer(journal)
+  }
+  journals.clear()
+}
+
 export function releaseRunSnapshotContext(database: SnapshotDatabase, snapshotId: string): void {
   const journal = journals.get(database)
   if (!journal) {

--- a/apps/server/src/modules/chat-runtime/runtime.ts
+++ b/apps/server/src/modules/chat-runtime/runtime.ts
@@ -288,9 +288,6 @@ function observeStaleActiveRunCompletion(activeRun: ActiveRun, fence: Parameters
   })
 }
 
-SessionService.onSessionArchived(releaseSideConversationsByParentSessionId)
-SessionService.onSessionCleanup(releaseSideConversationsByParentSessionId)
-
 function disposeRuntimeSessionResources(sessionId: string): void {
   const registry = getRuntimeRegistry()
   for (const item of registry.list()) {
@@ -303,8 +300,18 @@ function disposeRuntimeSessionResources(sessionId: string): void {
   }
 }
 
-SessionService.onSessionArchived(disposeRuntimeSessionResources)
-SessionService.onSessionCleanup(disposeRuntimeSessionResources)
+let sessionLifecycleHandlersRegistered = false
+
+export function registerChatRuntimeSessionLifecycleHandlers(): void {
+  if (sessionLifecycleHandlersRegistered) {
+    return
+  }
+  sessionLifecycleHandlersRegistered = true
+  SessionService.onSessionArchived(releaseSideConversationsByParentSessionId)
+  SessionService.onSessionCleanup(releaseSideConversationsByParentSessionId)
+  SessionService.onSessionArchived(disposeRuntimeSessionResources)
+  SessionService.onSessionCleanup(disposeRuntimeSessionResources)
+}
 
 function publishRunChunk(runId: string, chunk: UIMessageChunk): void {
   const activeRun = runRegistry.getActiveRun(runId)

--- a/apps/server/src/modules/test-reset/index.ts
+++ b/apps/server/src/modules/test-reset/index.ts
@@ -15,6 +15,8 @@ import {
   automationRuns,
   backendCapabilitySnapshots,
   backendRuns,
+  backendRunSnapshotEvents,
+  backendRunSnapshots,
   backendSessionBindings,
   backgroundJobs,
   downloadCenterTasks,
@@ -42,6 +44,7 @@ import { sql } from 'drizzle-orm'
 import { Elysia, t } from 'elysia'
 
 import { db, getServerConfig } from '../../infra'
+import { discardRunSnapshotWriteBehind } from '../chat-runtime/run-snapshot-journal'
 import { abortAllRuns } from '../chat-runtime/runtime'
 
 const TABLES_IN_DELETION_ORDER = [
@@ -61,6 +64,8 @@ const TABLES_IN_DELETION_ORDER = [
   kanbanBoards,
   messages,
   usageLogs,
+  backendRunSnapshotEvents,
+  backendRunSnapshots,
   workThreads,
   works,
   sessions,
@@ -117,6 +122,7 @@ export const testReset = new Elysia({
   '/',
   async () => {
     await abortAllRuns()
+    discardRunSnapshotWriteBehind()
     const d = db()
     d.run(sql`PRAGMA foreign_keys = OFF`)
     try {

--- a/apps/server/tests/elysia-skeleton.test.ts
+++ b/apps/server/tests/elysia-skeleton.test.ts
@@ -431,13 +431,21 @@ describe('elysia migration skeleton', () => {
         method: 'DELETE',
       }))
       expect(deleteCreated.status).toBe(200)
-      expect(await deleteCreated.json()).toEqual({ ok: true })
+      expect(await deleteCreated.json()).toEqual({
+        ok: true,
+        removedSessionIds: [],
+        removedWorkIds: [],
+      })
 
       const deleteExplicit = await app.handle(new Request(`http://localhost/workspaces/${explicit.id}`, {
         method: 'DELETE',
       }))
       expect(deleteExplicit.status).toBe(200)
-      expect(await deleteExplicit.json()).toEqual({ ok: true })
+      expect(await deleteExplicit.json()).toEqual({
+        ok: true,
+        removedSessionIds: [],
+        removedWorkIds: [],
+      })
 
       const finalList = await app.handle(new Request('http://localhost/workspaces'))
       expect(finalList.status).toBe(200)

--- a/apps/server/tests/test-reset.test.ts
+++ b/apps/server/tests/test-reset.test.ts
@@ -2,11 +2,23 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { providerTargetModelCache, providerTargets } from '@cradle/db'
+import {
+  backendRuns,
+  backendRunSnapshotEvents,
+  backendRunSnapshots,
+  providerTargetModelCache,
+  providerTargets,
+  sessions,
+} from '@cradle/db'
 import { describe, expect, it } from 'vitest'
 
 import { createServerApp } from '../src/app'
 import { db, shutdownInfra } from '../src/infra'
+import {
+  enqueueRunSnapshotEvent,
+  flushRunSnapshotWriteBehind,
+  registerRunSnapshotContext,
+} from '../src/modules/chat-runtime/run-snapshot-journal'
 
 function createSkillSentinel(rootDir: string): string {
   const skillDir = join(rootDir, '.cradle', 'skills', 'sentinel')
@@ -42,6 +54,88 @@ function restoreEnv(previous: {
 }
 
 describe('test-reset capability', () => {
+  it('discards queued run snapshot writes before deleting their owning rows', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'cradle-data-'))
+    const previous = {
+      dataDir: process.env.CRADLE_DATA_DIR,
+      home: process.env.HOME,
+      nodeEnv: process.env.NODE_ENV,
+    }
+    process.env.CRADLE_DATA_DIR = dataDir
+    process.env.HOME = join(dataDir, 'home')
+    process.env.NODE_ENV = 'test'
+
+    try {
+      const app = await createServerApp({ startBackgroundTasks: false })
+      const store = db()
+      const sessionId = 'test-reset-snapshot-session'
+      const runId = 'test-reset-snapshot-run'
+      const snapshotId = 'test-reset-snapshot'
+      store.insert(sessions).values({
+        id: sessionId,
+        title: 'Snapshot reset session',
+        titleSource: 'initial',
+        runtimeKind: 'standard',
+        createdAt: 1,
+        updatedAt: 1,
+      }).run()
+      store.insert(backendRuns).values({
+        id: runId,
+        bindingId: null,
+        chatSessionId: sessionId,
+        messageId: null,
+        origin: 'user',
+        status: 'streaming',
+        stopReason: null,
+        errorText: null,
+        startedAt: 1,
+        finishedAt: null,
+      }).run()
+      store.insert(backendRunSnapshots).values({
+        id: snapshotId,
+        schemaVersion: 1,
+        traceId: runId,
+        chatSessionId: sessionId,
+        runId,
+        runtimeKind: 'standard',
+        status: 'running',
+        startedAt: 1,
+      }).run()
+      registerRunSnapshotContext(store, snapshotId, null)
+      enqueueRunSnapshotEvent(store, {
+        id: 'test-reset-snapshot-event',
+        snapshotId,
+        chatSessionId: sessionId,
+        runId,
+        seq: 0,
+        phase: 'run_started',
+        chunkType: null,
+        toolCallId: null,
+        toolName: null,
+        modelId: null,
+        promptTokens: null,
+        completionTokens: null,
+        totalTokens: null,
+        estimatedCostUsd: null,
+        occurredAt: 1,
+        durationMs: null,
+        payloadJson: '{}',
+      })
+
+      const res = await app.handle(new Request('http://localhost/test/reset', { method: 'POST' }))
+
+      expect(res.status).toBe(200)
+      expect(() => flushRunSnapshotWriteBehind()).not.toThrow()
+      expect(store.select().from(backendRunSnapshots).all()).toHaveLength(0)
+      expect(store.select().from(backendRunSnapshotEvents).all()).toHaveLength(0)
+    }
+    finally {
+      shutdownInfra()
+      restoreEnv(previous)
+      rmSync(dataDir, { recursive: true, force: true })
+    }
+  })
+
   it('does not delete global skills outside the isolated test data root', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'cradle-data-'))
     const externalHome = mkdtempSync(join(tmpdir(), 'cradle-home-'))


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Move chat-runtime session lifecycle registration into the server composition root so importing provider/session modules no longer triggers a temporal-dead-zone cycle. Align workspace deletion contract assertions with the expanded response payload. Make the E2E test reset discard run-snapshot write-behind state and delete snapshot rows, preventing stale queued events from entering a permanent SQLite foreign-key retry loop and blocking durable queue recovery after reload.

## Summary

Move chat-runtime session lifecycle registration into the server composition root so importing provider/session modules no longer triggers a temporal-dead-zone cycle. Align workspace deletion contract assertions with the expanded response payload. Make the E2E test reset discard run-snapshot write-behind state and delete snapshot rows, preventing stale queued events from entering a permanent SQLite foreign-key retry loop and blocking durable queue recovery after reload.

## Test plan

- `pnpm --filter @cradle/server exec vitest run tests/run-snapshot.test.ts src/modules/issue-agent/service.test.ts src/modules/session/service.test.ts src/modules/session-group/service.test.ts src/modules/chat-runtime/stream/checkpoint-store.test.ts tests/elysia-skeleton.test.ts` (43 passed)
- `pnpm --filter @cradle/server exec vitest run tests/test-reset.test.ts tests/run-snapshot.test.ts` (18 passed)
- `pnpm --filter @cradle/server typecheck`
- `pnpm --filter @cradle/server check:boundaries`
- `pnpm exec eslint apps/server/src/app.ts apps/server/src/modules/chat-runtime/runtime.ts apps/server/src/modules/chat-runtime/run-snapshot-journal.ts apps/server/src/modules/test-reset/index.ts apps/server/tests/elysia-skeleton.test.ts apps/server/tests/test-reset.test.ts`
- `git diff --check`

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is declined or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** See Problem / pressure. Detailed directive transcript not attached (author-side sharing consent pending).
- **Constraints / non-goals:** N/A
- **Decision rationale:** N/A
- **Deliberately not done:** N/A
- **Unknowns / confidence:** N/A

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)