### PR TITLE
fix(e2e): restore queued stream UI and Codex approval bridge

### DIFF
--- a/apps/server/src/modules/chat-runtime/pending-tool-approval.test.ts
+++ b/apps/server/src/modules/chat-runtime/pending-tool-approval.test.ts
@@ -140,4 +140,43 @@ describe('pending runtime tool approval', () => {
 
     expect(hasPendingRuntimeToolApproval('session-pending-tool-approval-3')).toBe(false)
   })
+
+  it('does not block the native approval on interaction event persistence', async () => {
+    let releaseRequestedEvent!: () => void
+    setRuntimeInteractionEventRecorder(async (_sessionId, events) => {
+      recordedEvents.push(...events)
+      if (events[0]?.type === 'InteractionRequested') {
+        await new Promise<void>((resolve) => {
+          releaseRequestedEvent = resolve
+        })
+      }
+    })
+
+    const pending = requestRuntimeToolApproval({
+      sessionId: 'session-pending-tool-approval-4',
+      runId: 'run-pending-tool-approval-4',
+      providerRequestId: 'request-4',
+      providerKind: 'openai-compatible',
+      runtimeKind: 'codex',
+      providerMethod: 'item/commandExecution/requestApproval',
+      toolCallId: 'server-request-request-4',
+      metadata: { command: 'echo approval' },
+    })
+
+    const submitted = submitRuntimeToolApprovalIfPending({
+      sessionId: 'session-pending-tool-approval-4',
+      requestId: 'request-4',
+      approved: true,
+    })
+
+    expect(submitted).toEqual({
+      requestId: 'request-4',
+      approved: true,
+    })
+    await expect(pending).resolves.toEqual({
+      requestId: 'request-4',
+      approved: true,
+    })
+    releaseRequestedEvent()
+  })
 })

--- a/apps/server/src/modules/chat-runtime/pending-tool-approval.test.ts
+++ b/apps/server/src/modules/chat-runtime/pending-tool-approval.test.ts
@@ -179,4 +179,34 @@ describe('pending runtime tool approval', () => {
     })
     releaseRequestedEvent()
   })
+
+  it('does not reject the native approval when the interaction recorder throws synchronously', async () => {
+    setRuntimeInteractionEventRecorder(() => {
+      throw new Error('synchronous interaction audit failure')
+    })
+
+    const pending = requestRuntimeToolApproval({
+      sessionId: 'session-pending-tool-approval-5',
+      runId: 'run-pending-tool-approval-5',
+      providerRequestId: 'request-5',
+      providerKind: 'openai-compatible',
+      runtimeKind: 'codex',
+      providerMethod: 'item/commandExecution/requestApproval',
+      toolCallId: 'server-request-request-5',
+      metadata: { command: 'echo approval' },
+    })
+
+    await expect(submitRuntimeToolApproval({
+      sessionId: 'session-pending-tool-approval-5',
+      requestId: 'request-5',
+      approved: true,
+    })).resolves.toEqual({
+      requestId: 'request-5',
+      approved: true,
+    })
+    await expect(pending).resolves.toEqual({
+      requestId: 'request-5',
+      approved: true,
+    })
+  })
 })

--- a/apps/server/src/modules/chat-runtime/pending-tool-approval.ts
+++ b/apps/server/src/modules/chat-runtime/pending-tool-approval.ts
@@ -65,7 +65,7 @@ export async function requestRuntimeToolApproval(
     })
   })
 
-  void recordRuntimeInteractionRequested({
+  void recordRuntimeToolApprovalInteraction(() => recordRuntimeInteractionRequested({
     sessionId: input.sessionId,
     runId: input.runId,
     requestId: input.providerRequestId,
@@ -75,7 +75,7 @@ export async function requestRuntimeToolApproval(
     providerMethod: input.providerMethod,
     toolCallId: input.toolCallId,
     createdAt,
-  }).catch(() => undefined)
+  }))
 
   return pending
 }
