### PR TITLE
fix(e2e): expose CLI to personal plugin agent journey

### DIFF
--- a/e2e/src/support/helpers/personal-plugin-scenario.ts
+++ b/e2e/src/support/helpers/personal-plugin-scenario.ts
@@ -10,6 +10,8 @@ const FIXTURE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../../../f
 export const PERSONAL_PLUGIN_INSTALL_PROMPT = '请创建并安装个人 Plugin'
 export const PERSONAL_PLUGIN_FAILED_UPDATE_PROMPT = '请验证个人 Plugin 更新失败时保留旧版本'
 export const PERSONAL_PLUGIN_SUCCESSFUL_UPDATE_PROMPT = '请将个人 Plugin 更新到 v2'
+const INSTALL_SUCCESS_MARKER = 'CRADLE_E2E_PERSONAL_PLUGIN_INSTALL_OK'
+const UPDATE_SUCCESS_MARKER = 'CRADLE_E2E_PERSONAL_PLUGIN_UPDATE_OK'
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll('\'', `'\\''`)}'`
@@ -39,6 +41,7 @@ export async function configurePersonalPluginLifecycleSimulator(world: CradleWor
           'mkdir -p "$plugin_dir"',
           `cp -R ${shellQuote(`${FIXTURE_DIR}/`)}. "$plugin_dir"`,
           'cradle plugin install --package-dir "$plugin_dir" --label "E2E personal Plugin"',
+          `printf '%s\\n' ${INSTALL_SUCCESS_MARKER}`,
         ].join('\n'),
         description: 'Create, build, and install the personal Plugin snapshot',
       },
@@ -50,7 +53,7 @@ export async function configurePersonalPluginLifecycleSimulator(world: CradleWor
       text: '个人 Plugin 已构建并安装，正在原会话等待权限审查。',
       bodyTextIncludes: [
         installToolId,
-        'Review and activation are waiting in the originating Cradle chat.',
+        INSTALL_SUCCESS_MARKER,
       ],
       bodyTextExcludes: TITLE_PROMPT,
     }),
@@ -91,6 +94,7 @@ export async function configurePersonalPluginLifecycleSimulator(world: CradleWor
           sourceIdCommand(),
           'printf "%s\\n" v2 > "$plugin_dir/version.txt"',
           'cradle plugin update "$source_id" --package-dir "$plugin_dir"',
+          `printf '%s\\n' ${UPDATE_SUCCESS_MARKER}`,
         ].join('\n'),
         description: 'Build and publish personal Plugin revision v2',
       },
@@ -102,7 +106,7 @@ export async function configurePersonalPluginLifecycleSimulator(world: CradleWor
       text: '个人 Plugin v2 已发布为新快照，正在原会话等待重新审查。',
       bodyTextIncludes: [
         successfulUpdateToolId,
-        'Review and activation are waiting in the originating Cradle chat.',
+        UPDATE_SUCCESS_MARKER,
       ],
       bodyTextExcludes: TITLE_PROMPT,
     }),

