### PR TITLE
fix(desktop): anchor tearoffs to live cursor

### DIFF
--- a/apps/desktop/src/main/window-manager.test.ts
+++ b/apps/desktop/src/main/window-manager.test.ts
@@ -196,6 +196,9 @@ describe('windowManager tear-off windows', () => {
 
     expect(opened).toBe(warmWindow)
     expect(warmWindow.shown).toBe(true)
+    // The renderer supplied x=1200, but a held native drag must anchor to the
+    // browser process's live DIP cursor (mocked at x=100) instead.
+    expect(warmWindow.bounds).toMatchObject({ x: 0, y: 60 })
     expect(warmWindow.webContents.send).toHaveBeenCalledWith(
       'window:tearoff-surface-bound',
       {

--- a/apps/desktop/src/main/window-manager.ts
+++ b/apps/desktop/src/main/window-manager.ts
@@ -104,7 +104,13 @@ export class WindowManager {
       return existing
     }
 
-    const releasePoint = resolveTearoffReleasePoint(x, y)
+    // DOM drag events can report physical-pixel screen coordinates on Retina
+    // while Electron's screen/BrowserWindow APIs use DIP. For a live native
+    // handoff, the browser process owns the authoritative cursor position and
+    // guarantees that the new window is created underneath the held pointer.
+    const releasePoint = options.continuePointerDrag
+      ? screen.getCursorScreenPoint()
+      : resolveTearoffReleasePoint(x, y)
     const targetDisplay = screen.getDisplayNearestPoint(releasePoint)
     const targetSize = resolveWindowSize(
       readStoredWindowSize(join(app.getPath('userData'), TEAROFF_WINDOW_SIZE_FILE)),

--- a/apps/server/src/modules/chat-runtime-providers/kimi/provider.ts
+++ b/apps/server/src/modules/chat-runtime-providers/kimi/provider.ts
@@ -209,7 +209,7 @@ class KimiProvider implements ChatRuntime {
         totalTokens: status.context_tokens,
         maxTokens,
         rawMaxTokens: maxTokens,
-        percentage: maxTokens ? status.context_usage : null,
+        percentage: maxTokens ? (status.context_usage ?? null) : null,
         sections: [],
         messageBreakdown: null,
         apiUsage: null,

--- a/apps/server/src/modules/chat-runtime-providers/kimi/web-host.smoke.test.ts
+++ b/apps/server/src/modules/chat-runtime-providers/kimi/web-host.smoke.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { getApiV1Auth, postApiV1Config, postApiV1Sessions } from './protocol/rest/sdk.gen'
+import { getApiV1Config, postApiV1Config, postApiV1Sessions } from './protocol/rest/sdk.gen'
 import type { KimiWebHostResource } from './web-host'
 import { createKimiWebHostResource } from './web-host'
 
@@ -37,8 +37,8 @@ describe('kimi web host smoke', () => {
     })
     resources.push(resource)
 
-    const auth = await resource.http.request(getApiV1Auth({ client: resource.http.client }))
-    expect(auth.default_model).toBe('cradle-smoke-target/smoke-model')
+    const config = await resource.http.request(getApiV1Config({ client: resource.http.client }))
+    expect(config.default_model).toBe('cradle-smoke-target/smoke-model')
     await resource.http.request(postApiV1Config({
       client: resource.http.client,
       body: {

--- a/apps/server/tests/node-session-projection.test.ts
+++ b/apps/server/tests/node-session-projection.test.ts
@@ -124,6 +124,8 @@ async function startFakeRemoteCradleServer(): Promise<FakeRemoteCradleServer> {
           archivedAt: null,
           createdAt: 100 + index,
           updatedAt: 200 + index,
+          latestUserMessageAt: null,
+          latestAssistantMessageAt: null,
         }))
       writeJson(response, { items, nextCursor: null })
       return

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -8,8 +8,8 @@ import * as ReactDOMClient from 'react-dom/client'
 import { AppErrorBoundary } from './components/common/app-error-boundary'
 import { resolveInitialLocale } from './i18n/browser-locale'
 import { I18nProvider } from './i18n/client'
-import { queryClient } from './lib/query-client'
 import { createBootstrapDisposerRegistry } from './lib/bootstrap-disposer'
+import { queryClient } from './lib/query-client'
 import { waitForServer } from './lib/server-readiness'
 
 // Expose shared React modules for plugin runtime


### PR DESCRIPTION
## Author type

- [x] I am an Agent (AI / automation)
- [ ] I am a human

## Problem / pressure

On Retina displays, renderer drag events can report physical-pixel screen coordinates while Electron's `screen` and `BrowserWindow` APIs use device-independent pixels. A torn-off window could therefore be created to the right of the held cursor instead of underneath it.

The first CI run also exposed stale baseline contracts: the remote-session fixture omitted nullable activity fields, and the newly merged Kimi SDK made context usage optional and moved default-model reads from auth to config.

## Summary

- Use the browser process's live `screen.getCursorScreenPoint()` as the authoritative anchor for held-pointer native tear-offs.
- Preserve renderer-provided coordinates for non-drag window opens.
- Add regression coverage proving a renderer x-coordinate of 1200 is ignored in favor of the live DIP cursor at x=100 during native handoff.
- Complete the fake remote session summary contract so repeated reconciliation remains idempotent.
- Follow the current Kimi SDK's optional context-usage and config API contracts.
- Restore canonical bootstrap import ordering.

## Test plan

- `pnpm lint`
- `pnpm --filter @cradle/server exec vitest run tests/node-session-projection.test.ts` (3 consecutive runs; 24 assertions passed)
- `pnpm --filter @cradle/server exec tsc --noEmit` against the merge with current `main`
- `pnpm typecheck:node` against the merge with current `main`
- Focused desktop tear-off Vitest (6 passed)
- Desktop typecheck
- `git diff --check`
- GitHub CI #902: passed
- GitHub E2E PR Suite #325: passed

## Agent handoff

The pointer-coordinate change is intentionally limited to held-pointer tear-offs. Regular programmatic tear-off placement still respects supplied coordinates.