@@ -89,7 +89,6 @@ export async function submitRuntimeToolApproval(input: {
 }): Promise<RuntimeToolApprovalResolution> {
   const submitted = submitRuntimeToolApprovalIfPendingWithEvent(input)
   if (submitted) {
-    void submitted.eventRecorded.catch(() => undefined)
     return submitted.resolution
   }
 
@@ -112,7 +111,6 @@ export function submitRuntimeToolApprovalIfPending(input: {
   if (!submitted) {
     return null
   }
-  void submitted.eventRecorded.catch(() => undefined)
   return submitted.resolution
 }
 
@@ -122,7 +120,7 @@ function submitRuntimeToolApprovalIfPendingWithEvent(input: {
   approved: boolean
   scope?: 'once' | 'always'
   reason?: string
-}): { resolution: RuntimeToolApprovalResolution, eventRecorded: Promise<void> } | null {
+}): RuntimeToolApprovalResolution | null {
   const pendingKey = readPendingKey(input.sessionId, input.requestId)
   const pending = pendingToolApprovalById.get(pendingKey)
   if (!pending || pending.request.sessionId !== input.sessionId) {
@@ -137,18 +135,16 @@ function submitRuntimeToolApprovalIfPendingWithEvent(input: {
     ...(input.reason ? { reason: input.reason } : {}),
   }
   pending.resolve(resolution)
-  return {
-    resolution,
-    eventRecorded: recordRuntimeInteractionResolved({
-      sessionId: pending.request.sessionId,
-      runId: pending.request.runId,
-      requestId: input.requestId,
-      interactionKind: 'toolApproval',
-      resolution: 'submitted',
-      approved: input.approved,
-      updatedAt: currentUnixSeconds(),
-    }),
-  }
+  void recordRuntimeToolApprovalInteraction(() => recordRuntimeInteractionResolved({
+    sessionId: pending.request.sessionId,
+    runId: pending.request.runId,
+    requestId: input.requestId,
+    interactionKind: 'toolApproval',
+    resolution: 'submitted',
+    approved: input.approved,
+    updatedAt: currentUnixSeconds(),
+  }))
+  return resolution
 }
 
 export function rejectPendingToolApprovalsForRun(runId: string, error: Error): void {
@@ -158,14 +154,28 @@ export function rejectPendingToolApprovalsForRun(runId: string, error: Error): v
     }
     pendingToolApprovalById.delete(requestId)
     pending.reject(error)
-    void recordRuntimeInteractionResolved({
+    void recordRuntimeToolApprovalInteraction(() => recordRuntimeInteractionResolved({
       sessionId: pending.request.sessionId,
       runId: pending.request.runId,
       requestId: pending.request.providerRequestId,
       interactionKind: 'toolApproval',
       resolution: 'cancelled',
       updatedAt: currentUnixSeconds(),
-    }).catch(() => undefined)
+    }))
+  }
+}
+
+/**
+ * Interaction facts are diagnostic/audit records. Their recorder can be a
+ * synchronous database call, so catch both an immediate throw and an async
+ * rejection without allowing either to abort the native approval handshake.
+ */
+function recordRuntimeToolApprovalInteraction(record: () => Promise<void>): Promise<void> {
+  try {
+    return record().catch(() => undefined)
+  }
+  catch {
+    return Promise.resolve()
   }
 }
 

--- a/apps/server/src/modules/chat-runtime/pending-tool-approval.ts
+++ b/apps/server/src/modules/chat-runtime/pending-tool-approval.ts
@@ -89,7 +89,7 @@ export async function submitRuntimeToolApproval(input: {
 }): Promise<RuntimeToolApprovalResolution> {
   const submitted = submitRuntimeToolApprovalIfPendingWithEvent(input)
   if (submitted) {
-    return submitted.resolution
+    return submitted
   }
 
   throw new AppError({
@@ -111,7 +111,7 @@ export function submitRuntimeToolApprovalIfPending(input: {
   if (!submitted) {
     return null
   }
-  return submitted.resolution
+  return submitted
 }
 
 function submitRuntimeToolApprovalIfPendingWithEvent(input: {

--- a/apps/server/src/modules/chat-runtime/pending-tool-approval.ts
+++ b/apps/server/src/modules/chat-runtime/pending-tool-approval.ts
@@ -65,27 +65,17 @@ export async function requestRuntimeToolApproval(
     })
   })
 
-  try {
-    await recordRuntimeInteractionRequested({
-      sessionId: input.sessionId,
-      runId: input.runId,
-      requestId: input.providerRequestId,
-      interactionKind: 'toolApproval',
-      providerKind: input.providerKind,
-      runtimeKind: input.runtimeKind,
-      providerMethod: input.providerMethod,
-      toolCallId: input.toolCallId,
-      createdAt,
-    })
-  }
- catch (error) {
-    const current = pendingToolApprovalById.get(pendingKey)
-    if (current?.request === input) {
-      pendingToolApprovalById.delete(pendingKey)
-      current.reject(error instanceof Error ? error : new Error(String(error)))
-    }
-    throw error
-  }
+  void recordRuntimeInteractionRequested({
+    sessionId: input.sessionId,
+    runId: input.runId,
+    requestId: input.providerRequestId,
+    interactionKind: 'toolApproval',
+    providerKind: input.providerKind,
+    runtimeKind: input.runtimeKind,
+    providerMethod: input.providerMethod,
+    toolCallId: input.toolCallId,
+    createdAt,
+  }).catch(() => undefined)
 
   return pending
 }
@@ -99,7 +89,7 @@ export async function submitRuntimeToolApproval(input: {
 }): Promise<RuntimeToolApprovalResolution> {
   const submitted = submitRuntimeToolApprovalIfPendingWithEvent(input)
   if (submitted) {
-    await submitted.eventRecorded
+    void submitted.eventRecorded.catch(() => undefined)
     return submitted.resolution
   }
 

--- a/apps/server/tests/download-center.test.ts
+++ b/apps/server/tests/download-center.test.ts
@@ -266,6 +266,9 @@ describe('download center service', () => {
     expect(service.events.listenerCount).toBe(1)
     controller.abort()
     expect(service.events.listenerCount).toBe(0)
+    const openingFrame = await reader.read()
+    expect(openingFrame.done).toBe(false)
+    expect(new TextDecoder().decode(openingFrame.value)).toBe(': cradle-event-stream-open\n\n')
     await expect(reader.read()).resolves.toEqual({ done: true, value: undefined })
   })
 

--- a/apps/web/src/features/chat/session/use-chat-session-driver.test.tsx
+++ b/apps/web/src/features/chat/session/use-chat-session-driver.test.tsx
@@ -2,6 +2,7 @@
 import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { openPassiveSessionStream } from './session-passive-stream'
 import { useChatSessionDriver } from './use-chat-session-driver'
 
 interface FakeSyncEngine {
@@ -9,6 +10,11 @@ interface FakeSyncEngine {
   stop: ReturnType<typeof vi.fn>
   reconcileRuntimeState: ReturnType<typeof vi.fn>
   updatePassiveStream: ReturnType<typeof vi.fn>
+  passiveStreamFactory: ((request: {
+    sessionId: string
+    messageId: string
+    onSettled: () => void
+  }) => unknown) | null
 }
 
 const mocks = vi.hoisted(() => {
@@ -78,7 +84,12 @@ vi.mock('./use-chat-session-types', () => ({
 }))
 vi.mock('./session-snapshot-projection', () => ({
   deriveSessionPassiveStreamProjection: () => ({ locallyDriven: false }),
-  deriveSessionSnapshotProjection: () => null,
+  deriveSessionSnapshotProjection: () => ({
+    messages: [],
+    passiveRunState: { messageIds: [], status: 'idle' },
+    failedMessage: null,
+    requestSnapshotRefresh: false,
+  }),
   deriveStableSessionSnapshotProjection: () => null,
 }))
 vi.mock('./session-passive-stream', () => ({ openPassiveSessionStream: vi.fn() }))
@@ -92,12 +103,13 @@ vi.mock('~/store/chat', () => ({
 }))
 vi.mock('./session-sync-engine', () => ({
   SessionSyncEngine: class {
-    constructor() {
+    constructor(options: { passiveStreamFactory: FakeSyncEngine['passiveStreamFactory'] }) {
       const engine: FakeSyncEngine = {
         start: vi.fn(),
         stop: vi.fn(),
         reconcileRuntimeState: vi.fn(),
         updatePassiveStream: vi.fn(),
+        passiveStreamFactory: options.passiveStreamFactory,
       }
       mocks.engineInstances.push(engine)
       return engine
@@ -149,5 +161,41 @@ describe('useChatSessionDriver', () => {
       locallyDriven: false,
       runtimeActiveRunMessageId: 'assistant-1',
     })
+  })
+
+  it('releases a settled passive lease when its terminal snapshot arrived first', () => {
+    const driver = renderHook(() => useChatSessionDriver('new-session'))
+
+    act(() => {
+      mocks.snapshotQuery = {
+        data: { pages: [{ revision: 1, rows: [], nextCursor: null }] },
+        dataUpdatedAt: 10,
+        isError: false,
+        isFetching: false,
+      }
+      driver.rerender()
+    })
+
+    const factory = mocks.engineInstances[0]?.passiveStreamFactory
+    expect(factory).not.toBeNull()
+    factory?.({
+      sessionId: 'new-session',
+      messageId: 'assistant-1',
+      onSettled: vi.fn(),
+    })
+    const passiveStreamInput = vi.mocked(openPassiveSessionStream).mock.calls[0]?.[0]
+    expect(passiveStreamInput).toBeDefined()
+
+    act(() => {
+      passiveStreamInput?.releaseStreamLeaseAfterSnapshot('assistant-1')
+      mocks.runtimeStatusQuery = {
+        data: { status: 'idle', activeRun: null },
+        dataUpdatedAt: 10,
+        isFetchedAfterMount: true,
+      }
+      driver.rerender()
+    })
+
+    expect(mocks.store.releaseStreamLease).toHaveBeenCalledWith('assistant-1')
   })
 })

--- a/apps/web/src/features/chat/session/use-chat-session-driver.test.tsx
+++ b/apps/web/src/features/chat/session/use-chat-session-driver.test.tsx
@@ -17,6 +17,15 @@ interface FakeSyncEngine {
   }) => unknown) | null
 }
 
+interface FakeRuntimeStatusQuery {
+  data: {
+    status: 'idle' | 'streaming'
+    activeRun: { runId: string, messageId: string } | null
+  }
+  dataUpdatedAt: number
+  isFetchedAfterMount: boolean
+}
+
 const mocks = vi.hoisted(() => {
   const engineInstances: FakeSyncEngine[] = []
   const store = {
@@ -30,6 +39,15 @@ const mocks = vi.hoisted(() => {
     releaseStreamLease: vi.fn(),
   }
 
+  const runtimeStatusQuery: FakeRuntimeStatusQuery = {
+    data: {
+      status: 'streaming',
+      activeRun: { runId: 'run-1', messageId: 'assistant-1' },
+    },
+    dataUpdatedAt: Number.MAX_SAFE_INTEGER,
+    isFetchedAfterMount: true,
+  }
+
   return {
     engineInstances,
     snapshotQuery: {
@@ -38,14 +56,7 @@ const mocks = vi.hoisted(() => {
       isError: false,
       isFetching: false,
     },
-    runtimeStatusQuery: {
-      data: {
-        status: 'streaming',
-        activeRun: { runId: 'run-1', messageId: 'assistant-1' },
-      },
-      dataUpdatedAt: Number.MAX_SAFE_INTEGER,
-      isFetchedAfterMount: true,
-    },
+    runtimeStatusQuery,
     controls: {
       scheduleSnapshotRefresh: vi.fn(),
       refreshQueue: vi.fn(),
@@ -134,6 +145,7 @@ describe('useChatSessionDriver', () => {
       dataUpdatedAt: Number.MAX_SAFE_INTEGER,
       isFetchedAfterMount: true,
     }
+    mocks.store.streamLeaseMap.clear()
     vi.clearAllMocks()
   })
 
@@ -187,6 +199,7 @@ describe('useChatSessionDriver', () => {
     expect(passiveStreamInput).toBeDefined()
 
     act(() => {
+      mocks.store.streamLeaseMap.set('assistant-1', { sessionId: 'new-session' })
       passiveStreamInput?.releaseStreamLeaseAfterSnapshot('assistant-1')
       mocks.runtimeStatusQuery = {
         data: { status: 'idle', activeRun: null },

--- a/apps/web/src/features/chat/session/use-chat-session-driver.ts
+++ b/apps/web/src/features/chat/session/use-chat-session-driver.ts
@@ -279,7 +279,10 @@ export function useChatSessionDriver(chatSessionId: string | null, active = true
     if (
       pendingPassiveStreamLeaseRelease
       && !snapshotRowsQuery.isFetching
-      && snapshotRowsQuery.dataUpdatedAt > pendingPassiveStreamLeaseRelease.requestedDataUpdatedAt
+      && (
+        snapshotRowsQuery.dataUpdatedAt > pendingPassiveStreamLeaseRelease.requestedDataUpdatedAt
+        || runtimeIdle
+      )
     ) {
       pendingPassiveStreamLeaseReleaseRef.current = null
       const state = useChatStore.getState()

--- a/e2e/src/support/helpers/codex-tool-scenario.ts
+++ b/e2e/src/support/helpers/codex-tool-scenario.ts
@@ -33,6 +33,7 @@ export function codexToolTurnExchanges(input: {
   toolName: string
   argumentsJson: string
   finalText?: string
+  continuationBodyTextExcludes?: string | readonly string[]
 }): SimulatorExchange[] {
   return [
     openAiFunctionCallExchange({
@@ -45,6 +46,7 @@ export function codexToolTurnExchanges(input: {
       label: `${input.label}-continuation`,
       text: input.finalText ?? CODEX_FINAL_TEXT,
       bodyTextIncludes: input.callId,
+      bodyTextExcludes: input.continuationBodyTextExcludes,
     }),
   ]
 }
@@ -137,5 +139,10 @@ export async function configureCodexApprovalSimulator(world: CradleWorld): Promi
       justification: 'E2E 需要在沙盒外写入探针文件',
       sandbox_permissions: 'require_escalated',
     }),
+    // The command string itself contains the output marker. Requiring the
+    // continuation not to contain the native failure envelope ensures this is
+    // an actual allow-and-execute round trip, not a failed tool call followed
+    // by a superficially successful scripted response.
+    continuationBodyTextExcludes: 'exec_command failed',
   })
 }

--- a/e2e/src/support/pages/chat.ts
+++ b/e2e/src/support/pages/chat.ts
@@ -533,14 +533,14 @@ export class ApprovalPage {
   private async clickResponse(selector: string): Promise<void> {
     const button = this.page.locator(selector)
     await expect(button).toBeVisible()
-    const bounds = await button.boundingBox()
-    if (!bounds) {
-      throw new Error(`Approval response button has no clickable bounds: ${selector}`)
+    try {
+      await button.click()
     }
-    await this.page.mouse.click(
-      bounds.x + bounds.width / 2,
-      bounds.y + bounds.height / 2,
-    )
+    catch (error) {
+      if (await this.card().isVisible()) {
+        throw error
+      }
+    }
   }
 
   async expectHidden(timeout = 20_000): Promise<void> {

--- a/e2e/src/support/pages/chat.ts
+++ b/e2e/src/support/pages/chat.ts
@@ -523,11 +523,24 @@ export class ApprovalPage {
   }
 
   async allow(): Promise<void> {
-    await this.page.locator('[data-testid="approval-allow-btn"]').click()
+    await this.clickResponse('[data-testid="approval-allow-btn"]')
   }
 
   async deny(): Promise<void> {
-    await this.page.locator('[data-testid="approval-deny-btn"]').click()
+    await this.clickResponse('[data-testid="approval-deny-btn"]')
+  }
+
+  private async clickResponse(selector: string): Promise<void> {
+    const button = this.page.locator(selector)
+    await expect(button).toBeVisible()
+    const bounds = await button.boundingBox()
+    if (!bounds) {
+      throw new Error(`Approval response button has no clickable bounds: ${selector}`)
+    }
+    await this.page.mouse.click(
+      bounds.x + bounds.width / 2,
+      bounds.y + bounds.height / 2,
+    )
   }
 
   async expectHidden(timeout = 20_000): Promise<void> {


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Daily E2E on `main` left the refreshed durable queue turn displayed as `Thinking` after the server had completed it, and a real Codex approval could expire while interaction audit persistence was pending.

## Summary

- Release a passive stream lease once runtime state is idle, even when the terminal message snapshot arrived before the lease-cleanup callback.
- Make runtime tool-approval audit events best-effort so they cannot block the native Codex approval request or its resolution.
- Add focused regressions for both timing boundaries.

## Test plan

- Reviewed both failure recordings, screenshots, and unpacked Playwright traces from run `32802773862`.
- `git diff --check`
- Local focused Vitest/Cucumber execution blocked: dependency installation is unavailable in this environment (offline store lacks `@agentclientprotocol/sdk`, and registry access is restricted).
- PR CI is the requested real-runtime verification path.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

1. Read **Problem / pressure** first.
2. Judge whether the timing boundaries are removed without weakening the E2E assertions.

### Authoring context

N/A — author-side sharing consent was not requested.

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->