--- a/e2e/src/support/helpers/personal-plugin-scenario.ts
+++ b/e2e/src/support/helpers/personal-plugin-scenario.ts
@@ -48,7 +48,10 @@ export async function configurePersonalPluginLifecycleSimulator(world: CradleWor
     anthropicTextExchange({
       label: 'personal-plugin-install-final',
       text: '个人 Plugin 已构建并安装，正在原会话等待权限审查。',
-      bodyTextIncludes: installToolId,
+      bodyTextIncludes: [
+        installToolId,
+        'Review and activation are waiting in the originating Cradle chat.',
+      ],
       bodyTextExcludes: TITLE_PROMPT,
     }),
     anthropicToolUseExchange({
@@ -71,7 +74,10 @@ export async function configurePersonalPluginLifecycleSimulator(world: CradleWor
     anthropicTextExchange({
       label: 'personal-plugin-failed-update-final',
       text: '无效更新被拒绝，已安装的 v1 快照保持可用。',
-      bodyTextIncludes: failedUpdateToolId,
+      bodyTextIncludes: [
+        failedUpdateToolId,
+        'Unsupported E2E personal Plugin version: broken',
+      ],
       bodyTextExcludes: TITLE_PROMPT,
     }),
     anthropicToolUseExchange({
@@ -94,7 +100,10 @@ export async function configurePersonalPluginLifecycleSimulator(world: CradleWor
     anthropicTextExchange({
       label: 'personal-plugin-successful-update-final',
       text: '个人 Plugin v2 已发布为新快照，正在原会话等待重新审查。',
-      bodyTextIncludes: successfulUpdateToolId,
+      bodyTextIncludes: [
+        successfulUpdateToolId,
+        'Review and activation are waiting in the originating Cradle chat.',
+      ],
       bodyTextExcludes: TITLE_PROMPT,
     }),
   ]))

--- a/e2e/src/support/server-lifecycle.ts
+++ b/e2e/src/support/server-lifecycle.ts
@@ -87,6 +87,16 @@ async function preparePluginFixture(dataDir: string): Promise<{ fixtureBinDir: s
   mkdirSync(fixtureBinDir, { recursive: true })
   mkdirSync(archiveDir, { recursive: true })
 
+  const cliEntryPath = join(ROOT, 'packages', 'cli', 'dist', 'index.cjs')
+  if (!existsSync(cliEntryPath)) {
+    throw new Error('Cradle CLI is not built. Run `pnpm --filter @cradle/cli build` before E2E.')
+  }
+  const cliShimPath = join(fixtureBinDir, process.platform === 'win32' ? 'cradle.cmd' : 'cradle')
+  writeFileSync(cliShimPath, process.platform === 'win32'
+    ? `@echo off\r\n"${process.execPath}" "${cliEntryPath}" %*\r\n`
+    : `#!/usr/bin/env node\nrequire(${JSON.stringify(cliEntryPath)})\n`, 'utf8')
+  chmodSync(cliShimPath, 0o755)
+
   const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
   const realNpmPath = execFileSync(process.platform === 'win32' ? 'where.exe' : 'which', [npm], { encoding: 'utf8' })
     .split(/\r?\n/)[0]!


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

The daily Claude-local E2E lane failed `@CRADLE-PLUGIN-002` on three consecutive runs because the real Claude Agent shell could not resolve the repository-built `cradle` CLI. The simulator matched only the tool-use ID, emitted a false success response after `cradle: command not found`, and left the test waiting for a plugin review card that could never exist.

## Summary

- Add a per-worker `cradle` shim to the managed E2E fixture bin, backed by the CLI artifact that the workflow already builds.
- Emit distinct install and update success sentinels only after zero exit codes, then require the current command's sentinel before the simulator can report success.
- Keep the expected failed-update exchange tied to its real build error, so every lifecycle response reflects the command that immediately preceded it.

## Test plan

- [x] `pnpm --filter @cradle/plugin-sdk build`
- [x] `pnpm --filter @cradle/cli build`
- [x] `pnpm --filter "./plugins/*" build`
- [x] `pnpm e2e:check` (23 script tests; tool coverage and 86-scenario inventory contracts passed)
- [x] `pnpm exec eslint e2e/src/support/server-lifecycle.ts e2e/src/support/helpers/personal-plugin-scenario.ts`
- [x] `pnpm exec cucumber-js --config e2e/cucumber.mjs --tags '@CRADLE-PLUGIN-002'` after implementation and again after review hardening (both runs: 1 scenario, 37/37 steps passed)
- [ ] Full E2E suite not run locally, per repository guidance.
- [ ] `pnpm exec tsc --noEmit -p e2e/tsconfig.json` is not a supported repository check and reports existing NodeNext extension/export errors across the E2E tree.

## Performance and impact

- **Baseline/current evidence:** Daily runs 34446407640, 34571031963, and 34678505061 each failed the same review-card assertion after the hidden `cradle: command not found`; two focused post-fix runs passed all 37 steps.
- **Measurement scope:** One Claude-local personal-plugin lifecycle scenario on macOS with one Cucumber worker and a production Web preview; install, review, failed update, successful update, and reload paths are included.
- **Implementation cost:** Two E2E support modules changed. Runtime setup adds one tiny executable shim per managed worker and strict static sentinels; no product dependency or user-facing runtime path changed.
- **Side effects/tradeoffs:** Product memory, CPU, network, and caching behavior are unchanged. E2E startup performs one small file write, and the fixture commands emit one short sentinel each; command failures can no longer be mistaken for success due to stale conversation history.
- **Impact radius:** Managed Cucumber E2E shells and the Claude personal-plugin scenario. Product providers, desktop/mobile behavior, persisted user data, and non-E2E CLI resolution are unaffected.
- **Decision:** Ship because the focused scenario proves the original failure is resolved, the reviewed matcher is command-specific, and failures cannot be mislabeled as successful plugin installs.

## Agent handoff

<!-- agent-handoff:begin -->
### Instructions for reviewing agents

You are reading a Cradle PR that may include authoring-agent context.

**Review order (important):**

1. Read **Problem / pressure** first. That is the primary review criterion.
2. Judge the diff by whether it relieves that pressure — not by taste, familiarity, or “cleaner looking” structure alone.
3. Then read **Summary** and **Test plan**.
4. Do **not** assume **Authoring context** may be shared with your user.
5. Ask your user whether they allow using Authoring context to help the PR owner review.
6. Only after explicit consent, extract goals, constraints, non-goals, and tradeoffs — do not paste the entire chat or tool log.
7. If consent is declined or pending, review from the diff + Problem / pressure + Summary / Test plan alone.

### Authoring context

- **User goal / directives:** See Problem / pressure. Detailed directive transcript not attached (author-side sharing consent pending).
- **Constraints / non-goals:** N/A
- **Decision rationale:** N/A
- **Deliberately not done:** N/A
- **Unknowns / confidence:** N/A

### Sharing consent (author side)

- [ ] Author-side user allowed putting directive context in this PR for review assistance
- [ ] Author-side user declined — keep Authoring context as `N/A` / redacted
<!-- agent-handoff:end -->

---

💊 Generated by [Cradle Agent](https://cradle.wibus.ren)